### PR TITLE
Add a method to check if the OpenSearch query is too long

### DIFF
--- a/tests/vcr_cassettes/test_date_arithmetic.yaml
+++ b/tests/vcr_cassettes/test_date_arithmetic.yaml
@@ -1,0 +1,1366 @@
+interactions:
+- request:
+    body: q=%28beginPosition%3A%5B2015-12-01T00%3A00%3A00Z-1DAY+TO+2015-12-01T00%3A00%3A00Z%252B1DAY-1HOUR%5D%29+AND+%28footprint%3A%22Intersects%28ENVELOPE%280%2C+10%2C+10%2C+0%29%29%22%29
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['179']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.11]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=100&start=0
+  response:
+    body: {string: "{\"feed\": {\n   \"opensearch:Query\": {\n      \"startPage\"\
+        : \"1\",\n      \"role\": \"request\",\n      \"searchTerms\": \"(beginPosition:[2015-12-01T00:00:00Z-1DAY\
+        \ TO 2015-12-01T00:00:00Z%2B1DAY-1HOUR]) AND (footprint:\\\"Intersects(ENVELOPE(0,\
+        \ 10, 10, 0))\\\")\"\n   },\n   \"author\": {\"name\": \"Sentinels Scientific\
+        \ Data Hub\"},\n   \"link\": [\n      {\n         \"rel\": \"self\",\n   \
+        \      \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[2015-12-01T00:00:00Z-1DAY\
+        \ TO 2015-12-01T00:00:00Z%2B1DAY-1HOUR]) AND (footprint:\\\"Intersects(ENVELOPE(0,\
+        \ 10, 10, 0))\\\")&start=0&rows=100\",\n         \"type\": \"application/atom+xml\"\
+        \n      },\n      {\n         \"rel\": \"first\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[2015-12-01T00:00:00Z-1DAY\
+        \ TO 2015-12-01T00:00:00Z%2B1DAY-1HOUR]) AND (footprint:\\\"Intersects(ENVELOPE(0,\
+        \ 10, 10, 0))\\\")&start=0&rows=100\",\n         \"type\": \"application/atom+xml\"\
+        \n      },\n      {\n         \"rel\": \"last\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[2015-12-01T00:00:00Z-1DAY\
+        \ TO 2015-12-01T00:00:00Z%2B1DAY-1HOUR]) AND (footprint:\\\"Intersects(ENVELOPE(0,\
+        \ 10, 10, 0))\\\")&start=21&rows=100\",\n         \"type\": \"application/atom+xml\"\
+        \n      },\n      {\n         \"rel\": \"search\",\n         \"href\": \"\
+        opensearch_description.xml\",\n         \"type\": \"application/opensearchdescription+xml\"\
+        \n      }\n   ],\n   \"title\": \"Sentinels Scientific Data Hub search results\
+        \ for: (beginPosition:[2015-12-01T00:00:00Z-1DAY TO 2015-12-01T00:00:00Z%2B1DAY-1HOUR])\
+        \ AND (footprint:\\\"Intersects(ENVELOPE(0, 10, 10, 0))\\\")\",\n   \"opensearch:startIndex\"\
+        : \"0\",\n   \"opensearch:totalResults\": \"22\",\n   \"entry\": [\n     \
+        \ {\n         \"summary\": \"Date: 2015-12-01T17:46:09.185Z, Instrument: SAR-C\
+        \ SAR, Mode: VV VH, Satellite: Sentinel-1, Size: 6.92 GB\",\n         \"str\"\
+        : [\n            {\n               \"name\": \"acquisitiontype\",\n      \
+        \         \"content\": \"NOMINAL\"\n            },\n            {\n      \
+        \         \"name\": \"filename\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174609_20151201T174636_008852_00CA51_E1D1.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>11.472023,5.271984 11.915055,7.533403\
+        \ 10.290114,7.855282 9.842856,5.606579 11.472023,5.271984<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174609_20151201T174636_008852_00CA51_E1D1\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((5.271984 11.472023,7.533403 11.915055,7.855282 10.290114,5.606579\
+        \ 9.842856,5.271984 11.472023))\"\n            },\n            {\n       \
+        \        \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            },\n            {\n\
+        \               \"name\": \"uuid\",\n               \"content\": \"f0dca969-90e3-494a-99cb-0b0067689c0a\"\
+        \n            }\n         ],\n         \"date\": [\n            {\n      \
+        \         \"name\": \"ingestiondate\",\n               \"content\": \"2016-12-15T19:36:58.699Z\"\
+        \n            },\n            {\n               \"name\": \"beginposition\"\
+        ,\n               \"content\": \"2015-12-01T17:46:09.185Z\"\n            },\n\
+        \            {\n               \"name\": \"endposition\",\n              \
+        \ \"content\": \"2015-12-01T17:46:36.119Z\"\n            }\n         ],\n\
+        \         \"link\": [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('f0dca969-90e3-494a-99cb-0b0067689c0a')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('f0dca969-90e3-494a-99cb-0b0067689c0a')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('f0dca969-90e3-494a-99cb-0b0067689c0a')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"f0dca969-90e3-494a-99cb-0b0067689c0a\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174609_20151201T174636_008852_00CA51_E1D1\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"6\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:19.529Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 6.92 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"acquisitiontype\",\n               \"content\": \"\
+        NOMINAL\"\n            },\n            {\n               \"name\": \"filename\"\
+        ,\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174519_20151201T174546_008852_00CA51_7F0B.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>8.467887,5.885473 8.919121,8.126501\
+        \ 7.293953,8.452742 6.838244,6.220663 8.467887,5.885473<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174519_20151201T174546_008852_00CA51_7F0B\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((5.885473 8.467887,8.126501 8.919121,8.452742 7.293953,6.220663\
+        \ 6.838244,5.885473 8.467887))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            },\n            {\n\
+        \               \"name\": \"uuid\",\n               \"content\": \"057dec78-9110-4cfb-976a-abd52d95738f\"\
+        \n            }\n         ],\n         \"date\": [\n            {\n      \
+        \         \"name\": \"ingestiondate\",\n               \"content\": \"2016-12-15T19:33:20.059Z\"\
+        \n            },\n            {\n               \"name\": \"beginposition\"\
+        ,\n               \"content\": \"2015-12-01T17:45:19.529Z\"\n            },\n\
+        \            {\n               \"name\": \"endposition\",\n              \
+        \ \"content\": \"2015-12-01T17:45:46.467Z\"\n            }\n         ],\n\
+        \         \"link\": [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('057dec78-9110-4cfb-976a-abd52d95738f')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('057dec78-9110-4cfb-976a-abd52d95738f')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('057dec78-9110-4cfb-976a-abd52d95738f')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"057dec78-9110-4cfb-976a-abd52d95738f\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174519_20151201T174546_008852_00CA51_7F0B\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"4\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:54.7Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1,\
+        \ Size: 6.92 GB\",\n         \"str\": [\n            {\n               \"\
+        name\": \"acquisitiontype\",\n               \"content\": \"NOMINAL\"\n  \
+        \          },\n            {\n               \"name\": \"filename\",\n   \
+        \            \"content\": \"S1A_IW_SLC__1SDV_20151201T174454_20151201T174521_008852_00CA51_F26E.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>6.965777,6.192880 7.421263,8.426208\
+        \ 5.795935,8.755039 5.335845,6.528827 6.965777,6.192880<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174454_20151201T174521_008852_00CA51_F26E\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((6.192880 6.965777,8.426208 7.421263,8.755039 5.795935,6.528827\
+        \ 5.335845,6.192880 6.965777))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            },\n            {\n\
+        \               \"name\": \"uuid\",\n               \"content\": \"c82ec797-68ce-4113-b9b7-5e40abe0f93b\"\
+        \n            }\n         ],\n         \"date\": [\n            {\n      \
+        \         \"name\": \"ingestiondate\",\n               \"content\": \"2016-12-15T19:33:18.298Z\"\
+        \n            },\n            {\n               \"name\": \"beginposition\"\
+        ,\n               \"content\": \"2015-12-01T17:44:54.7Z\"\n            },\n\
+        \            {\n               \"name\": \"endposition\",\n              \
+        \ \"content\": \"2015-12-01T17:45:21.642Z\"\n            }\n         ],\n\
+        \         \"link\": [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('c82ec797-68ce-4113-b9b7-5e40abe0f93b')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('c82ec797-68ce-4113-b9b7-5e40abe0f93b')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('c82ec797-68ce-4113-b9b7-5e40abe0f93b')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"c82ec797-68ce-4113-b9b7-5e40abe0f93b\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174454_20151201T174521_008852_00CA51_F26E\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"3\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:44.358Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 6.92 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"acquisitiontype\",\n               \"content\": \"\
+        NOMINAL\"\n            },\n            {\n               \"name\": \"filename\"\
+        ,\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174544_20151201T174611_008852_00CA51_C88F.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>9.969681,5.576680 10.416935,7.827862\
+        \ 8.791853,8.151800 8.340250,5.911435 9.969681,5.576680<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174544_20151201T174611_008852_00CA51_C88F\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((5.576680 9.969681,7.827862 10.416935,8.151800 8.791853,5.911435\
+        \ 8.340250,5.576680 9.969681))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            },\n            {\n\
+        \               \"name\": \"uuid\",\n               \"content\": \"5c7a5267-7c05-469b-a150-b8d2ab082902\"\
+        \n            }\n         ],\n         \"date\": [\n            {\n      \
+        \         \"name\": \"ingestiondate\",\n               \"content\": \"2016-12-15T19:33:18.283Z\"\
+        \n            },\n            {\n               \"name\": \"beginposition\"\
+        ,\n               \"content\": \"2015-12-01T17:45:44.358Z\"\n            },\n\
+        \            {\n               \"name\": \"endposition\",\n              \
+        \ \"content\": \"2015-12-01T17:46:11.294Z\"\n            }\n         ],\n\
+        \         \"link\": [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('5c7a5267-7c05-469b-a150-b8d2ab082902')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('5c7a5267-7c05-469b-a150-b8d2ab082902')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('5c7a5267-7c05-469b-a150-b8d2ab082902')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"5c7a5267-7c05-469b-a150-b8d2ab082902\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174544_20151201T174611_008852_00CA51_C88F\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"5\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:28.929Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 7.15 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"acquisitiontype\",\n               \"content\": \"\
+        NOMINAL\"\n            },\n            {\n               \"name\": \"filename\"\
+        ,\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174428_20151201T174456_008852_00CA51_C867.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>5.463472,6.501430 5.923287,8.728557\
+        \ 4.241314,9.071843 3.776596,6.850169 5.463472,6.501430<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174428_20151201T174456_008852_00CA51_C867\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((6.501430 5.463472,8.728557 5.923287,9.071843 4.241314,6.850169\
+        \ 3.776596,6.501430 5.463472))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"7.15\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            },\n            {\n\
+        \               \"name\": \"uuid\",\n               \"content\": \"9c60cf14-a05a-4d87-953e-ceceb78de80b\"\
+        \n            }\n         ],\n         \"date\": [\n            {\n      \
+        \         \"name\": \"ingestiondate\",\n               \"content\": \"2016-12-15T19:26:39.391Z\"\
+        \n            },\n            {\n               \"name\": \"beginposition\"\
+        ,\n               \"content\": \"2015-12-01T17:44:28.929Z\"\n            },\n\
+        \            {\n               \"name\": \"endposition\",\n              \
+        \ \"content\": \"2015-12-01T17:44:56.813Z\"\n            }\n         ],\n\
+        \         \"link\": [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('9c60cf14-a05a-4d87-953e-ceceb78de80b')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('9c60cf14-a05a-4d87-953e-ceceb78de80b')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('9c60cf14-a05a-4d87-953e-ceceb78de80b')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"9c60cf14-a05a-4d87-953e-ceceb78de80b\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174428_20151201T174456_008852_00CA51_C867\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"2\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:28.929Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 7.15 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174428_20151201T174456_008852_00CA51_800D.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>5.463472,6.501430 5.923287,8.728558\
+        \ 4.241314,9.071843 3.776596,6.850169 5.463472,6.501430<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174428_20151201T174456_008852_00CA51_800D\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((6.501430 5.463472,8.728558 5.923287,9.071843 4.241314,6.850169\
+        \ 3.776596,6.501430 5.463472))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"7.15\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:42:41.849Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:28.929Z\"\n            },\n          \
+        \  {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:44:56.813Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0951c491-5805-4f95-9f6f-7e271c77b6dd')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0951c491-5805-4f95-9f6f-7e271c77b6dd')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0951c491-5805-4f95-9f6f-7e271c77b6dd')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"0951c491-5805-4f95-9f6f-7e271c77b6dd\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174428_20151201T174456_008852_00CA51_800D\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"2\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:41.67Z, Instrument: SAR-C SAR, Mode: VH VV, Satellite:\
+        \ Sentinel-1, Size: 1.5 GB\",\n         \"str\": [\n            {\n      \
+        \         \"name\": \"processed\",\n               \"content\": \"T\"\n  \
+        \          },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174541_20151201T174614_008852_00CA51_6B9F.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>8.2462,8.0723 10.2031,7.6792\
+        \ 9.9113,5.4614 7.9503,5.8667 8.2462,8.0723 8.2462,8.0723<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174541_20151201T174614_008852_00CA51_6B9F\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"footprint\"\
+        ,\n               \"content\": \"POLYGON ((8.0723 8.2462,7.6792 10.2031,5.4614\
+        \ 9.9113,5.8667 7.9503,8.0723 8.2462,8.0723 8.2462))\"\n            },\n \
+        \           {\n               \"name\": \"platformidentifier\",\n        \
+        \       \"content\": \"0000-000A\"\n            },\n            {\n      \
+        \         \"name\": \"orbitdirection\",\n               \"content\": \"ASCENDING\"\
+        \n            },\n            {\n               \"name\": \"polarisationmode\"\
+        ,\n               \"content\": \"VH VV\"\n            },\n            {\n\
+        \               \"name\": \"productclass\",\n               \"content\": \"\
+        S\"\n            },\n            {\n               \"name\": \"productconsolidation\"\
+        ,\n               \"content\": \"SLICE\"\n            },\n            {\n\
+        \               \"name\": \"producttype\",\n               \"content\": \"\
+        RAW\"\n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.5\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:38:11.921Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:45:41.67Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:46:14.07Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('a78af755-eeed-4e9e-85b8-ea9ee9a48fb5')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('a78af755-eeed-4e9e-85b8-ea9ee9a48fb5')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('a78af755-eeed-4e9e-85b8-ea9ee9a48fb5')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"a78af755-eeed-4e9e-85b8-ea9ee9a48fb5\"\
+        ,\n         \"title\": \"S1A_IW_RAW__0SDV_20151201T174541_20151201T174614_008852_00CA51_6B9F\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"5\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:20.37Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 1.58 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174520_20151201T174545_008852_00CA51_4D35.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>8.401388,5.899721 8.853489,8.143825\
+        \ 7.344970,8.444779 6.888820,6.209581 8.401388,5.899721<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174520_20151201T174545_008852_00CA51_4D35\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW\"\n            },\n            {\n   \
+        \            \"name\": \"footprint\",\n               \"content\": \"POLYGON\
+        \ ((5.899721 8.401388,8.143825 8.853489,8.444779 7.344970,6.209581 6.888820,5.899721\
+        \ 8.401388))\"\n            },\n            {\n               \"name\": \"\
+        platformidentifier\",\n               \"content\": \"0000-000A\"\n       \
+        \     },\n            {\n               \"name\": \"orbitdirection\",\n  \
+        \             \"content\": \"ASCENDING\"\n            },\n            {\n\
+        \               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"GRD\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.58\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:36:18.379Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:45:20.37Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:45:45.369Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('5fb264e0-9030-4726-98dc-05c255295b9e')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('5fb264e0-9030-4726-98dc-05c255295b9e')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('5fb264e0-9030-4726-98dc-05c255295b9e')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"5fb264e0-9030-4726-98dc-05c255295b9e\"\
+        ,\n         \"title\": \"S1A_IW_GRDH_1SDV_20151201T174520_20151201T174545_008852_00CA51_4D35\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"4\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:54.7Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1,\
+        \ Size: 6.92 GB\",\n         \"str\": [\n            {\n               \"\
+        name\": \"processed\",\n               \"content\": \"T\"\n            },\n\
+        \            {\n               \"name\": \"acquisitiontype\",\n          \
+        \     \"content\": \"NOMINAL\"\n            },\n            {\n          \
+        \     \"name\": \"filename\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174454_20151201T174521_008852_00CA51_6183.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>6.965777,6.192880 7.421263,8.426208\
+        \ 5.795935,8.755039 5.335845,6.528827 6.965777,6.192880<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174454_20151201T174521_008852_00CA51_6183\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((6.192880 6.965777,8.426208 7.421263,8.755039 5.795935,6.528827\
+        \ 5.335845,6.192880 6.965777))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:34:54.624Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:54.7Z\"\n            },\n            {\n\
+        \               \"name\": \"endposition\",\n               \"content\": \"\
+        2015-12-01T17:45:21.642Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('6a4756ee-6343-48b2-9eea-ae7ef2ba6ba7')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('6a4756ee-6343-48b2-9eea-ae7ef2ba6ba7')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('6a4756ee-6343-48b2-9eea-ae7ef2ba6ba7')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"6a4756ee-6343-48b2-9eea-ae7ef2ba6ba7\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174454_20151201T174521_008852_00CA51_6183\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"3\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:46:09.185Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 6.92 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174609_20151201T174636_008852_00CA51_9C08.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>11.472023,5.271984 11.915055,7.533403\
+        \ 10.290114,7.855282 9.842856,5.606579 11.472023,5.271984<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174609_20151201T174636_008852_00CA51_9C08\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((5.271984 11.472023,7.533403 11.915055,7.855282 10.290114,5.606579\
+        \ 9.842856,5.271984 11.472023))\"\n            },\n            {\n       \
+        \        \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:34:54.432Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:46:09.185Z\"\n            },\n          \
+        \  {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:46:36.119Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0f0aeb68-60e7-4d7b-97b5-2ed3ada05901')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0f0aeb68-60e7-4d7b-97b5-2ed3ada05901')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0f0aeb68-60e7-4d7b-97b5-2ed3ada05901')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"0f0aeb68-60e7-4d7b-97b5-2ed3ada05901\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174609_20151201T174636_008852_00CA51_9C08\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"6\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:19.529Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 6.92 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174519_20151201T174546_008852_00CA51_3FAC.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>8.467886,5.885473 8.919121,8.126501\
+        \ 7.293953,8.452742 6.838244,6.220663 8.467886,5.885473<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174519_20151201T174546_008852_00CA51_3FAC\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((5.885473 8.467886,8.126501 8.919121,8.452742 7.293953,6.220663\
+        \ 6.838244,5.885473 8.467886))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:28:36.729Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:45:19.529Z\"\n            },\n          \
+        \  {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:45:46.467Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('476dee1c-2768-4c05-b6ce-6b97ddbd6099')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('476dee1c-2768-4c05-b6ce-6b97ddbd6099')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('476dee1c-2768-4c05-b6ce-6b97ddbd6099')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"476dee1c-2768-4c05-b6ce-6b97ddbd6099\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174519_20151201T174546_008852_00CA51_3FAC\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"4\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:44.358Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 6.92 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174544_20151201T174611_008852_00CA51_E131.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>9.969681,5.576680 10.416935,7.827862\
+        \ 8.791853,8.151800 8.340250,5.911435 9.969681,5.576680<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_SLC__1SDV_20151201T174544_20151201T174611_008852_00CA51_E131\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW1 IW2 IW3\"\n            },\n         \
+        \   {\n               \"name\": \"footprint\",\n               \"content\"\
+        : \"POLYGON ((5.576680 9.969681,7.827862 10.416935,8.151800 8.791853,5.911435\
+        \ 8.340250,5.576680 9.969681))\"\n            },\n            {\n        \
+        \       \"name\": \"platformidentifier\",\n               \"content\": \"\
+        0000-000A\"\n            },\n            {\n               \"name\": \"orbitdirection\"\
+        ,\n               \"content\": \"ASCENDING\"\n            },\n           \
+        \ {\n               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"SLC\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"6.92\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:28:35.498Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:45:44.358Z\"\n            },\n          \
+        \  {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:46:11.294Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('da103fee-4967-45f5-8803-2e27e2e76109')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('da103fee-4967-45f5-8803-2e27e2e76109')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('da103fee-4967-45f5-8803-2e27e2e76109')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"da103fee-4967-45f5-8803-2e27e2e76109\"\
+        ,\n         \"title\": \"S1A_IW_SLC__1SDV_20151201T174544_20151201T174611_008852_00CA51_E131\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"5\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:46:10.37Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 1.58 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174610_20151201T174635_008852_00CA51_9042.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>11.426519,5.281443 11.870754,7.548145\
+        \ 10.362045,7.844109 9.913903,5.589486 11.426519,5.281443<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174610_20151201T174635_008852_00CA51_9042\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW\"\n            },\n            {\n   \
+        \            \"name\": \"footprint\",\n               \"content\": \"POLYGON\
+        \ ((5.281443 11.426519,7.548145 11.870754,7.844109 10.362045,5.589486 9.913903,5.281443\
+        \ 11.426519))\"\n            },\n            {\n               \"name\": \"\
+        platformidentifier\",\n               \"content\": \"0000-000A\"\n       \
+        \     },\n            {\n               \"name\": \"orbitdirection\",\n  \
+        \             \"content\": \"ASCENDING\"\n            },\n            {\n\
+        \               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"GRD\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.58\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:24:11.906Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:46:10.37Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:46:35.369Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('8c8f12b9-9018-47be-9984-79cfa1575f75')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('8c8f12b9-9018-47be-9984-79cfa1575f75')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('8c8f12b9-9018-47be-9984-79cfa1575f75')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"8c8f12b9-9018-47be-9984-79cfa1575f75\"\
+        ,\n         \"title\": \"S1A_IW_GRDH_1SDV_20151201T174610_20151201T174635_008852_00CA51_9042\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"6\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:45.37Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 1.58 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174545_20151201T174610_008852_00CA51_93A6.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>9.913814,5.589504 10.361956,7.844127\
+        \ 8.853579,8.143806 8.401478,5.899703 9.913814,5.589504<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174545_20151201T174610_008852_00CA51_93A6\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW\"\n            },\n            {\n   \
+        \            \"name\": \"footprint\",\n               \"content\": \"POLYGON\
+        \ ((5.589504 9.913814,7.844127 10.361956,8.143806 8.853579,5.899703 8.401478,5.589504\
+        \ 9.913814))\"\n            },\n            {\n               \"name\": \"\
+        platformidentifier\",\n               \"content\": \"0000-000A\"\n       \
+        \     },\n            {\n               \"name\": \"orbitdirection\",\n  \
+        \             \"content\": \"ASCENDING\"\n            },\n            {\n\
+        \               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"GRD\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.58\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:22:22.153Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:45:45.37Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:46:10.369Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('bfe2dea8-c1dd-4cc1-9f86-3c4c33ff428a')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('bfe2dea8-c1dd-4cc1-9f86-3c4c33ff428a')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('bfe2dea8-c1dd-4cc1-9f86-3c4c33ff428a')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"bfe2dea8-c1dd-4cc1-9f86-3c4c33ff428a\"\
+        ,\n         \"title\": \"S1A_IW_GRDH_1SDV_20151201T174545_20151201T174610_008852_00CA51_93A6\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"5\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:55.37Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 1.58 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174455_20151201T174520_008852_00CA51_E30C.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>6.888731,6.209600 7.344916,8.444976\
+        \ 5.836586,8.748874 5.376272,6.520835 6.888731,6.209600<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174455_20151201T174520_008852_00CA51_E30C\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW\"\n            },\n            {\n   \
+        \            \"name\": \"footprint\",\n               \"content\": \"POLYGON\
+        \ ((6.209600 6.888731,8.444976 7.344916,8.748874 5.836586,6.520835 5.376272,6.209600\
+        \ 6.888731))\"\n            },\n            {\n               \"name\": \"\
+        platformidentifier\",\n               \"content\": \"0000-000A\"\n       \
+        \     },\n            {\n               \"name\": \"orbitdirection\",\n  \
+        \             \"content\": \"ASCENDING\"\n            },\n            {\n\
+        \               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"GRD\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.58\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:22:22.112Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:55.37Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:45:20.368Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('60dcc7f1-ef1c-4209-ad35-db9ec779ced5')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('60dcc7f1-ef1c-4209-ad35-db9ec779ced5')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('60dcc7f1-ef1c-4209-ad35-db9ec779ced5')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"60dcc7f1-ef1c-4209-ad35-db9ec779ced5\"\
+        ,\n         \"title\": \"S1A_IW_GRDH_1SDV_20151201T174455_20151201T174520_008852_00CA51_E30C\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"3\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:30.37Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 1.58 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174430_20151201T174455_008852_00CA51_9E2B.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>5.376182,6.520854 5.836551,8.749157\
+        \ 4.328243,9.055175 3.863658,6.832670 5.376182,6.520854<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174430_20151201T174455_008852_00CA51_9E2B\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW\"\n            },\n            {\n   \
+        \            \"name\": \"footprint\",\n               \"content\": \"POLYGON\
+        \ ((6.520854 5.376182,8.749157 5.836551,9.055175 4.328243,6.832670 3.863658,6.520854\
+        \ 5.376182))\"\n            },\n            {\n               \"name\": \"\
+        platformidentifier\",\n               \"content\": \"0000-000A\"\n       \
+        \     },\n            {\n               \"name\": \"orbitdirection\",\n  \
+        \             \"content\": \"ASCENDING\"\n            },\n            {\n\
+        \               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"GRD\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.58\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:22:20.766Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:30.37Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:44:55.368Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('668c9f44-339b-4ad5-82a6-bbfb075c41fc')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('668c9f44-339b-4ad5-82a6-bbfb075c41fc')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('668c9f44-339b-4ad5-82a6-bbfb075c41fc')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"668c9f44-339b-4ad5-82a6-bbfb075c41fc\"\
+        ,\n         \"title\": \"S1A_IW_GRDH_1SDV_20151201T174430_20151201T174455_008852_00CA51_9E2B\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"2\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:01.356Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite:\
+        \ Sentinel-1, Size: 1.83 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174401_20151201T174430_008852_00CA51_12BF.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>3.863568,6.832688 4.328227,9.055546\
+        \ 2.578137,9.415103 2.108477,7.197077 3.863568,6.832688<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_GRDH_1SDV_20151201T174401_20151201T174430_008852_00CA51_12BF\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"swathidentifier\"\
+        ,\n               \"content\": \"IW\"\n            },\n            {\n   \
+        \            \"name\": \"footprint\",\n               \"content\": \"POLYGON\
+        \ ((6.832688 3.863568,9.055546 4.328227,9.415103 2.578137,7.197077 2.108477,6.832688\
+        \ 3.863568))\"\n            },\n            {\n               \"name\": \"\
+        platformidentifier\",\n               \"content\": \"0000-000A\"\n       \
+        \     },\n            {\n               \"name\": \"orbitdirection\",\n  \
+        \             \"content\": \"ASCENDING\"\n            },\n            {\n\
+        \               \"name\": \"polarisationmode\",\n               \"content\"\
+        : \"VV VH\"\n            },\n            {\n               \"name\": \"productclass\"\
+        ,\n               \"content\": \"S\"\n            },\n            {\n    \
+        \           \"name\": \"producttype\",\n               \"content\": \"GRD\"\
+        \n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.83\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T09:22:19.092Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:01.356Z\"\n            },\n          \
+        \  {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:44:30.368Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('4a06fedb-6739-43da-9759-9ead3bef034e')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('4a06fedb-6739-43da-9759-9ead3bef034e')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('4a06fedb-6739-43da-9759-9ead3bef034e')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"4a06fedb-6739-43da-9759-9ead3bef034e\"\
+        ,\n         \"title\": \"S1A_IW_GRDH_1SDV_20151201T174401_20151201T174430_008852_00CA51_12BF\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"1\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:45:16.67Z, Instrument: SAR-C SAR, Mode: VH VV, Satellite:\
+        \ Sentinel-1, Size: 1.54 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174516_20151201T174549_008852_00CA51_539A.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>6.7367,8.3784 8.6930,7.9821\
+        \ 8.3981,5.7741 6.4373,6.1805 6.7367,8.3784 6.7367,8.3784<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174516_20151201T174549_008852_00CA51_539A\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"footprint\"\
+        ,\n               \"content\": \"POLYGON ((8.3784 6.7367,7.9821 8.6930,5.7741\
+        \ 8.3981,6.1805 6.4373,8.3784 6.7367,8.3784 6.7367))\"\n            },\n \
+        \           {\n               \"name\": \"platformidentifier\",\n        \
+        \       \"content\": \"0000-000A\"\n            },\n            {\n      \
+        \         \"name\": \"orbitdirection\",\n               \"content\": \"ASCENDING\"\
+        \n            },\n            {\n               \"name\": \"polarisationmode\"\
+        ,\n               \"content\": \"VH VV\"\n            },\n            {\n\
+        \               \"name\": \"productclass\",\n               \"content\": \"\
+        S\"\n            },\n            {\n               \"name\": \"productconsolidation\"\
+        ,\n               \"content\": \"SLICE\"\n            },\n            {\n\
+        \               \"name\": \"producttype\",\n               \"content\": \"\
+        RAW\"\n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.54\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T08:58:10.104Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:45:16.67Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:45:49.069Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0d6dd15b-d82f-4adb-96ea-b6bc416b0c6c')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0d6dd15b-d82f-4adb-96ea-b6bc416b0c6c')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('0d6dd15b-d82f-4adb-96ea-b6bc416b0c6c')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"0d6dd15b-d82f-4adb-96ea-b6bc416b0c6c\"\
+        ,\n         \"title\": \"S1A_IW_RAW__0SDV_20151201T174516_20151201T174549_008852_00CA51_539A\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"4\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:26.67Z, Instrument: SAR-C SAR, Mode: VH VV, Satellite:\
+        \ Sentinel-1, Size: 1.61 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174426_20151201T174459_008852_00CA51_E34C.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>3.7189,8.9991 5.6742,8.5955\
+        \ 5.3723,6.4020 3.4121,6.8116 3.7189,8.9991 3.7189,8.9991<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174426_20151201T174459_008852_00CA51_E34C\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"footprint\"\
+        ,\n               \"content\": \"POLYGON ((8.9991 3.7189,8.5955 5.6742,6.4020\
+        \ 5.3723,6.8116 3.4121,8.9991 3.7189,8.9991 3.7189))\"\n            },\n \
+        \           {\n               \"name\": \"platformidentifier\",\n        \
+        \       \"content\": \"0000-000A\"\n            },\n            {\n      \
+        \         \"name\": \"orbitdirection\",\n               \"content\": \"ASCENDING\"\
+        \n            },\n            {\n               \"name\": \"polarisationmode\"\
+        ,\n               \"content\": \"VH VV\"\n            },\n            {\n\
+        \               \"name\": \"productclass\",\n               \"content\": \"\
+        S\"\n            },\n            {\n               \"name\": \"productconsolidation\"\
+        ,\n               \"content\": \"SLICE\"\n            },\n            {\n\
+        \               \"name\": \"producttype\",\n               \"content\": \"\
+        RAW\"\n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.61\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T08:52:18.891Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:26.67Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:44:59.069Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('6c00f0c4-c106-484a-b534-610c8fe23f78')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('6c00f0c4-c106-484a-b534-610c8fe23f78')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('6c00f0c4-c106-484a-b534-610c8fe23f78')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"6c00f0c4-c106-484a-b534-610c8fe23f78\"\
+        ,\n         \"title\": \"S1A_IW_RAW__0SDV_20151201T174426_20151201T174459_008852_00CA51_E34C\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"2\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:01.669Z, Instrument: SAR-C SAR, Mode: VH VV, Satellite:\
+        \ Sentinel-1, Size: 1.54 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174401_20151201T174434_008852_00CA51_5782.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>2.2108,9.3143 4.1654,8.9065\
+        \ 3.8597,6.7178 1.8999,7.1296 2.2108,9.3143 2.2108,9.3143<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174401_20151201T174434_008852_00CA51_5782\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"footprint\"\
+        ,\n               \"content\": \"POLYGON ((9.3143 2.2108,8.9065 4.1654,6.7178\
+        \ 3.8597,7.1296 1.8999,9.3143 2.2108,9.3143 2.2108))\"\n            },\n \
+        \           {\n               \"name\": \"platformidentifier\",\n        \
+        \       \"content\": \"0000-000A\"\n            },\n            {\n      \
+        \         \"name\": \"orbitdirection\",\n               \"content\": \"ASCENDING\"\
+        \n            },\n            {\n               \"name\": \"polarisationmode\"\
+        ,\n               \"content\": \"VH VV\"\n            },\n            {\n\
+        \               \"name\": \"productclass\",\n               \"content\": \"\
+        S\"\n            },\n            {\n               \"name\": \"productconsolidation\"\
+        ,\n               \"content\": \"SLICE\"\n            },\n            {\n\
+        \               \"name\": \"producttype\",\n               \"content\": \"\
+        RAW\"\n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.54\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T08:52:18.266Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:01.669Z\"\n            },\n          \
+        \  {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:44:34.069Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('08312f59-73bc-4f65-b3ba-47ef31190680')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('08312f59-73bc-4f65-b3ba-47ef31190680')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('08312f59-73bc-4f65-b3ba-47ef31190680')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"08312f59-73bc-4f65-b3ba-47ef31190680\"\
+        ,\n         \"title\": \"S1A_IW_RAW__0SDV_20151201T174401_20151201T174434_008852_00CA51_5782\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"1\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:44:51.67Z, Instrument: SAR-C SAR, Mode: VH VV, Satellite:\
+        \ Sentinel-1, Size: 1.57 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174451_20151201T174524_008852_00CA51_9AF6.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>5.2276,8.6873 7.1834,8.2875\
+        \ 6.8851,6.0875 4.9246,6.4953 5.2276,8.6873 5.2276,8.6873<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174451_20151201T174524_008852_00CA51_9AF6\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"footprint\"\
+        ,\n               \"content\": \"POLYGON ((8.6873 5.2276,8.2875 7.1834,6.0875\
+        \ 6.8851,6.4953 4.9246,8.6873 5.2276,8.6873 5.2276))\"\n            },\n \
+        \           {\n               \"name\": \"platformidentifier\",\n        \
+        \       \"content\": \"0000-000A\"\n            },\n            {\n      \
+        \         \"name\": \"orbitdirection\",\n               \"content\": \"ASCENDING\"\
+        \n            },\n            {\n               \"name\": \"polarisationmode\"\
+        ,\n               \"content\": \"VH VV\"\n            },\n            {\n\
+        \               \"name\": \"productclass\",\n               \"content\": \"\
+        S\"\n            },\n            {\n               \"name\": \"productconsolidation\"\
+        ,\n               \"content\": \"SLICE\"\n            },\n            {\n\
+        \               \"name\": \"producttype\",\n               \"content\": \"\
+        RAW\"\n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.57\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T08:52:17.683Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:44:51.67Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:45:24.07Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('f8f14957-bd5b-428b-94ac-ed56816321e0')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('f8f14957-bd5b-428b-94ac-ed56816321e0')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('f8f14957-bd5b-428b-94ac-ed56816321e0')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"f8f14957-bd5b-428b-94ac-ed56816321e0\"\
+        ,\n         \"title\": \"S1A_IW_RAW__0SDV_20151201T174451_20151201T174524_008852_00CA51_9AF6\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"3\"\
+        \n            }\n         ]\n      },\n      {\n         \"summary\": \"Date:\
+        \ 2015-12-01T17:46:06.67Z, Instrument: SAR-C SAR, Mode: VH VV, Satellite:\
+        \ Sentinel-1, Size: 1.47 GB\",\n         \"str\": [\n            {\n     \
+        \          \"name\": \"processed\",\n               \"content\": \"T\"\n \
+        \           },\n            {\n               \"name\": \"acquisitiontype\"\
+        ,\n               \"content\": \"NOMINAL\"\n            },\n            {\n\
+        \               \"name\": \"filename\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174606_20151201T174639_008852_00CA51_CBEB.SAFE\"\
+        \n            },\n            {\n               \"name\": \"gmlfootprint\"\
+        ,\n               \"content\": \"<gml:Polygon srsName=\\\"http://www.opengis.net/gml/srs/epsg.xml#4326\\\
+        \" xmlns:gml=\\\"http://www.opengis.net/gml\\\">\\n   <gml:outerBoundaryIs>\\\
+        n      <gml:LinearRing>\\n         <gml:coordinates>9.7561,7.7686 11.7133,7.3784\
+        \ 11.4245,5.1492 9.4634,5.5539 9.7561,7.7686 9.7561,7.7686<\\/gml:coordinates>\\\
+        n      <\\/gml:LinearRing>\\n   <\\/gml:outerBoundaryIs>\\n<\\/gml:Polygon>\"\
+        \n            },\n            {\n               \"name\": \"format\",\n  \
+        \             \"content\": \"SAFE\"\n            },\n            {\n     \
+        \          \"name\": \"identifier\",\n               \"content\": \"S1A_IW_RAW__0SDV_20151201T174606_20151201T174639_008852_00CA51_CBEB\"\
+        \n            },\n            {\n               \"name\": \"instrumentshortname\"\
+        ,\n               \"content\": \"SAR-C SAR\"\n            },\n           \
+        \ {\n               \"name\": \"sensoroperationalmode\",\n               \"\
+        content\": \"IW\"\n            },\n            {\n               \"name\"\
+        : \"instrumentname\",\n               \"content\": \"Synthetic Aperture Radar\
+        \ (C-band)\"\n            },\n            {\n               \"name\": \"footprint\"\
+        ,\n               \"content\": \"POLYGON ((7.7686 9.7561,7.3784 11.7133,5.1492\
+        \ 11.4245,5.5539 9.4634,7.7686 9.7561,7.7686 9.7561))\"\n            },\n\
+        \            {\n               \"name\": \"platformidentifier\",\n       \
+        \        \"content\": \"0000-000A\"\n            },\n            {\n     \
+        \          \"name\": \"orbitdirection\",\n               \"content\": \"ASCENDING\"\
+        \n            },\n            {\n               \"name\": \"polarisationmode\"\
+        ,\n               \"content\": \"VH VV\"\n            },\n            {\n\
+        \               \"name\": \"productclass\",\n               \"content\": \"\
+        S\"\n            },\n            {\n               \"name\": \"productconsolidation\"\
+        ,\n               \"content\": \"SLICE\"\n            },\n            {\n\
+        \               \"name\": \"producttype\",\n               \"content\": \"\
+        RAW\"\n            },\n            {\n               \"name\": \"platformname\"\
+        ,\n               \"content\": \"Sentinel-1\"\n            },\n          \
+        \  {\n               \"name\": \"size\",\n               \"content\": \"1.47\
+        \ GB\"\n            },\n            {\n               \"name\": \"status\"\
+        ,\n               \"content\": \"ARCHIVED\"\n            }\n         ],\n\
+        \         \"date\": [\n            {\n               \"name\": \"ingestiondate\"\
+        ,\n               \"content\": \"2015-12-02T08:52:17.296Z\"\n            },\n\
+        \            {\n               \"name\": \"beginposition\",\n            \
+        \   \"content\": \"2015-12-01T17:46:06.67Z\"\n            },\n           \
+        \ {\n               \"name\": \"endposition\",\n               \"content\"\
+        : \"2015-12-01T17:46:39.069Z\"\n            }\n         ],\n         \"link\"\
+        : [\n            {\"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('52ee4c3f-8da3-4936-89d1-383b4b3cbe41')/$value\"\
+        },\n            {\n               \"rel\": \"alternative\",\n            \
+        \   \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('52ee4c3f-8da3-4936-89d1-383b4b3cbe41')/\"\
+        \n            },\n            {\n               \"rel\": \"icon\",\n     \
+        \          \"href\": \"https://scihub.copernicus.eu/apihub/odata/v1/Products('52ee4c3f-8da3-4936-89d1-383b4b3cbe41')/Products('Quicklook')/$value\"\
+        \n            }\n         ],\n         \"id\": \"52ee4c3f-8da3-4936-89d1-383b4b3cbe41\"\
+        ,\n         \"title\": \"S1A_IW_RAW__0SDV_20151201T174606_20151201T174639_008852_00CA51_CBEB\"\
+        ,\n         \"int\": [\n            {\n               \"name\": \"missiondatatakeid\"\
+        ,\n               \"content\": \"51793\"\n            },\n            {\n\
+        \               \"name\": \"orbitnumber\",\n               \"content\": \"\
+        8852\"\n            },\n            {\n               \"name\": \"lastorbitnumber\"\
+        ,\n               \"content\": \"8852\"\n            },\n            {\n \
+        \              \"name\": \"relativeorbitnumber\",\n               \"content\"\
+        : \"30\"\n            },\n            {\n               \"name\": \"lastrelativeorbitnumber\"\
+        ,\n               \"content\": \"30\"\n            },\n            {\n   \
+        \            \"name\": \"slicenumber\",\n               \"content\": \"6\"\
+        \n            }\n         ]\n      }\n   ],\n   \"xmlns\": \"http://www.w3.org/2005/Atom\"\
+        ,\n   \"subtitle\": \"Displaying 22 results. Request done in 2.267 seconds.\"\
+        ,\n   \"opensearch:itemsPerPage\": \"100\",\n   \"id\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[2015-12-01T00:00:00Z-1DAY\
+        \ TO 2015-12-01T00:00:00Z%2B1DAY-1HOUR]) AND (footprint:\\\"Intersects(ENVELOPE(0,\
+        \ 10, 10, 0))\\\")\",\n   \"updated\": \"2017-06-03T18:02:25.921Z\",\n   \"\
+        xmlns:opensearch\": \"http://a9.com/-/spec/opensearch/1.1/\"\n}}"}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['100824']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/vcr_cassettes/test_too_long_query.yaml
+++ b/tests/vcr_cassettes/test_too_long_query.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: q=%28beginPosition%3A%5BNOW+TO+NOW%5D%29+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending
+    body: q=%28beginPosition%3A%5BNOW+TO+NOW%5D%29+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['3240']
+      Content-Length: ['3752']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [sentinelsat/0.11]
     method: POST
@@ -46,11 +46,16 @@ interactions:
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
-        \ AND orbitdirection:descending AND orbitdirection:descending\"\n   },\n \
-        \  \"xmlns\": \"http://www.w3.org/2005/Atom\",\n   \"author\": {\"name\":\
-        \ \"Sentinels Scientific Data Hub\"},\n   \"subtitle\": \"Displaying 0 results.\
-        \ Request done in 0.487 seconds.\",\n   \"link\": [\n      {\n         \"\
-        rel\": \"self\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\"\
+        \n   },\n   \"xmlns\": \"http://www.w3.org/2005/Atom\",\n   \"author\": {\"\
+        name\": \"Sentinels Scientific Data Hub\"},\n   \"subtitle\": \"Displaying\
+        \ 0 results. Request done in 0.016 seconds.\",\n   \"link\": [\n      {\n\
+        \         \"rel\": \"self\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
         \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
         \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
@@ -84,7 +89,12 @@ interactions:
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
-        \ AND orbitdirection:descending AND orbitdirection:descending&start=0&rows=100\"\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending&start=0&rows=100\"\
         ,\n         \"type\": \"application/atom+xml\"\n      },\n      {\n      \
         \   \"rel\": \"first\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
         \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
@@ -120,7 +130,12 @@ interactions:
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
-        \ AND orbitdirection:descending AND orbitdirection:descending&start=0&rows=100\"\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending&start=0&rows=100\"\
         ,\n         \"type\": \"application/atom+xml\"\n      },\n      {\n      \
         \   \"rel\": \"last\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
         \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
@@ -156,7 +171,12 @@ interactions:
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
-        \ AND orbitdirection:descending AND orbitdirection:descending&start=-1&rows=100\"\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending&start=-1&rows=100\"\
         ,\n         \"type\": \"application/atom+xml\"\n      },\n      {\n      \
         \   \"rel\": \"search\",\n         \"href\": \"opensearch_description.xml\"\
         ,\n         \"type\": \"application/opensearchdescription+xml\"\n      }\n\
@@ -194,8 +214,13 @@ interactions:
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
-        \ AND orbitdirection:descending AND orbitdirection:descending\",\n   \"title\"\
-        : \"Sentinels Scientific Data Hub search results for: (beginPosition:[NOW\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\"\
+        ,\n   \"title\": \"Sentinels Scientific Data Hub search results for: (beginPosition:[NOW\
         \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
         \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
@@ -229,24 +254,29 @@ interactions:
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
         \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
-        \ AND orbitdirection:descending AND orbitdirection:descending\",\n   \"opensearch:startIndex\"\
-        : \"0\",\n   \"updated\": \"2017-06-02T22:06:25.574Z\",\n   \"opensearch:totalResults\"\
-        : \"0\",\n   \"xmlns:opensearch\": \"http://a9.com/-/spec/opensearch/1.1/\"\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\"\
+        ,\n   \"opensearch:startIndex\": \"0\",\n   \"updated\": \"2017-06-03T12:32:05.727Z\"\
+        ,\n   \"opensearch:totalResults\": \"0\",\n   \"xmlns:opensearch\": \"http://a9.com/-/spec/opensearch/1.1/\"\
         \n}}"}
     headers:
       Content-Type: [application/json]
       Pragma: [no-cache]
       Server: [Apache-Coyote/1.1]
       Vary: [Accept-Encoding]
-      content-length: ['19447']
+      content-length: ['22327']
     status: {code: 200, message: OK}
 - request:
-    body: q=%28beginPosition%3A%5BNOW+TO+NOW%5D%29+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending
+    body: q=%28beginPosition%3A%5BNOW+TO+NOW%5D%29+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['3880']
+      Content-Length: ['3784']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [sentinelsat/0.11]
     method: POST

--- a/tests/vcr_cassettes/test_too_long_query.yaml
+++ b/tests/vcr_cassettes/test_too_long_query.yaml
@@ -1,0 +1,260 @@
+interactions:
+- request:
+    body: q=%28beginPosition%3A%5BNOW+TO+NOW%5D%29+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3240']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.11]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=100&start=0
+  response:
+    body: {string: "{\"feed\": {\n   \"opensearch:Query\": {\n      \"startPage\"\
+        : \"1\",\n      \"role\": \"request\",\n      \"searchTerms\": \"(beginPosition:[NOW\
+        \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
+        \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending\"\n   },\n \
+        \  \"xmlns\": \"http://www.w3.org/2005/Atom\",\n   \"author\": {\"name\":\
+        \ \"Sentinels Scientific Data Hub\"},\n   \"subtitle\": \"Displaying 0 results.\
+        \ Request done in 0.487 seconds.\",\n   \"link\": [\n      {\n         \"\
+        rel\": \"self\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
+        \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
+        \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending&start=0&rows=100\"\
+        ,\n         \"type\": \"application/atom+xml\"\n      },\n      {\n      \
+        \   \"rel\": \"first\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
+        \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
+        \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending&start=0&rows=100\"\
+        ,\n         \"type\": \"application/atom+xml\"\n      },\n      {\n      \
+        \   \"rel\": \"last\",\n         \"href\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
+        \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
+        \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending&start=-1&rows=100\"\
+        ,\n         \"type\": \"application/atom+xml\"\n      },\n      {\n      \
+        \   \"rel\": \"search\",\n         \"href\": \"opensearch_description.xml\"\
+        ,\n         \"type\": \"application/opensearchdescription+xml\"\n      }\n\
+        \   ],\n   \"opensearch:itemsPerPage\": \"100\",\n   \"id\": \"https://scihub.copernicus.eu/apihub/search?q=(beginPosition:[NOW\
+        \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
+        \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending\",\n   \"title\"\
+        : \"Sentinels Scientific Data Hub search results for: (beginPosition:[NOW\
+        \ TO NOW]) AND orbitdirection:descending AND orbitdirection:descending AND\
+        \ orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending AND orbitdirection:descending\
+        \ AND orbitdirection:descending AND orbitdirection:descending\",\n   \"opensearch:startIndex\"\
+        : \"0\",\n   \"updated\": \"2017-06-02T22:06:25.574Z\",\n   \"opensearch:totalResults\"\
+        : \"0\",\n   \"xmlns:opensearch\": \"http://a9.com/-/spec/opensearch/1.1/\"\
+        \n}}"}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['19447']
+    status: {code: 200, message: OK}
+- request:
+    body: q=%28beginPosition%3A%5BNOW+TO+NOW%5D%29+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending+AND+orbitdirection%3Adescending
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3880']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.11]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=100&start=0
+  response:
+    body: {string: ''}
+    headers:
+      Connection: [close]
+      Server: [Apache-Coyote/1.1]
+    status: {code: 500, message: Internal Server Error}
+version: 1


### PR DESCRIPTION
I noticed that SciHub has an effective query length limit of about 2700–3600 bytes (depending on the content) when I tried to use a too detailed WKT polygon.
I experimented a bit and determined that the query size is effectively limited by the formatting and length of the server's internal query. I added a method `api.check_query_length()` that is able to calculate whether a query is too long with fairly good accuracy.
I also made the `SentinelAPIError` error messages for such situations more informative (the server reports back no useful information in this case).
I set up the relevant unit test to fail if the server's limit should change at some point in the future.

Edit: turns out the effective query length limit is approximately 3893 characters, but any special characters are counted twice towards that.