### PR TITLE
Fix failing test for docs

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -17,7 +17,7 @@ def test_rst(rst_file):
         contents = input_file.read()
 
     all_errors = []
-    for error in rstcheck.check(contents, report_level=2, ignore=['python', 'bash']):
+    for error in rstcheck.check(contents, report_level=2, ignore={'languages': ['python', 'bash']}):
         # report only warnings and higher, ignore Python and Bash pseudocode examples
         if 'Title underline too short' in error[1]:
             # These are caused by unicode en dashes and can be ignored


### PR DESCRIPTION
Fix for error when running `py.test -v`
Traceback was:
```
    def check(source,
              filename='<string>',
              report_level=docutils.utils.Reporter.INFO_LEVEL,
              ignore=None,
              debug=False):
        """Yield errors.
    
        Use lower report_level for noisier error output.
    
        Each yielded error is a tuple of the form:
    
            (line_number, message)
    
        Line numbers are indexed at 1 and are with respect to the full RST file.
    
        Each code block is checked asynchronously in a subprocess.
    
        Note that this function mutates state by calling the ``docutils``
        ``register_*()`` functions.
    
        """
        # Do this at call time rather than import time to avoid unnecessarily
        # mutating state.
        register_code_directive()
        ignore_sphinx()
    
        ignore = ignore or {}
    
        try:
>           ignore.setdefault('languages', []).extend(
                find_ignored_languages(source)
            )
E           AttributeError: 'list' object has no attribute 'setdefault'
```