### PR TITLE
improve numpydoc, test docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 Added
 ~~~~~
 * contribution guidelines
-
+* tests for validity of documentation and RST files
 
 [0.11] – 2017-06-01
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Change Log
 All notable changes to ``sentinelsat`` will be listed here.
 
 [0.11.1] – 2017-XX-XX
--------------------
+---------------------
 
 Added
 ~~~~~

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -43,7 +43,7 @@ We aspire to 100% coverage but regard meaningful tests to be more important than
 We keep a changelog (`CHANGELOG.rst <https://github.com/sentinelsat/sentinelsat/blob/master/CHANGELOG.rst>`_) following the `keepachangelog <http://keepachangelog.com>`_ template.
 
 Good documentation is important to us. We use `Sphinx <http://www.sphinx-doc.org>`_ and host the documentation at `sentinelsat.readthedocs.io <https://sentinelsat.readthedocs.io/en/master/>`_.
-
+All public functions should have docstrings. We use the `numpy docstring standard <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard>`_.
 
 Development Environment
 =======================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -260,4 +260,17 @@ API
 ---
 
 .. automodule:: sentinelsat
+
+.. autoclass:: SentinelAPI
     :members:
+
+.. autofunction:: read_geojson
+
+.. autofunction:: geojson_to_wkt
+
+Exceptions
+----------
+
+.. autoexception:: SentinelAPIError
+
+.. autoexception:: InvalidChecksumError

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,7 +24,8 @@ To run the tests on ``sentinelsat``:
 By default, prerecorded responses to Copernicus Open Access Hub queries are used to not be affected by its downtime.
 To allow the tests to run actual queries against Copernicus Open Access Hub set the environment variables
 
-.. code-block:: bash
+.. code-block:: console
+
     export SENTINEL_USER=<your scihub username>
     export SENTINEL_PASSWORD=<your scihub password>
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -683,6 +683,8 @@ class InvalidChecksumError(Exception):
 
 
 def read_geojson(geojson_file):
+    """Read a GeoJSON file into a GeoJSON object.
+    """
     with open(geojson_file) as f:
         return geojson.load(f)
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(name='sentinelsat',
               'shapely',
               'pytest',
               'requests-mock',
-              'vcrpy'
+              'vcrpy',
+              'rstcheck'
           ],
           'docs': [
               'sphinx',

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,22 @@
+import os.path
+import pytest
+import rstcheck
+
+@pytest.mark.parametrize('rst_file', [
+    'CONTRIBUTE.rst',
+    'README.rst',
+    'CHANGELOG.rst',
+    os.path.join('docs', 'cli.rst'),
+    os.path.join('docs', 'index.rst'),
+    os.path.join('docs', 'install.rst')
+])
+def test_rst(rst_file):
+    with open(rst_file) as input_file:
+        contents = input_file.read()
+
+    all_errors = []
+    for error in rstcheck.check(contents, report_level=2, ignore=['python', 'bash']):
+        # report only warnings and higher, ignore Python and Bash pseudocode examples
+        all_errors.append(error)
+
+    assert len(all_errors) == 0


### PR DESCRIPTION
This PR addresses #139 with:

1. make the `.. automodule:` API documentation more explicit, making `numpydoc` more verbose when failing
2. test `.rst` files for errors, which cause Sphinx to fail (silently)