### PR TITLE
authors list as separate file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,24 @@
+Creator
+=======
+
+* Marcel Wille `@willemarcel <https://github.com/willemarcel>`_
+
+Maintainers
+===========
+
+* Kersten Clauss `@Fernerkundung <https://github.com/Fernerkundung>`_
+* Martin Valgur `@valgur <https://github.com/valgur>`_
+* Jonas Sølvsteen `@j08lue <https://github.com/j08lue>`_
+
+Contributors
+============
+
+* Luca Delucchi `@lucadelu <https://github.com/lucadelu>`_
+* Gaston Keller `@gkeller2 <https://github.com/gkeller2>`_
+* Malte `@temal- <https://github.com/temal->`_
+* unnic `@unnic <https://github.com/unnic>`_
+* Leonard Kioi kinyanjui `@lenniezelk <https://github.com/lenniezelk>`_
+* Schlump `@Schlump <https://github.com/Schlump>`_
+* Caio Castro `@caiocacastro <https://github.com/caiocacastro>`_
+* martinber `@martinber <https://github.com/martinber>`_
+* Nicklas Keck `@NiklasKeck <https://github.com/NiklasKeck>`_

--- a/README.rst
+++ b/README.rst
@@ -239,14 +239,9 @@ See `CHANGELOG <CHANGELOG.rst>`_. You can also use Githubs compare view to see t
 Contributors
 ============
 
-* Wille Marcel
-* Kersten Clauss
-* Martin Valgur
-* Jonas Sølvsteen
-* Luca Delucchi
-* Gaston Keller
-
 We invite anyone to participate by contributing code, reporting bugs, fixing bugs, writing documentation and tutorials and discussing the future of this project. Please check `CONTRIBUTE.rst <CONTRIBUTE.rst>`_.
+
+For a list of maintainers and contributors please see `AUTHORS.rst <AUTHORS.rst>`_ and the `contributor graph <https://github.com/sentinelsat/sentinelsat/graphs/contributors>`_.
 
 License
 =======

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -8,6 +8,7 @@ import rstcheck
     'CONTRIBUTE.rst',
     'README.rst',
     'CHANGELOG.rst',
+    'AUTHORS.rst',
     os.path.join('docs', 'cli.rst'),
     os.path.join('docs', 'index.rst'),
     os.path.join('docs', 'install.rst')


### PR DESCRIPTION
I propose to change the list of authors/contributors to a separate file. This enables us the shorten the Readme and include people who do not appear in the contributor graph (see #194)

Are you ok with the Creator/Maintainer/Contributor distinction @willemarcel @valgur @j08lue?
 I tried to model this after other popular FOSS projects but the structure is open for discussion.