### PR TITLE
Add search-by-tile example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -268,7 +268,7 @@ To search for recent Sentinel 2 imagery by MGRS tile, use the `tileid` parameter
   from collections import OrderedDict
   from sentinelsat import SentinelAPI
 
-  api = SentinelAPI('myuser', 'mypass')
+  api = SentinelAPI('user', 'password')
 
   tiles = ['33VUC', '33UUB']
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -255,6 +255,44 @@ or add a custom handler for ``sentinelsat`` (as implemented in ``cli.py``)
   h.setFormatter(fmt)
   logger.addHandler(h)
 
+More Examples
+-------------
+
+Search Sentinel 2 by tile
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To search for recent Sentinel 2 imagery by MGRS tile, use the `tileid` parameter:
+
+.. code-block:: python
+
+  from collections import OrderedDict
+  from sentinelsat import SentinelAPI
+
+  api = SentinelAPI('myuser', 'mypass')
+
+  tiles = ['33VUC', '33UUB']
+
+  query_kwargs = {
+          'platformname': 'Sentinel-2',
+          'producttype': 'S2MSI1C',
+          'date': ('NOW-14DAYS', 'NOW')}
+
+  products = OrderedDict()
+  for tile in tiles:
+      kw = query_kwargs.copy()
+      kw['tileid'] = tile  # products after 2017-03-31
+      pp = api.query(**kw)
+      products.update(pp)
+
+  api.download_all(products)
+
+NB: The `tileid` parameter only works for products from April 2017 onward due to
+missing metadata in SciHub's DHuS catalogue. Before that, but only from
+December 2016 onward (i.e. for single-tile products), you can use a `filename` pattern instead:
+
+.. code-block:: python
+
+  kw['filename'] = '*_T{}_*'.format(tile)  # products after 2016-12-01
 
 API
 ---


### PR DESCRIPTION
We talked about adding some examples of the API usage to the docs. And that one of the examples could be how to search for Sentinel 2 imagery by tile.

How about this?

Closes #140