### PR TITLE
increased verbosity regarding optional dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 Added
 ~~~~~
+* made exceptions more verbose regarding optional dependencies (#176)
 
 Changed
 ~~~~~~~

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -327,8 +327,8 @@ class SentinelAPI:
         """
         try:
             import pandas as pd
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("to_dataframe requires the optional dependency Pandas.")
+        except ImportError:
+            raise ImportError("to_dataframe requires the optional dependency Pandas.")
 
         return pd.DataFrame.from_dict(products, orient='index')
 
@@ -340,8 +340,8 @@ class SentinelAPI:
         try:
             import geopandas as gpd
             import shapely.wkt
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("to_geodataframe requires the optional dependencies GeoPandas and Shapely.")
+        except ImportError:
+            raise ImportError("to_geodataframe requires the optional dependencies GeoPandas and Shapely.")
 
         df = SentinelAPI.to_dataframe(products)
         crs = {'init': 'epsg:4326'}  # WGS84

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -325,7 +325,10 @@ class SentinelAPI:
         """Return the products from a query response as a Pandas DataFrame
         with the values in their appropriate Python types.
         """
-        import pandas as pd
+        try:
+            import pandas as pd
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("to_dataframe requires the optional dependency Pandas.")
 
         return pd.DataFrame.from_dict(products, orient='index')
 
@@ -334,8 +337,11 @@ class SentinelAPI:
         """Return the products from a query response as a GeoPandas GeoDataFrame
         with the values in their appropriate Python types.
         """
-        import geopandas as gpd
-        import shapely.wkt
+        try:
+            import geopandas as gpd
+            import shapely.wkt
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("to_geodataframe requires the optional dependencies GeoPandas and Shapely.")
 
         df = SentinelAPI.to_dataframe(products)
         crs = {'init': 'epsg:4326'}  # WGS84

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -640,20 +640,6 @@ def test_get_products_invalid_json():
             )
         assert excinfo.value.msg == "Invalid API response."
 
-@pytest.mark.fast
-def test_missing_dependency_dataframe():
-    api = SentinelAPI("mock_user", "mock_password")
-
-    with pytest.raises(ModuleNotFoundError) as excinfo:
-        sys.modules["pandas"] = None                
-        api.to_dataframe({"test":"test"})
-    assert excinfo.value.msg == "to_dataframe requires the optional dependency Pandas."
-
-    with pytest.raises(ModuleNotFoundError) as excinfo:
-        sys.modules["geopandas"] = None
-        api.to_geodataframe({"test":"tst"})
-    assert excinfo.value.msg == "to_geodataframe requires the optional dependencies GeoPandas and Shapely."
-
 
 @my_vcr.use_cassette
 @pytest.mark.scihub
@@ -772,6 +758,21 @@ def test_response_to_dict(raw_products):
     props = dictionary['44517f66-9845-4792-a988-b5ae6e81fd3e']
     expected_title = 'S2A_OPER_PRD_MSIL1C_PDMC_20151228T112523_R110_V20151227T142229_20151227T142229'
     assert props['title'] == expected_title
+
+
+@pytest.mark.fast
+@pytest.mark.pandas
+@pytest.mark.geopandas
+def test_missing_dependency_dataframe(monkeypatch):
+    api = SentinelAPI("mock_user", "mock_password")
+
+    with pytest.raises(ImportError):
+        monkeypatch.setitem(sys.modules, "pandas", None)                
+        api.to_dataframe({"test":"test"})
+
+    with pytest.raises(ImportError):
+        monkeypatch.setitem(sys.modules, "geopandas", None)
+        api.to_geodataframe({"test":"tst"})
 
 
 @pytest.mark.pandas

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -2,6 +2,7 @@ import hashlib
 import textwrap
 from datetime import date, datetime, timedelta
 from os import environ
+import sys
 
 import geojson
 import py.path
@@ -638,6 +639,20 @@ def test_get_products_invalid_json():
                 platformname="Sentinel-2"
             )
         assert excinfo.value.msg == "Invalid API response."
+
+@pytest.mark.fast
+def test_missing_dependency_dataframe():
+    api = SentinelAPI("mock_user", "mock_password")
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        sys.modules["pandas"] = None                
+        api.to_dataframe({"test":"test"})
+    assert excinfo.value.msg == "to_dataframe requires the optional dependency Pandas."
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        sys.modules["geopandas"] = None
+        api.to_geodataframe({"test":"tst"})
+    assert excinfo.value.msg == "to_geodataframe requires the optional dependencies GeoPandas and Shapely."
 
 
 @my_vcr.use_cassette


### PR DESCRIPTION
This PR adds more verbose exceptions regarding the optional dependencies for `to_dataframe` and `to_geodataframe`.

The idea is to avoid confusion about the dependencies being optional in case users encounter this prior to reading the docs (which is the standard case I guess). See #176 
