### PR TITLE
Add FAQ

### DIFF
--- a/docs/common_problems.rst
+++ b/docs/common_problems.rst
@@ -1,0 +1,41 @@
+.. _common_problems:
+
+Common problems
+===============
+
+.. Using "rubric" directives as titles so they don't show on the TOC
+
+
+.. rubric:: I keep getting *HTTP 401 Unauthorized* messages
+
+This means that the given username/password combination is incorrect. Note that
+if you created your account recently it could take a while (a few days?) until
+you can use that account on *apihub* and therefore *sentinelsat* too. You can go
+`here`__ to test access on the *apihub* endpoint.
+
+__ https://scihub.copernicus.eu/apihub/search?
+
+
+.. rubric:: The query fails with *HTTP 500 connect time out*
+
+Scihub servers are known to have outages due to high demand, try again later.
+
+
+.. rubric:: How I can see the images?
+
+Take a look at the `Sentinel Toolbox`__.
+
+__ https://sentinel.esa.int/web/sentinel/toolboxes/sentinel-2
+
+
+.. rubric:: My search returns 0 results
+
+Maybe there are no images for the specified time period, by default
+*sentinelsat* will query the last 24 hours only.
+
+
+.. rubric:: Anything else?
+
+Make sure to check the `issues on GitHub`__ too.
+
+__ https://github.com/sentinelsat/sentinelsat/issues

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Contents
    install
    cli
    api
+   common_problems
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Hi, I think that a FAQ could be useful, because I was stuck with authentication issues and the answer was on a closed issue (it takes a few days until you can use a new account on apihub).

I don't know if you agree, I looked at some closed issues looking for more problems that people had:

- #178: Query returns 0 results because of time interval (I made that mistake too).
- #178: User asks for something to view the images.
- #73: Authentication issues because of slow account creation on apihub.
- #67 and  #80: 500 time out because of server issues.

So I made a FAQ on README.md with those problems. Keep in mind that maybe I should copy it to the readthedocs documentation, also I'm not a native english speaker so I could have made some mistakes.

Thank you for this useful tool.