### PR TITLE
Replace Coveralls with Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ branches:
 before_install:
 - pip install -U pip
 install:
-- pip install coveralls
+- pip install codecov
 - pip install -e .[test]
 script:
 - if [[ $TRAVIS_PULL_REQUEST = false ]]; then coverage run --source=sentinelsat -m py.test -v; fi
 - if [[ $TRAVIS_PULL_REQUEST != false ]]; then coverage run --source=sentinelsat -m py.test -v -m "not homura"; fi
 after_success:
-- if [[ $TRAVIS_PYTHON_VERSION = 3.6 ]]; then coveralls; fi
+- codecov
 - if [[ $TRAVIS_PYTHON_VERSION = 3.6 && $TRAVIS_PULL_REQUEST = false ]]; then curl -X POST http://readthedocs.org/build/sentinelsat; fi
 sudo: false
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ sentinelsat
 .. image:: https://travis-ci.org/sentinelsat/sentinelsat.svg
     :target: https://travis-ci.org/sentinelsat/sentinelsat
 
-.. image:: https://codecov.io/gh/sentinelsat/sentinelsat/coverage.svg?branch=master
+.. image:: https://codecov.io/gh/sentinelsat/sentinelsat/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/sentinelsat/sentinelsat
 
 .. image:: https://readthedocs.org/projects/sentinelsat/badge/?version=master

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ sentinelsat
 .. image:: https://travis-ci.org/sentinelsat/sentinelsat.svg
     :target: https://travis-ci.org/sentinelsat/sentinelsat
 
-.. image:: https://coveralls.io/repos/sentinelsat/sentinelsat/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/sentinelsat/sentinelsat?branch=master
+.. image:: https://codecov.io/gh/sentinelsat/sentinelsat/coverage.svg?branch=master
+    :target: https://codecov.io/gh/sentinelsat/sentinelsat
 
 .. image:: https://readthedocs.org/projects/sentinelsat/badge/?version=master
     :target: http://sentinelsat.readthedocs.io/en/master/?badge=master


### PR DESCRIPTION
I have a small suggestion: let's replace [Coveralls](https://coveralls.io/github/sentinelsat/sentinelsat) with [Codecov](https://codecov.io/gh/sentinelsat/sentinelsat). You can take a look at the Codecov page for [pandas](https://codecov.io/gh/pandas-dev/pandas) for a good example of what is offered.

I find the Codecov user interface a lot cleaner and more useful than Coverall's and I also like their [browser extension](https://github.com/codecov/browser-extension), which makes it easy to see coverage straight inside GitHub source code view.

Here's what the badge looks like:
[![codecov](https://codecov.io/gh/sentinelsat/sentinelsat/branch/master/graph/badge.svg)](https://codecov.io/gh/sentinelsat/sentinelsat)