### PR TITLE
set user, pass, url for the CLI via env vars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 Added
 ~~~~~
 * made exceptions more verbose regarding optional dependencies (#176)
-* CLI username, password and DHuS URL can be set with environment variables ``DHUS_USER``, ``DHUS_PASSWORD`` and ``DHUS_URL``(thanks @temal-)
+* CLI username, password and DHuS URL can be set with environment variables ``DHUS_USER``, ``DHUS_PASSWORD`` and ``DHUS_URL`` (thanks @temal-)
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,12 +9,14 @@ All notable changes to ``sentinelsat`` will be listed here.
 Added
 ~~~~~
 * made exceptions more verbose regarding optional dependencies (#176)
+* CLI username, password and DHuS URL can be set with environment variables ``DHUS_USER``, ``DHUS_PASSWORD`` and ``DHUS_URL``(thanks @temal-)
 
 Changed
 ~~~~~~~
 
 Deprecated
 ~~~~~~~~~~
+* environment variables ``SENTINEL_USER`` and ``SENTINEL_PASSWORD`` are superceded by ``DHUS_USER`` and ``DHUS_PASSWORD``
 
 Fixed
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -111,14 +111,11 @@ Command Line Interface
 ----------------------
 
 A basic search query consists of a search area geometry as well as the username and
-password (which can either be set via ``SENTINEL_USER`` and ``SENTINEL_PASSWORD`` environment
-variables or via CLI arguments) to access the Copernicus Open Access Hub.
+password to access the Copernicus Open Access Hub.
 
 .. code-block:: bash
 
-  export SENTINEL_USER="<user>"
-  export SENTINEL_PASSWORD="<password>"
-  sentinelsat -g <geojson>
+  sentinelsat -u <user> -p <password> -g <geojson>
 
 Search areas are provided as GeoJSON files, which can be created with
 `QGIS <http://qgis.org/en/site/>`_ or `geojson.io <http://geojson.io>`_.
@@ -133,55 +130,67 @@ orbit, for the year 2015.
 
 .. code-block:: bash
 
-  sentinelsat -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
+  sentinelsat -u <user> -p <password> -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending" \
   --url "https://scihub.copernicus.eu/dhus"
+
+Username, password and DHuS URL can also be set via environment variables for convenience.
+
+.. code-block:: bash
+ 
+  # same result as query above
+  export DHUS_USER="<user>"
+  export DHUS_PASSWORD="<password>"
+  export DHUS_URL="https://scihub.copernicus.eu/dhus"
+
+  sentinelsat -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
+  --producttype SLC -q "orbitdirection=Descending"
 
 Options
 ^^^^^^^
 
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -u | -\-user       | TEXT | SENTINEL_USER     | Username [required]                                                                        |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -p | -\-password   | TEXT | SENTINEL_PASSWORD | Password [required]                                                                        |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-url        | TEXT | SENTINEL_URL      | Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.             |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -s | -\-start      | TEXT |                   | Start date of the query in the format YYYYMMDD.                                            |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -e | -\-end        | TEXT |                   | End date of the query in the format YYYYMMDD.                                              |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -g | -\-geometry   | PATH |                   | Search area geometry as GeoJSON file.                                                      |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-uuid       | TEXT |                   | Select a specific product UUID instead of a query. Multiple UUIDs can separated by commas. |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-name       | TEXT |                   | Select specific product(s) by filename. Supports wildcards.                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-sentinel   |      |                   | Limit search to a Sentinel satellite (constellation).                                      |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-instrument |      |                   | Limit search to a specific instrument on a Sentinel satellite.                             |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-producttype|      |                   | Limit search to a Sentinel product type.                                                   |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -c | -\-cloud      | INT  |                   | Maximum cloud cover in percent. (requires --sentinel to be 2 or 3)                         |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -o | -\-order-by   | TEXT |                   | Comma-separated list of keywords to order the result by. Prefix '-' for descending order.  |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -l | -\-limit      | INT  |                   |  Maximum number of results to return. Defaults to no limit.                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -d | -\-download   |      |                   | Download all results of the query.                                                         |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-path       | PATH |                   | Set the path where the files will be saved.                                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -q | -\-query      | TEXT |                   | Extra search keywords you want to use in the query. Separate keywords with comma.          |
-|    |               |      |                   | Example: 'producttype=GRD,polarisationmode=HH'.                                            |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -f | -\-footprints |      |                   | Create geojson file search_footprints.geojson with footprints of the query result.         |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-version    |      |                   | Show version number and exit.                                                              |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-help       |      |                   | Show help message and exit.                                                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -u | -\-user       | TEXT | Username [required] (or environment variable DHUS_USER)                                    |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -p | -\-password   | TEXT | Password [required] (or environment variable DHUS_PASSWORD)                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-url        | TEXT | Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.             |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -s | -\-start      | TEXT | Start date of the query in the format YYYYMMDD.                                            |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -e | -\-end        | TEXT | End date of the query in the format YYYYMMDD.                                              |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -g | -\-geometry   | PATH | Search area geometry as GeoJSON file.                                                      |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-uuid       | TEXT | Select a specific product UUID instead of a query. Multiple UUIDs can separated by commas. |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-name       | TEXT | Select specific product(s) by filename. Supports wildcards.                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-sentinel   |      | Limit search to a Sentinel satellite (constellation).                                      |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-instrument |      | Limit search to a specific instrument on a Sentinel satellite.                             |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-producttype|      | Limit search to a Sentinel product type.                                                   |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -c | -\-cloud      | INT  | Maximum cloud cover in percent. (requires --sentinel to be 2 or 3)                         |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -o | -\-order-by   | TEXT | Comma-separated list of keywords to order the result by. Prefix '-' for descending order.  |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -l | -\-limit      | INT  |  Maximum number of results to return. Defaults to no limit.                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -d | -\-download   |      | Download all results of the query.                                                         |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-path       | PATH | Set the path where the files will be saved.                                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -q | -\-query      | TEXT | Extra search keywords you want to use in the query. Separate keywords with comma.          |
+|    |               |      | Example: 'producttype=GRD,polarisationmode=HH'.                                            |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -f | -\-footprints |      | Create geojson file search_footprints.geojson with footprints of the query result.         |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-version    |      | Show version number and exit.                                                              |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-help       |      | Show help message and exit.                                                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
 
 Tests
 =====

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -15,18 +15,15 @@ password to access the Copernicus Open Access Hub.
 
   sentinelsat -u <user> -p <password> -g <geojson>
 
-To simplify command execution and reduce information leakage it is recommended to specify
-the user and password (and optionally the api_url) values via environment variables.
+For convenience and added security you can set the username, password and DHuS URL as environment variables and omit their entry on the command line.
 
 .. code-block:: bash
 
-  export SENTINEL_USER="<user>"
-  export SENTINEL_PASSWORD="<password>"
-  export SENTINEL_URL="<api_url>"
+  export DHUS_USER="<user>"
+  export DHUS_PASSWORD="<password>"
+  export DHUS_URL="<api_url>"
 
   sentinelsat -g <geojson>
-
-All further examples expect ``SENTINEL_USER`` and ``SENTINEL_PASSWORD`` to be set.
 
 Search areas are provided as GeoJSON polygons, which can be created with
 `QGIS <http://qgis.org/en/site/>`_ or `geojson.io <http://geojson.io>`_.
@@ -45,7 +42,7 @@ orbit for the year 2015.
 
 .. code-block:: bash
 
-  sentinelsat -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
+  sentinelsat -u <user> -p <password> -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending" \
   --url "https://scihub.copernicus.eu/dhus"
 
@@ -54,13 +51,13 @@ on Christmas Eve 2015.
 
 .. code-block:: bash
 
-  sentinelsat -d --uuid a9048d1d-fea6-4df8-bedd-7bcb212be12e
+  sentinelsat -u <user> -p <password> -d --uuid a9048d1d-fea6-4df8-bedd-7bcb212be12e
 
 or by using its filename
 
 .. code-block:: bash
 
-  sentinelsat -d --name S1A_EW_GRDM_1SDH_20151224T154142_20151224T154207_009186_00D3B0_C71E
+  sentinelsat -u <user> -p <password> -d --name S1A_EW_GRDM_1SDH_20151224T154142_20151224T154207_009186_00D3B0_C71E
 
 Sentinel-2
 ~~~~~~~~~~
@@ -70,65 +67,65 @@ cover of 40%.
 
 .. code-block:: bash
 
-  sentinelsat -g <search_polygon.geojson> -s 20160101 -e 20160131 --sentinel 2 --cloud 40 -d
+  sentinelsat -u <user> -p <password> -g <search_polygon.geojson> -s 20160101 -e 20160131 --sentinel 2 --cloud 40 -d
 
 Download all Sentinel-2 scenes published in the last 24 hours.
 
 .. code-block:: bash
 
-  sentinelsat -g <search_polygon.geojson> --sentinel 2 -d
+  sentinelsat -u <user> -p <password> -g <search_polygon.geojson> --sentinel 2 -d
 
 sentinelsat
 ---------------
 
 .. code-block:: console
 
-    sentinelsat [OPTIONS]
+    sentinelsat -u <user> -p <password> [OPTIONS]
 
 Options:
 
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -u | -\-user       | TEXT | SENTINEL_USER     | Username [required]                                                                        |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -p | -\-password   | TEXT | SENTINEL_PASSWORD | Password [required]                                                                        |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-url        | TEXT | SENTINEL_URL      | Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.             |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -s | -\-start      | TEXT |                   | Start date of the query in the format YYYYMMDD.                                            |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -e | -\-end        | TEXT |                   | End date of the query in the format YYYYMMDD.                                              |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -g | -\-geometry   | PATH |                   | Search area geometry as GeoJSON file.                                                      |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-uuid       | TEXT |                   | Select a specific product UUID instead of a query. Multiple UUIDs can separated by commas. |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-name       | TEXT |                   | Select specific product(s) by filename. Supports wildcards.                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-sentinel   |      |                   | Limit search to a Sentinel satellite (constellation).                                      |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-instrument |      |                   | Limit search to a specific instrument on a Sentinel satellite.                             |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-producttype|      |                   | Limit search to a Sentinel product type.                                                   |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -c | -\-cloud      | INT  |                   | Maximum cloud cover in percent. (requires --sentinel to be 2 or 3)                         |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -o | -\-order-by   | TEXT |                   | Comma-separated list of keywords to order the result by. Prefix '-' for descending order.  |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -l | -\-limit      | INT  |                   |  Maximum number of results to return. Defaults to no limit.                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -d | -\-download   |      |                   | Download all results of the query.                                                         |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-path       | PATH |                   | Set the path where the files will be saved.                                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -q | -\-query      | TEXT |                   | Extra search keywords you want to use in the query. Separate keywords with comma.          |
-|    |               |      |                   | Example: 'producttype=GRD,polarisationmode=HH'.                                            |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-| -f | -\-footprints |      |                   | Create geojson file search_footprints.geojson with footprints of the query result.         |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-version    |      |                   | Show version number and exit.                                                              |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
-|    | -\-help       |      |                   | Show help message and exit.                                                                |
-+----+---------------+------+-------------------+--------------------------------------------------------------------------------------------+
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -u | -\-user       | TEXT | Username [required] (or environment variable DHUS_USER)                                    |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -p | -\-password   | TEXT | Password [required] (or environment variable DHUS_PASSWORD)                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-url        | TEXT | Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.             |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -s | -\-start      | TEXT | Start date of the query in the format YYYYMMDD.                                            |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -e | -\-end        | TEXT | End date of the query in the format YYYYMMDD.                                              |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -g | -\-geometry   | PATH | Search area geometry as GeoJSON file.                                                      |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-uuid       | TEXT | Select a specific product UUID instead of a query. Multiple UUIDs can separated by commas. |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-name       | TEXT | Select specific product(s) by filename. Supports wildcards.                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-sentinel   |      | Limit search to a Sentinel satellite (constellation).                                      |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-instrument |      | Limit search to a specific instrument on a Sentinel satellite.                             |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-producttype|      | Limit search to a Sentinel product type.                                                   |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -c | -\-cloud      | INT  | Maximum cloud cover in percent. (requires --sentinel to be 2 or 3)                         |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -o | -\-order-by   | TEXT | Comma-separated list of keywords to order the result by. Prefix '-' for descending order.  |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -l | -\-limit      | INT  |  Maximum number of results to return. Defaults to no limit.                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -d | -\-download   |      | Download all results of the query.                                                         |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-path       | PATH | Set the path where the files will be saved.                                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -q | -\-query      | TEXT | Extra search keywords you want to use in the query. Separate keywords with comma.          |
+|    |               |      | Example: 'producttype=GRD,polarisationmode=HH'.                                            |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+| -f | -\-footprints |      | Create geojson file search_footprints.geojson with footprints of the query result.         |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-version    |      | Show version number and exit.                                                              |
++----+---------------+------+--------------------------------------------------------------------------------------------+
+|    | -\-help       |      | Show help message and exit.                                                                |
++----+---------------+------+--------------------------------------------------------------------------------------------+
 
 ESA maintains a `list of valid search keywords <https://scihub.copernicus.eu/userguide/3FullTextSearch>`_ that can be used with :option:`--query`.
 

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -21,15 +21,15 @@ def _set_logger_handler(level='INFO'):
 
 @click.command()
 @click.option(
-    '--user', '-u', type=str, required=True, envvar='SENTINEL_USER',
-    help='Username')
+    '--user', '-u', type=str, required=True, envvar='DHUS_USER',
+    help='Username (or environment variable DHUS_USER is set)')
 @click.option(
-    '--password', '-p', type=str, required=True, envvar='SENTINEL_PASSWORD',
-    help='Password')
+    '--password', '-p', type=str, required=True, envvar='DHUS_PASSWORD',
+    help='Password (or environment variable DHUS_PASSWORD is set)')
 @click.option(
-    '--url', type=str, default='https://scihub.copernicus.eu/apihub/', envvar='SENTINEL_URL',
+    '--url', type=str, default='https://scihub.copernicus.eu/apihub/', envvar='DHUS_URL',
     help="""Define API URL. Default URL is
-        'https://scihub.copernicus.eu/apihub/'.
+        'https://scihub.copernicus.eu/apihub/' (or environment variable DHUS_URL).
         """)
 @click.option(
     '--start', '-s', type=str, default='NOW-1DAY',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,9 @@ from sentinelsat import InvalidChecksumError, SentinelAPI
 from sentinelsat.scripts.cli import cli
 from .shared import my_vcr, FIXTURES_DIR
 
-_api_auth = [environ.get('SENTINEL_USER', "user"), environ.get('SENTINEL_PASSWORD', "pw")]
+# local tests require environment variables `DHUS_USER` and `DHUS_PASSWORD`
+# for Travis CI they are set as encrypted environment variables and stored
+_api_auth = [environ.get('DHUS_USER', "user"), environ.get('DHUS_PASSWORD', "pw")]
 
 # TODO: change test fictures from subcommands to unified commands
 # TODO: include test for --uuid option, with comma separated list.


### PR DESCRIPTION
Adding on to #184 by @temal-:

* changed environment variables from SENTINEL_* to DHUS_*
* fixed RST tables
* reverted documentation examples (I think the examples should be self-contained/self-explanatory and therefore include the user and password options)
* changelog