### PR TITLE
Fix order_by not being included in subqueries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 Changed
 ~~~~~~~
 * remove hard coded product type list from cli (#190, @lenniezelk)
+* Made the function signature of ``count()`` fully compatible with ``query()``. Irrelevant parameters are simply ignored.
 
 Deprecated
 ~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,9 @@ Deprecated
 
 Fixed
 ~~~~~
-* Updated invalid query handling. A client-side error is raised in such cases. #168
+* Updated handling of invalid queries. An exception is raised in such cases. #168
+* Fixed ``order_by`` parameter being ignored in queries that require multiple subqueries (that is, queries that return
+  more than 100 products) (#200)
 * Special handling of quote symbols in query strings due to a server-side error is no
   longer necessary and has been removed. #168
 * Updated effective query length calculation in ``check_query_length()`` to reflect

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -214,7 +214,7 @@ class SentinelAPI:
         )
         return self.query(raw=query, order_by=order_by, limit=limit, offset=offset)
 
-    def count(self, *args, **kwargs):
+    def count(self, area=None, date=None, raw=None, area_relation='Intersects', **keywords):
         """Get the number of products matching a query.
 
         This is a significantly more efficient alternative to doing len(api.query()),
@@ -229,7 +229,12 @@ class SentinelAPI:
         int
             The number of products matching a query.
         """
-        query = self.format_query(*args, **kwargs)
+        for kw in ['order_by', 'limit', 'offset']:
+            # Allow these function arguments to be included for compatibility with query(),
+            # but ignore them.
+            if kw in keywords:
+                del keywords[kw]
+        query = self.format_query(area, date, raw, area_relation, **keywords)
         _, total_count = self._load_query(query, limit=0)
         return total_count
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -254,7 +254,7 @@ class SentinelAPI:
                 new_limit = limit
                 if limit is not None:
                     new_limit = limit - new_offset + offset
-                ret = self._load_subquery(query, limit=new_limit, offset=new_offset)[0]
+                ret = self._load_subquery(query, order_by, new_limit, new_offset)[0]
                 progress.update(len(ret))
                 products += ret
             progress.close()

--- a/tests/fixtures/vcr_cassettes/test_order_by.yaml
+++ b/tests/fixtures/vcr_cassettes/test_order_by.yaml
@@ -1,6 +1,50 @@
 interactions:
 - request:
-    body: q=beginPosition%3A%5B2015-12-19T00%3A00%3A00Z+TO+2015-12-28T00%3A00%3A00Z%5D+cloudcoverpercentage%3A%5B0+TO+10%5D+platformname%3ASentinel-2+footprint%3A%22Intersects%28POLYGON%28%28-66.2695+-8.0592%2C-66.2695+0.7031%2C-57.3047+0.7031%2C-57.3047+-8.0592%2C-66.2695+-8.0592%29%29%29%22
+    body: q=beginPosition%3A%5B2015-12-19T00%3A00%3A00Z+TO+2016-10-19T00%3A00%3A00Z%5D+cloudcoverpercentage%3A%5B0+TO+10%5D+platformname%3ASentinel-2+footprint%3A%22Intersects%28POLYGON%28%28-66.2695+-8.0592%2C-66.2695+0.7031%2C-57.3047+0.7031%2C-57.3047+-8.0592%2C-66.2695+-8.0592%29%29%29%22
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['283']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.1]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","subtitle":"Displaying 0 to
+        -1 of 132 total results. Request done in 0.136 seconds.","updated":"2018-06-06T13:15:26.257Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","opensearch:totalResults":"132","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=131&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['2772']
+    status: {code: 200, message: OK}
+- request:
+    body: q=beginPosition%3A%5B2015-12-19T00%3A00%3A00Z+TO+2016-10-19T00%3A00%3A00Z%5D+cloudcoverpercentage%3A%5B0+TO+10%5D+platformname%3ASentinel-2+footprint%3A%22Intersects%28POLYGON%28%28-66.2695+-8.0592%2C-66.2695+0.7031%2C-57.3047+0.7031%2C-57.3047+-8.0592%2C-66.2695+-8.0592%29%29%29%22
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -13,26 +57,2886 @@ interactions:
   response:
     body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
         Scientific Data Hub search results for: beginPosition:[2015-12-19T00:00:00Z
-        TO 2015-12-28T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
         footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
-        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","subtitle":"Displaying 3 results.
-        Request done in 0.064 seconds.","updated":"2017-10-24T19:58:43.201Z","author":{"name":"Sentinels
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","subtitle":"Displaying 0 to
+        99 of 132 total results. Request done in 0.131 seconds.","updated":"2018-06-06T13:15:26.713Z","author":{"name":"Sentinels
         Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
-        TO 2015-12-28T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
         footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
-        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","opensearch:totalResults":"3","opensearch:startIndex":"0","opensearch:itemsPerPage":"100","opensearch:Query":{"role":"request","searchTerms":"beginPosition:[2015-12-19T00:00:00Z
-        TO 2015-12-28T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","opensearch:totalResults":"132","opensearch:startIndex":"0","opensearch:itemsPerPage":"100","opensearch:Query":{"role":"request","searchTerms":"beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
         footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
         0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
-        TO 2015-12-28T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
         footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
         0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=0&rows=100"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
-        TO 2015-12-28T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
         footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
-        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=0&rows=100"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
-        TO 2015-12-28T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=0&rows=100"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
         footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
-        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=2&rows=100"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}],"entry":[{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20151228T112701_R110_V20151227T142229_20151227T142229","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6ed0b7de-3435-43df-98bf-ad63c8d077ef'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6ed0b7de-3435-43df-98bf-ad63c8d077ef'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6ed0b7de-3435-43df-98bf-ad63c8d077ef'')/Products(''Quicklook'')/$value"}],"id":"6ed0b7de-3435-43df-98bf-ad63c8d077ef","summary":"Date:
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=100&rows=100"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=131&rows=100"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}],"entry":[{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164230_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''204870df-bbf9-4970-b4ba-376752abac74'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''204870df-bbf9-4970-b4ba-376752abac74'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''204870df-bbf9-4970-b4ba-376752abac74'')/Products(''Quicklook'')/$value"}],"id":"204870df-bbf9-4970-b4ba-376752abac74","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        23.11 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:37:26.254Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"204870df-bbf9-4970-b4ba-376752abac74"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164230_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.518264837627849,-60.28079735037396
+        -4.590021398553755,-60.29650970256024 -4.518335502644501,-60.29680494075908
+        -4.518264837627849,-60.28079735037396 -4.518264837627849,-60.28079735037396</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164230_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.28079735037396 -4.518264837627849,-60.29650970256024
+        -4.590021398553755,-60.29680494075908 -4.518335502644501,-60.28079735037396
+        -4.518264837627849,-60.28079735037396 -4.518264837627849))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"23.11
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164241_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''df60c6d8-f008-480e-9151-6ae0a17de2ba'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''df60c6d8-f008-480e-9151-6ae0a17de2ba'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''df60c6d8-f008-480e-9151-6ae0a17de2ba'')/Products(''Quicklook'')/$value"}],"id":"df60c6d8-f008-480e-9151-6ae0a17de2ba","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        22.84 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:41:34.326Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"df60c6d8-f008-480e-9151-6ae0a17de2ba"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164241_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.80727161972489,-59.68720642356852
+        -1.849734575994482,-59.69661607927717 -1.807260224698412,-59.69653612035876
+        -1.80727161972489,-59.68720642356852 -1.80727161972489,-59.68720642356852</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164241_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.68720642356852 -1.80727161972489,-59.69661607927717
+        -1.849734575994482,-59.69653612035876 -1.807260224698412,-59.68720642356852
+        -1.80727161972489,-59.68720642356852 -1.80727161972489))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"22.84
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210540_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''26d56944-0e59-4dba-aa2c-b35bb06e0db4'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''26d56944-0e59-4dba-aa2c-b35bb06e0db4'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''26d56944-0e59-4dba-aa2c-b35bb06e0db4'')/Products(''Quicklook'')/$value"}],"id":"26d56944-0e59-4dba-aa2c-b35bb06e0db4","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        23.13 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:30:55.425Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"26d56944-0e59-4dba-aa2c-b35bb06e0db4"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210540_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.808430560490599,-64.72751236709793
+        -1.854827472075815,-64.73770980421178 -2.003396645126754,-64.77031478630461
+        -2.131409587829396,-64.7983481208288 -1.808379623510098,-64.79794257495176
+        -1.808430560490599,-64.72751236709793 -1.808430560490599,-64.72751236709793</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210540_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.72751236709793 -1.808430560490599,-64.73770980421178
+        -1.854827472075815,-64.77031478630461 -2.003396645126754,-64.7983481208288
+        -2.131409587829396,-64.79794257495176 -1.808379623510098,-64.72751236709793
+        -1.808430560490599,-64.72751236709793 -1.808430560490599))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"23.13
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T221951_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''861faaed-ae1a-4a15-8c3f-990dd684598a'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''861faaed-ae1a-4a15-8c3f-990dd684598a'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''861faaed-ae1a-4a15-8c3f-990dd684598a'')/Products(''Quicklook'')/$value"}],"id":"861faaed-ae1a-4a15-8c3f-990dd684598a","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        23.14 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:32:07.791Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"861faaed-ae1a-4a15-8c3f-990dd684598a"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T221951_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.807263789154724,-59.69361771585355
+        -1.820693416572702,-59.696561408643575 -1.807260224698412,-59.69653612035876
+        -1.807263789154724,-59.69361771585355 -1.807263789154724,-59.69361771585355</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T221951_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.69361771585355 -1.807263789154724,-59.696561408643575
+        -1.820693416572702,-59.69653612035876 -1.807260224698412,-59.69361771585355
+        -1.807263789154724,-59.69361771585355 -1.807263789154724))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"23.14
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225436_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8f116b23-5d09-4156-8db3-668e2f2f8353'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8f116b23-5d09-4156-8db3-668e2f2f8353'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8f116b23-5d09-4156-8db3-668e2f2f8353'')/Products(''Quicklook'')/$value"}],"id":"8f116b23-5d09-4156-8db3-668e2f2f8353","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        23.30 MB","date":[{"name":"ingestiondate","content":"2016-09-28T23:02:21.16Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"8f116b23-5d09-4156-8db3-668e2f2f8353"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225436_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.518292103772303,-60.28697388994736
+        -4.562296038219515,-60.29662388939356 -4.518335502644501,-60.29680494075908
+        -4.518292103772303,-60.28697388994736 -4.518292103772303,-60.28697388994736</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225436_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.28697388994736 -4.518292103772303,-60.29662388939356
+        -4.562296038219515,-60.29680494075908 -4.518335502644501,-60.28697388994736
+        -4.518292103772303,-60.28697388994736 -4.518292103772303))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"23.30
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T095544_R053_V20160730T142756_20160730T142756","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a2084021-4a52-4005-a8d9-e2cd67f18dd7'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a2084021-4a52-4005-a8d9-e2cd67f18dd7'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a2084021-4a52-4005-a8d9-e2cd67f18dd7'')/Products(''Quicklook'')/$value"}],"id":"a2084021-4a52-4005-a8d9-e2cd67f18dd7","summary":"Date:
+        2016-07-30T14:27:56Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.44 GB","date":[{"name":"ingestiondate","content":"2016-07-31T10:06:40.714Z"},{"name":"beginposition","content":"2016-07-30T14:27:56Z"},{"name":"endposition","content":"2016-07-30T14:27:56Z"}],"int":[{"name":"orbitnumber","content":"5770"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"a2084021-4a52-4005-a8d9-e2cd67f18dd7"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T095544_R053_V20160730T142756_20160730T142756.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.238154459367503,-63.620797991388486
+        -7.386451328846193,-63.654419385405646 -7.534705805151418,-63.68813196538172
+        -7.683013878197098,-63.7218697430427 -7.831387176626889,-63.755562629372285
+        -7.979810885707101,-63.789213487128784 -8.128345394580602,-63.82274036846365
+        -8.229536108458491,-63.84556832707143 -8.230398500927846,-63.00018159295572
+        -8.230498859705568,-63.00018159299859 -8.2304437940123,-62.95578165428927
+        -8.23048908614055,-62.911382652974034 -8.23038872950755,-62.911382673891325
+        -8.22937260678506,-62.09207424566609 -8.229472946800525,-62.09207403140284
+        -8.229317536684688,-62.047670753471174 -8.229262491883746,-62.003287660422316
+        -8.229162198038187,-62.00328789552824 -8.226297324933649,-61.18474557597368
+        -8.226398126465138,-61.18474514567033 -8.226140988458726,-61.14007762170651
+        -8.226034161761417,-61.109555441695704 -8.163418602736966,-61.09572995387261
+        -8.163418602736952,-61.09572995387261 -8.111852525109143,-61.084344186669775
+        -7.963510684170291,-61.05165692731624 -7.815066989742145,-61.019109730478334
+        -7.666514917988577,-60.986574749536295 -7.517871708740619,-60.954056010075966
+        -7.36917159073997,-60.921593537572654 -7.232178884621026,-60.89184056656043
+        -7.220373725838058,-60.889276645042166 -7.071674298562274,-60.856831837616085
+        -6.923018416471074,-60.82440745567165 -6.774499313193103,-60.791814343420015
+        -6.626045020178537,-60.75920706268626 -6.477649314649427,-60.726662358115874
+        -6.329316455355318,-60.69402522695945 -6.180904109451888,-60.661412749748095
+        -6.032427798148934,-60.62879167547683 -5.883830372285293,-60.59623893188441
+        -5.735119264337427,-60.5637465818559 -5.586343031169998,-60.5312842739471
+        -5.437537291663092,-60.498876626806975 -5.422869414731799,-60.49567738255557
+        -5.425362066336241,-61.15086321305925 -5.427449229390539,-62.05319609957077
+        -5.428189238842002,-62.9560382527078 -5.428015294178294,-63.214047232707856
+        -5.456622611922337,-63.220494631722566 -5.604911899590591,-63.25393447196978
+        -5.753214162509993,-63.2873786454421 -5.901596725036068,-63.32073163991832
+        -6.050068419897535,-63.35395161732881 -6.198567469193102,-63.38724126385764
+        -6.33209466024956,-63.417115461932646 -6.347149607831226,-63.42048372335195
+        -6.49578813185831,-63.45367440683544 -6.644399543746193,-63.486900992479534
+        -6.792970234082816,-63.52024905400771 -6.941465368457515,-63.55365589415212
+        -7.089848698994576,-63.587190054149865 -7.236639731153193,-63.620454735060264
+        -7.238154459367503,-63.620797991388486</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T095544_R053_V20160730T142756_20160730T142756"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.620797991388486
+        -7.238154459367503,-63.654419385405646 -7.386451328846193,-63.68813196538172
+        -7.534705805151418,-63.7218697430427 -7.683013878197098,-63.755562629372285
+        -7.831387176626889,-63.789213487128784 -7.979810885707101,-63.82274036846365
+        -8.128345394580602,-63.84556832707143 -8.229536108458491,-63.00018159295572
+        -8.230398500927846,-63.00018159299859 -8.230498859705568,-62.95578165428927
+        -8.2304437940123,-62.911382652974034 -8.23048908614055,-62.911382673891325
+        -8.23038872950755,-62.09207424566609 -8.22937260678506,-62.09207403140284
+        -8.229472946800525,-62.047670753471174 -8.229317536684688,-62.003287660422316
+        -8.229262491883746,-62.00328789552824 -8.229162198038187,-61.18474557597368
+        -8.226297324933649,-61.18474514567033 -8.226398126465138,-61.14007762170651
+        -8.226140988458726,-61.109555441695704 -8.226034161761417,-61.09572995387261
+        -8.163418602736966,-61.09572995387261 -8.163418602736952,-61.084344186669775
+        -8.111852525109143,-61.05165692731624 -7.963510684170291,-61.019109730478334
+        -7.815066989742145,-60.986574749536295 -7.666514917988577,-60.954056010075966
+        -7.517871708740619,-60.921593537572654 -7.36917159073997,-60.89184056656043
+        -7.232178884621026,-60.889276645042166 -7.220373725838058,-60.856831837616085
+        -7.071674298562274,-60.82440745567165 -6.923018416471074,-60.791814343420015
+        -6.774499313193103,-60.75920706268626 -6.626045020178537,-60.726662358115874
+        -6.477649314649427,-60.69402522695945 -6.329316455355318,-60.661412749748095
+        -6.180904109451888,-60.62879167547683 -6.032427798148934,-60.59623893188441
+        -5.883830372285293,-60.5637465818559 -5.735119264337427,-60.5312842739471
+        -5.586343031169998,-60.498876626806975 -5.437537291663092,-60.49567738255557
+        -5.422869414731799,-61.15086321305925 -5.425362066336241,-62.05319609957077
+        -5.427449229390539,-62.9560382527078 -5.428189238842002,-63.214047232707856
+        -5.428015294178294,-63.220494631722566 -5.456622611922337,-63.25393447196978
+        -5.604911899590591,-63.2873786454421 -5.753214162509993,-63.32073163991832
+        -5.901596725036068,-63.35395161732881 -6.050068419897535,-63.38724126385764
+        -6.198567469193102,-63.417115461932646 -6.33209466024956,-63.42048372335195
+        -6.347149607831226,-63.45367440683544 -6.49578813185831,-63.486900992479534
+        -6.644399543746193,-63.52024905400771 -6.792970234082816,-63.55365589415212
+        -6.941465368457515,-63.587190054149865 -7.089848698994576,-63.620454735060264
+        -7.236639731153193,-63.620797991388486 -7.238154459367503))"},{"name":"s2datatakeid","content":"GS2A_20160730T142802_005770_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.44
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160718T050114_R010_V20160717T142041_20160717T142041","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ac11abbc-1fe6-4e63-a1f7-a1ae998c1478'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ac11abbc-1fe6-4e63-a1f7-a1ae998c1478'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ac11abbc-1fe6-4e63-a1f7-a1ae998c1478'')/Products(''Quicklook'')/$value"}],"id":"ac11abbc-1fe6-4e63-a1f7-a1ae998c1478","summary":"Date:
+        2016-07-17T14:20:41Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.19 GB","date":[{"name":"ingestiondate","content":"2016-07-18T05:24:36.194Z"},{"name":"beginposition","content":"2016-07-17T14:20:41Z"},{"name":"endposition","content":"2016-07-17T14:20:41Z"}],"int":[{"name":"orbitnumber","content":"5584"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.0"},"str":[{"name":"uuid","content":"ac11abbc-1fe6-4e63-a1f7-a1ae998c1478"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160718T050114_R010_V20160717T142041_20160717T142041.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.236383951347981,-62.09419464575659
+        -8.229472946800525,-62.09207403140284 -8.226297324933649,-61.18474557597368
+        -8.226398126465138,-61.18474514567033 -8.226140988458724,-61.140077621706126
+        -8.225984792224422,-61.09544973653788 -8.225884081237991,-61.095450187595624
+        -8.221174458521304,-60.27734014430516 -8.221274538592427,-60.277339503652556
+        -8.220918997302837,-60.232963895702774 -8.220663876926901,-60.18864685496363
+        -8.220563930551878,-60.18864751558619 -8.216833080207858,-59.72299484166875
+        -8.221272080743814,-59.723023261271635 -8.226296312759192,-58.81561742540932
+        -8.22639648636114,-58.815617853117644 -8.226541922193537,-58.771258917803664
+        -8.226787741770087,-58.72686245728039 -8.22668748239152,-58.72686205012567
+        -8.229664156708726,-57.818955784450985 -7.325011205780803,-57.81721330024698
+        -7.325011235731498,-57.81720304463014 -7.280627889666042,-57.81712781196424
+        -7.236551833181055,-57.8170429155052 -7.236551803794858,-57.81705310012441
+        -6.420864357044481,-57.81567045670977 -6.420864383205277,-57.8156602442492
+        -6.376226064789988,-57.81559479189346 -6.331858920051649,-57.81551958668987
+        -6.331858894408632,-57.81552973711715 -5.427676976856658,-57.81420395158968
+        -5.42562550187137,-58.76098681421245 -5.423640334598856,-59.30349460796113
+        -5.416924739912873,-59.30353928373773 -5.4219309173953585,-60.2489962355772
+        -5.425531020312141,-61.19527224752645 -6.329352766457671,-61.192335123226385
+        -6.329352866202743,-61.192357609869305 -6.373702387567744,-61.192191001500596
+        -6.418322819571477,-61.1920459997282 -6.418322717812893,-61.19202337578098
+        -7.2335956909932015,-61.18896063021043 -7.236383951347981,-62.09419464575659</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160718T050114_R010_V20160717T142041_20160717T142041"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.09419464575659 -7.236383951347981,-62.09207403140284
+        -8.229472946800525,-61.18474557597368 -8.226297324933649,-61.18474514567033
+        -8.226398126465138,-61.140077621706126 -8.226140988458724,-61.09544973653788
+        -8.225984792224422,-61.095450187595624 -8.225884081237991,-60.27734014430516
+        -8.221174458521304,-60.277339503652556 -8.221274538592427,-60.232963895702774
+        -8.220918997302837,-60.18864685496363 -8.220663876926901,-60.18864751558619
+        -8.220563930551878,-59.72299484166875 -8.216833080207858,-59.723023261271635
+        -8.221272080743814,-58.81561742540932 -8.226296312759192,-58.815617853117644
+        -8.22639648636114,-58.771258917803664 -8.226541922193537,-58.72686245728039
+        -8.226787741770087,-58.72686205012567 -8.22668748239152,-57.818955784450985
+        -8.229664156708726,-57.81721330024698 -7.325011205780803,-57.81720304463014
+        -7.325011235731498,-57.81712781196424 -7.280627889666042,-57.8170429155052
+        -7.236551833181055,-57.81705310012441 -7.236551803794858,-57.81567045670977
+        -6.420864357044481,-57.8156602442492 -6.420864383205277,-57.81559479189346
+        -6.376226064789988,-57.81551958668987 -6.331858920051649,-57.81552973711715
+        -6.331858894408632,-57.81420395158968 -5.427676976856658,-58.76098681421245
+        -5.42562550187137,-59.30349460796113 -5.423640334598856,-59.30353928373773
+        -5.416924739912873,-60.2489962355772 -5.4219309173953585,-61.19527224752645
+        -5.425531020312141,-61.192335123226385 -6.329352766457671,-61.192357609869305
+        -6.329352866202743,-61.192191001500596 -6.373702387567744,-61.1920459997282
+        -6.418322819571477,-61.19202337578098 -6.418322717812893,-61.18896063021043
+        -7.2335956909932015,-62.09419464575659 -7.236383951347981))"},{"name":"s2datatakeid","content":"GS2A_20160717T142042_005584_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.19
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160825T234149_R139_V20160825T144732_20160825T144732","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''75535801-5f79-4397-8aeb-1130268e0e68'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''75535801-5f79-4397-8aeb-1130268e0e68'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''75535801-5f79-4397-8aeb-1130268e0e68'')/Products(''Quicklook'')/$value"}],"id":"75535801-5f79-4397-8aeb-1130268e0e68","summary":"Date:
+        2016-08-25T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.34 GB","date":[{"name":"ingestiondate","content":"2016-08-26T00:30:02.667Z"},{"name":"beginposition","content":"2016-08-25T14:47:32Z"},{"name":"endposition","content":"2016-08-25T14:47:32Z"}],"int":[{"name":"orbitnumber","content":"6142"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"7.846153846153847E-4"},"str":[{"name":"uuid","content":"75535801-5f79-4397-8aeb-1130268e0e68"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160825T234149_R139_V20160825T144732_20160825T144732.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.325393039256953,-68.67420316392258
+        -7.406438514242518,-68.69243709110916 -7.555024296184373,-68.72597274205549
+        -7.703687291042039,-68.75932065810196 -7.852256431724967,-68.79283235688352
+        -8.000684684782673,-68.82643003138054 -8.149003128091717,-68.86016574049243
+        -8.230348186888156,-68.87869281366346 -8.22937260678506,-68.09207424566608
+        -8.229472946800525,-68.09207403140283 -8.229317536684688,-68.04767075347118
+        -8.229262491883746,-68.0032876604223 -8.229162198038187,-68.00328789552823
+        -8.226297324933649,-67.18474557597366 -8.226398126465138,-67.18474514567032
+        -8.226140988458724,-67.14007762170615 -8.225984792224422,-67.09544973653786
+        -8.225884081237991,-67.0954501875956 -8.221174458521304,-66.27734014430516
+        -8.221274538592427,-66.27733950365256 -8.220918997302839,-66.23296389570291
+        -8.220663876926901,-66.18864685496362 -8.220563930551876,-66.18864751558618
+        -8.220188144856243,-66.14174517487123 -8.131416186459381,-66.12235145499466
+        -7.982774761802772,-66.08980454623716 -7.834188081981428,-66.0572776534909
+        -7.685613728451028,-66.02468118996356 -7.537125136404392,-65.9921358983943
+        -7.388758328647155,-65.95948457863815 -7.240449418924524,-65.92683155325435
+        -7.092127900655607,-65.89419804623205 -6.943691751315845,-65.86160824022448
+        -6.795126174984564,-65.82904418628002 -6.646428383853683,-65.7965246671582
+        -6.497638968759485,-65.76405137784096 -6.348884647867236,-65.73158377835038
+        -6.321945438348088,-65.72569501290754 -6.256136335278681,-65.71130949904514
+        -6.2561363352787,-65.71130949904514 -6.200195277496167,-65.69908108649014
+        -6.051581535644328,-65.66656715866745 -5.902988369267837,-65.63403844145087
+        -5.754457487398187,-65.60145779042037 -5.606001369047521,-65.56894899946403
+        -5.457587501853227,-65.53640826771387 -5.4181119014842,-65.52774431132501
+        -5.4219309173953585,-66.24899623557715 -5.425362066336241,-67.15086321305921
+        -5.427449229390539,-68.0531960995708 -5.427608172847141,-68.24711369386918
+        -5.476380761427771,-68.2580203258496 -5.624979425798625,-68.29126236724042
+        -5.773634914538981,-68.32447123615503 -5.922254538523781,-68.35775936996724
+        -6.07078104471907,-68.3910431896969 -6.219170266110237,-68.42452589086888
+        -6.367506655886855,-68.45797484237971 -6.515744384921368,-68.49154403806567
+        -6.664047964999596,-68.52503583948665 -6.812450856930053,-68.55851486199155
+        -6.960901432852602,-68.5919636977808 -7.109391907127534,-68.6254585113258
+        -7.257870290029103,-68.65901163234012 -7.325393039256953,-68.67420316392258</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160825T234149_R139_V20160825T144732_20160825T144732"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-68.67420316392258 -7.325393039256953,-68.69243709110916
+        -7.406438514242518,-68.72597274205549 -7.555024296184373,-68.75932065810196
+        -7.703687291042039,-68.79283235688352 -7.852256431724967,-68.82643003138054
+        -8.000684684782673,-68.86016574049243 -8.149003128091717,-68.87869281366346
+        -8.230348186888156,-68.09207424566608 -8.22937260678506,-68.09207403140283
+        -8.229472946800525,-68.04767075347118 -8.229317536684688,-68.0032876604223
+        -8.229262491883746,-68.00328789552823 -8.229162198038187,-67.18474557597366
+        -8.226297324933649,-67.18474514567032 -8.226398126465138,-67.14007762170615
+        -8.226140988458724,-67.09544973653786 -8.225984792224422,-67.0954501875956
+        -8.225884081237991,-66.27734014430516 -8.221174458521304,-66.27733950365256
+        -8.221274538592427,-66.23296389570291 -8.220918997302839,-66.18864685496362
+        -8.220663876926901,-66.18864751558618 -8.220563930551876,-66.14174517487123
+        -8.220188144856243,-66.12235145499466 -8.131416186459381,-66.08980454623716
+        -7.982774761802772,-66.0572776534909 -7.834188081981428,-66.02468118996356
+        -7.685613728451028,-65.9921358983943 -7.537125136404392,-65.95948457863815
+        -7.388758328647155,-65.92683155325435 -7.240449418924524,-65.89419804623205
+        -7.092127900655607,-65.86160824022448 -6.943691751315845,-65.82904418628002
+        -6.795126174984564,-65.7965246671582 -6.646428383853683,-65.76405137784096
+        -6.497638968759485,-65.73158377835038 -6.348884647867236,-65.72569501290754
+        -6.321945438348088,-65.71130949904514 -6.256136335278681,-65.71130949904514
+        -6.2561363352787,-65.69908108649014 -6.200195277496167,-65.66656715866745
+        -6.051581535644328,-65.63403844145087 -5.902988369267837,-65.60145779042037
+        -5.754457487398187,-65.56894899946403 -5.606001369047521,-65.53640826771387
+        -5.457587501853227,-65.52774431132501 -5.4181119014842,-66.24899623557715
+        -5.4219309173953585,-67.15086321305921 -5.425362066336241,-68.0531960995708
+        -5.427449229390539,-68.24711369386918 -5.427608172847141,-68.2580203258496
+        -5.476380761427771,-68.29126236724042 -5.624979425798625,-68.32447123615503
+        -5.773634914538981,-68.35775936996724 -5.922254538523781,-68.3910431896969
+        -6.07078104471907,-68.42452589086888 -6.219170266110237,-68.45797484237971
+        -6.367506655886855,-68.49154403806567 -6.515744384921368,-68.52503583948665
+        -6.664047964999596,-68.55851486199155 -6.812450856930053,-68.5919636977808
+        -6.960901432852602,-68.6254585113258 -7.109391907127534,-68.65901163234012
+        -7.257870290029103,-68.67420316392258 -7.325393039256953))"},{"name":"s2datatakeid","content":"GS2A_20160825T144732_006142_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.34
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163820_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d18aeb4d-f70f-401b-bf7a-5b77d8f985dc'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d18aeb4d-f70f-401b-bf7a-5b77d8f985dc'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d18aeb4d-f70f-401b-bf7a-5b77d8f985dc'')/Products(''Quicklook'')/$value"}],"id":"d18aeb4d-f70f-401b-bf7a-5b77d8f985dc","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        426.41 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:33:35.947Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0029"},"str":[{"name":"uuid","content":"d18aeb4d-f70f-401b-bf7a-5b77d8f985dc"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163820_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.707432286377921,-62.81287689013403
+        -3.603402797068897,-62.78978312302111 -3.455045830704997,-62.75681362271256
+        -3.306640365247633,-62.72394665820496 -3.158215012131489,-62.69095598923965
+        -3.009688346500589,-62.65795038439892 -2.861086283422202,-62.62492364121229
+        -2.714006334049603,-62.59221232065058 -2.713768419219708,-62.01238363602219
+        -3.706983235273412,-62.01142918479083 -3.707432286377921,-62.81287689013403
+        -3.707432286377921,-62.81287689013403</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163820_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.81287689013403 -3.707432286377921,-62.78978312302111
+        -3.603402797068897,-62.75681362271256 -3.455045830704997,-62.72394665820496
+        -3.306640365247633,-62.69095598923965 -3.158215012131489,-62.65795038439892
+        -3.009688346500589,-62.62492364121229 -2.861086283422202,-62.59221232065058
+        -2.714006334049603,-62.01238363602219 -2.713768419219708,-62.01142918479083
+        -3.706983235273412,-62.81287689013403 -3.707432286377921,-62.81287689013403
+        -3.707432286377921))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"426.41
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160620T211044_R053_V20160620T142754_20160620T142754","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9a03071b-36f0-4ce0-bba8-bd1236c28f89'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9a03071b-36f0-4ce0-bba8-bd1236c28f89'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9a03071b-36f0-4ce0-bba8-bd1236c28f89'')/Products(''Quicklook'')/$value"}],"id":"9a03071b-36f0-4ce0-bba8-bd1236c28f89","summary":"Date:
+        2016-06-20T14:27:54Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.44 GB","date":[{"name":"ingestiondate","content":"2016-06-20T21:36:57.725Z"},{"name":"beginposition","content":"2016-06-20T14:27:54Z"},{"name":"endposition","content":"2016-06-20T14:27:54Z"}],"int":[{"name":"orbitnumber","content":"5198"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.00325"},"str":[{"name":"uuid","content":"9a03071b-36f0-4ce0-bba8-bd1236c28f89"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160620T211044_R053_V20160620T142754_20160620T142754.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.280458254640564,-63.906261799713896
+        -8.22947212599136,-63.90828910774846 -8.230398500927846,-63.00018159295572
+        -8.230498859705568,-63.00018159299859 -8.2304437940123,-62.955781654289254
+        -8.23048908614055,-62.911382652974034 -8.23038872950755,-62.911382673891325
+        -8.22937260678506,-62.09207424566609 -8.229472946800525,-62.09207403140284
+        -8.229317536684688,-62.047670753471174 -8.229262491883746,-62.003287660422316
+        -8.229162198038187,-62.00328789552824 -8.226297324933649,-61.18474557597368
+        -8.226398126465138,-61.18474514567033 -8.226140988458724,-61.140077621706126
+        -8.225984792224422,-61.09544973653788 -8.225884081237991,-61.095450187595624
+        -8.220663876926901,-60.18864685496363 -7.272677254442484,-60.19491282857524
+        -6.369271485814847,-60.20016780456912 -5.42176328831644,-60.204935446218734
+        -5.425362066336241,-61.15086321305924 -5.427449229390539,-62.05319609957077
+        -5.428189238842002,-62.956038252707735 -5.427550802672508,-63.90301909922936
+        -6.3760776819297655,-63.90456160754002 -7.280458254640564,-63.906261799713896</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160620T211044_R053_V20160620T142754_20160620T142754"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.906261799713896
+        -7.280458254640564,-63.90828910774846 -8.22947212599136,-63.00018159295572
+        -8.230398500927846,-63.00018159299859 -8.230498859705568,-62.955781654289254
+        -8.2304437940123,-62.911382652974034 -8.23048908614055,-62.911382673891325
+        -8.23038872950755,-62.09207424566609 -8.22937260678506,-62.09207403140284
+        -8.229472946800525,-62.047670753471174 -8.229317536684688,-62.003287660422316
+        -8.229262491883746,-62.00328789552824 -8.229162198038187,-61.18474557597368
+        -8.226297324933649,-61.18474514567033 -8.226398126465138,-61.140077621706126
+        -8.226140988458724,-61.09544973653788 -8.225984792224422,-61.095450187595624
+        -8.225884081237991,-60.18864685496363 -8.220663876926901,-60.19491282857524
+        -7.272677254442484,-60.20016780456912 -6.369271485814847,-60.204935446218734
+        -5.42176328831644,-61.15086321305924 -5.425362066336241,-62.05319609957077
+        -5.427449229390539,-62.956038252707735 -5.428189238842002,-63.90301909922936
+        -5.427550802672508,-63.90456160754002 -6.3760776819297655,-63.906261799713896
+        -7.280458254640564))"},{"name":"s2datatakeid","content":"GS2A_20160620T142752_005198_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.44
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T003659_R096_V20160812T143752_20160812T143749","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9f43aa36-dca6-4072-b6f4-e5572c06f056'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9f43aa36-dca6-4072-b6f4-e5572c06f056'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9f43aa36-dca6-4072-b6f4-e5572c06f056'')/Products(''Quicklook'')/$value"}],"id":"9f43aa36-dca6-4072-b6f4-e5572c06f056","summary":"Date:
+        2016-08-12T14:37:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.90 GB","date":[{"name":"ingestiondate","content":"2016-08-13T00:35:36.746Z"},{"name":"beginposition","content":"2016-08-12T14:37:52Z"},{"name":"endposition","content":"2016-08-12T14:37:49Z"}],"int":[{"name":"orbitnumber","content":"5956"},{"name":"relativeorbitnumber","content":"96"}],"double":{"name":"cloudcoverpercentage","content":"0.006392307692307692"},"str":[{"name":"uuid","content":"9f43aa36-dca6-4072-b6f4-e5572c06f056"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T003659_R096_V20160812T143752_20160812T143749.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.412237382795615,-65.95308026227349
+        -6.472959644778038,-65.96672537584683 -6.621564520947572,-65.99990680131684
+        -6.770153311685106,-66.03317931828492 -6.918726026994323,-66.06651238828611
+        -7.067213572481141,-66.09989252733895 -7.215598863308593,-66.13339776567206
+        -7.31664857609285,-66.15626634899802 -7.31664857609285,-66.156266348998 -7.363915909559552,-66.1669634299119
+        -7.480914148434906,-66.1935364305842 -7.480914148434884,-66.1935364305842
+        -7.512163583075624,-66.20063389850935 -7.66038261648311,-66.23438461566614
+        -7.808730440537711,-66.26804592726366 -7.859892283716793,-66.27965285614376
+        -7.859892283716798,-66.27965285614376 -7.957125559707294,-66.30171186827219
+        -8.105624729385278,-66.33533985293094 -8.221659493325166,-66.36159569262733
+        -8.221174458521304,-66.27734014430516 -8.221274538592427,-66.27733950365256
+        -8.220918997302837,-66.23296389570278 -8.220663876926901,-66.18864685496362
+        -8.220563930551878,-66.18864751558618 -8.216833080207858,-65.72299484166875
+        -8.221272080743814,-65.72302326127163 -8.226296312759192,-64.81561742540931
+        -8.22639648636114,-64.81561785311763 -8.226541922193537,-64.77125891780369
+        -8.226787741770087,-64.72686245728039 -8.22668748239152,-64.72686205012566
+        -8.229371267918504,-63.90828889229283 -8.22947212599136,-63.90828910774846
+        -8.229517681770956,-63.86363165409404 -8.229664156708726,-63.81895578445098
+        -8.229563256535252,-63.81895559010357 -8.229757954569779,-63.6280968553664
+        -8.089224172044368,-63.59713191751195 -7.940794503975608,-63.5645137183348
+        -7.792259840762049,-63.531963722609255 -7.643580657053612,-63.49950123313016
+        -7.494862668212512,-63.467040847810495 -7.346143812405979,-63.43460885676095
+        -7.236827989914048,-63.41075547912657 -7.197470837838766,-63.40216750906273
+        -7.048787782712749,-63.36974008476325 -6.900168936605606,-63.33726794325169
+        -6.751660922059818,-63.30475593947644 -6.60325744217049,-63.27216491533744
+        -6.454948368580164,-63.23954175196916 -6.421250958212863,-63.232134871126505
+        -6.306638193639792,-63.206942339089565 -6.158219553580949,-63.174423560005245
+        -6.009636974542286,-63.141944757443056 -5.860930288561426,-63.10948637315399
+        -5.712120901495529,-63.07705990165875 -5.563343613999401,-63.044596055605695
+        -5.428149493512307,-63.01499178284603 -5.427580735171929,-63.85862076311501
+        -5.4256255018713695,-64.76098681421246 -5.423640334598856,-65.30349460796113
+        -5.416924739912873,-65.30353928373772 -5.419181957770018,-65.72983306223841
+        -5.434056135772236,-65.73317237352822 -5.582356532385505,-65.76653637713271
+        -5.730616136696084,-65.799976366149 -5.878939718799178,-65.83337937694753
+        -6.0273637175937,-65.866733527614 -6.175873674091228,-65.90004727185128 -6.323225733492075,-65.93307879186248
+        -6.324417876413865,-65.93334603137673 -6.412237382795615,-65.95308026227349</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T003659_R096_V20160812T143752_20160812T143749"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.95308026227349 -6.412237382795615,-65.96672537584683
+        -6.472959644778038,-65.99990680131684 -6.621564520947572,-66.03317931828492
+        -6.770153311685106,-66.06651238828611 -6.918726026994323,-66.09989252733895
+        -7.067213572481141,-66.13339776567206 -7.215598863308593,-66.15626634899802
+        -7.31664857609285,-66.156266348998 -7.31664857609285,-66.1669634299119 -7.363915909559552,-66.1935364305842
+        -7.480914148434906,-66.1935364305842 -7.480914148434884,-66.20063389850935
+        -7.512163583075624,-66.23438461566614 -7.66038261648311,-66.26804592726366
+        -7.808730440537711,-66.27965285614376 -7.859892283716793,-66.27965285614376
+        -7.859892283716798,-66.30171186827219 -7.957125559707294,-66.33533985293094
+        -8.105624729385278,-66.36159569262733 -8.221659493325166,-66.27734014430516
+        -8.221174458521304,-66.27733950365256 -8.221274538592427,-66.23296389570278
+        -8.220918997302837,-66.18864685496362 -8.220663876926901,-66.18864751558618
+        -8.220563930551878,-65.72299484166875 -8.216833080207858,-65.72302326127163
+        -8.221272080743814,-64.81561742540931 -8.226296312759192,-64.81561785311763
+        -8.22639648636114,-64.77125891780369 -8.226541922193537,-64.72686245728039
+        -8.226787741770087,-64.72686205012566 -8.22668748239152,-63.90828889229283
+        -8.229371267918504,-63.90828910774846 -8.22947212599136,-63.86363165409404
+        -8.229517681770956,-63.81895578445098 -8.229664156708726,-63.81895559010357
+        -8.229563256535252,-63.6280968553664 -8.229757954569779,-63.59713191751195
+        -8.089224172044368,-63.5645137183348 -7.940794503975608,-63.531963722609255
+        -7.792259840762049,-63.49950123313016 -7.643580657053612,-63.467040847810495
+        -7.494862668212512,-63.43460885676095 -7.346143812405979,-63.41075547912657
+        -7.236827989914048,-63.40216750906273 -7.197470837838766,-63.36974008476325
+        -7.048787782712749,-63.33726794325169 -6.900168936605606,-63.30475593947644
+        -6.751660922059818,-63.27216491533744 -6.60325744217049,-63.23954175196916
+        -6.454948368580164,-63.232134871126505 -6.421250958212863,-63.206942339089565
+        -6.306638193639792,-63.174423560005245 -6.158219553580949,-63.141944757443056
+        -6.009636974542286,-63.10948637315399 -5.860930288561426,-63.07705990165875
+        -5.712120901495529,-63.044596055605695 -5.563343613999401,-63.01499178284603
+        -5.428149493512307,-63.85862076311501 -5.427580735171929,-64.76098681421246
+        -5.4256255018713695,-65.30349460796113 -5.423640334598856,-65.30353928373772
+        -5.416924739912873,-65.72983306223841 -5.419181957770018,-65.73317237352822
+        -5.434056135772236,-65.76653637713271 -5.582356532385505,-65.799976366149
+        -5.730616136696084,-65.83337937694753 -5.878939718799178,-65.866733527614
+        -6.0273637175937,-65.90004727185128 -6.175873674091228,-65.93307879186248
+        -6.323225733492075,-65.93334603137673 -6.324417876413865,-65.95308026227349
+        -6.412237382795615))"},{"name":"s2datatakeid","content":"GS2A_20160812T143752_005956_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.90
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160723T221439_R096_V20160723T143750_20160723T143750","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c10f99fd-9c69-432c-ac5c-f411732fc63c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c10f99fd-9c69-432c-ac5c-f411732fc63c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c10f99fd-9c69-432c-ac5c-f411732fc63c'')/Products(''Quicklook'')/$value"}],"id":"c10f99fd-9c69-432c-ac5c-f411732fc63c","summary":"Date:
+        2016-07-23T14:37:50Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.11 GB","date":[{"name":"ingestiondate","content":"2016-07-23T22:31:58.629Z"},{"name":"beginposition","content":"2016-07-23T14:37:50Z"},{"name":"endposition","content":"2016-07-23T14:37:50Z"}],"int":[{"name":"orbitnumber","content":"5670"},{"name":"relativeorbitnumber","content":"96"}],"double":{"name":"cloudcoverpercentage","content":"0.0094"},"str":[{"name":"uuid","content":"c10f99fd-9c69-432c-ac5c-f411732fc63c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160723T221439_R096_V20160723T143750_20160723T143750.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.412222954551176,-65.95077541467344
+        -6.483369358761329,-65.9667232479425 -6.632069677394524,-65.99990991186529
+        -6.780711889886192,-66.03322667882634 -6.929296929212971,-66.06659721056482
+        -7.077778204198659,-66.10005276910894 -7.226177496609528,-66.13357832217156
+        -7.316632732728458,-66.1540463674379 -7.374513077097583,-66.16714342582179
+        -7.522791448116501,-66.20081127281269 -7.671068092772905,-66.23456615386574
+        -7.819417677117585,-66.26821934869903 -7.967828626351122,-66.30184927785606
+        -8.116276821668995,-66.33549855278187 -8.221646841014875,-66.35939785582752
+        -8.221174458521304,-66.27734014430516 -8.221274538592427,-66.27733950365256
+        -8.220918997302837,-66.2329638957028 -8.220663876926901,-66.18864685496362
+        -8.220563930551878,-66.18864751558618 -8.216833080207858,-65.72299484166875
+        -8.221272080743814,-65.72302326127163 -8.226296312759192,-64.81561742540931
+        -8.22639648636114,-64.81561785311763 -8.226541922193537,-64.77125891780369
+        -8.226787741770087,-64.72686245728039 -8.22668748239152,-64.72686205012566
+        -8.229371267918504,-63.90828889229283 -8.22947212599136,-63.90828910774846
+        -8.229517681770956,-63.86363165409411 -8.229664156708726,-63.81895578445098
+        -8.22956325653525,-63.81895559010357 -8.229760169661441,-63.625925443656214
+        -8.09984478850226,-63.5972515111256 -7.951415670013742,-63.56458478151746
+        -7.802913276878179,-63.531934444377605 -7.654238768320749,-63.499500203362736
+        -7.505466882371128,-63.467026276274346 -7.356632590984494,-63.43459716137552
+        -7.236830086857682,-63.40841971786935 -7.207911941435379,-63.40210095914546
+        -7.059265896154626,-63.36965223757312 -6.910695137708182,-63.337142317850734
+        -6.762191769550816,-63.30459134429288 -6.6137789471591,-63.27193852648696
+        -6.465402160859644,-63.23926035541383 -6.332257481453769,-63.209974468258366
+        -6.316995420005405,-63.206617495893184 -6.16848984527453,-63.17412012636381
+        -6.019891641359573,-63.14160837208692 -5.871208219230182,-63.109105044342265
+        -5.722447910758552,-63.07670599035539 -5.573610643117516,-63.044354239562
+        -5.42815106293667,-63.01266388401743 -5.427580735171929,-63.85862076311499
+        -5.4256255018713695,-64.76098681421246 -5.423640334598856,-65.30349460796113
+        -5.416924739912873,-65.30353928373772 -5.419167865668602,-65.72717165534752
+        -5.444375175462078,-65.73282910354658 -5.592755729295702,-65.76618853731179
+        -5.741110106827773,-65.79960615979059 -5.889451696934874,-65.83304203301935
+        -6.037852186733989,-65.86648530793971 -6.186294100707088,-65.8999602309757
+        -6.323211725047847,-65.93080968687157 -6.334776683708011,-65.93341543382228
+        -6.412222954551176,-65.95077541467344</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160723T221439_R096_V20160723T143750_20160723T143750"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.95077541467344 -6.412222954551176,-65.9667232479425
+        -6.483369358761329,-65.99990991186529 -6.632069677394524,-66.03322667882634
+        -6.780711889886192,-66.06659721056482 -6.929296929212971,-66.10005276910894
+        -7.077778204198659,-66.13357832217156 -7.226177496609528,-66.1540463674379
+        -7.316632732728458,-66.16714342582179 -7.374513077097583,-66.20081127281269
+        -7.522791448116501,-66.23456615386574 -7.671068092772905,-66.26821934869903
+        -7.819417677117585,-66.30184927785606 -7.967828626351122,-66.33549855278187
+        -8.116276821668995,-66.35939785582752 -8.221646841014875,-66.27734014430516
+        -8.221174458521304,-66.27733950365256 -8.221274538592427,-66.2329638957028
+        -8.220918997302837,-66.18864685496362 -8.220663876926901,-66.18864751558618
+        -8.220563930551878,-65.72299484166875 -8.216833080207858,-65.72302326127163
+        -8.221272080743814,-64.81561742540931 -8.226296312759192,-64.81561785311763
+        -8.22639648636114,-64.77125891780369 -8.226541922193537,-64.72686245728039
+        -8.226787741770087,-64.72686205012566 -8.22668748239152,-63.90828889229283
+        -8.229371267918504,-63.90828910774846 -8.22947212599136,-63.86363165409411
+        -8.229517681770956,-63.81895578445098 -8.229664156708726,-63.81895559010357
+        -8.22956325653525,-63.625925443656214 -8.229760169661441,-63.5972515111256
+        -8.09984478850226,-63.56458478151746 -7.951415670013742,-63.531934444377605
+        -7.802913276878179,-63.499500203362736 -7.654238768320749,-63.467026276274346
+        -7.505466882371128,-63.43459716137552 -7.356632590984494,-63.40841971786935
+        -7.236830086857682,-63.40210095914546 -7.207911941435379,-63.36965223757312
+        -7.059265896154626,-63.337142317850734 -6.910695137708182,-63.30459134429288
+        -6.762191769550816,-63.27193852648696 -6.6137789471591,-63.23926035541383
+        -6.465402160859644,-63.209974468258366 -6.332257481453769,-63.206617495893184
+        -6.316995420005405,-63.17412012636381 -6.16848984527453,-63.14160837208692
+        -6.019891641359573,-63.109105044342265 -5.871208219230182,-63.07670599035539
+        -5.722447910758552,-63.044354239562 -5.573610643117516,-63.01266388401743
+        -5.42815106293667,-63.85862076311499 -5.427580735171929,-64.76098681421246
+        -5.4256255018713695,-65.30349460796113 -5.423640334598856,-65.30353928373772
+        -5.416924739912873,-65.72717165534752 -5.419167865668602,-65.73282910354658
+        -5.444375175462078,-65.76618853731179 -5.592755729295702,-65.79960615979059
+        -5.741110106827773,-65.83304203301935 -5.889451696934874,-65.86648530793971
+        -6.037852186733989,-65.8999602309757 -6.186294100707088,-65.93080968687157
+        -6.323211725047847,-65.93341543382228 -6.334776683708011,-65.95077541467344
+        -6.412222954551176))"},{"name":"s2datatakeid","content":"GS2A_20160723T143752_005670_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.11
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205310_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''598000b8-e80c-44f5-97f9-df57b9ced4f3'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''598000b8-e80c-44f5-97f9-df57b9ced4f3'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''598000b8-e80c-44f5-97f9-df57b9ced4f3'')/Products(''Quicklook'')/$value"}],"id":"598000b8-e80c-44f5-97f9-df57b9ced4f3","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        593.82 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:19:32.142Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.0156"},"str":[{"name":"uuid","content":"598000b8-e80c-44f5-97f9-df57b9ced4f3"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205310_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-65.69520275703948
+        0,-64.70920384697635 -0.992949043014349,-64.70945890646591 -0.992287651053575,-65.695604599504
+        0,-65.69520275703948 0,-65.69520275703948</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205310_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.69520275703948 0,-64.70920384697635
+        0,-64.70945890646591 -0.992949043014349,-65.695604599504 -0.992287651053575,-65.69520275703948
+        0,-65.69520275703948 0))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"593.82
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003647_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d7b55540-db2e-44b3-9376-147585054160'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d7b55540-db2e-44b3-9376-147585054160'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d7b55540-db2e-44b3-9376-147585054160'')/Products(''Quicklook'')/$value"}],"id":"d7b55540-db2e-44b3-9376-147585054160","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        234.52 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:08:43.633Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.0268"},"str":[{"name":"uuid","content":"d7b55540-db2e-44b3-9376-147585054160"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003647_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.234976627227669,-58.36297517059968
+        -7.236099103057056,-58.36322021862552 -7.384872267534232,-58.39583727542166
+        -7.533537708607835,-58.428474518490894 -7.682053737317158,-58.46114719179595
+        -7.830532881551941,-58.49361359658333 -7.978904612992187,-58.52621502832861
+        -8.127278333485156,-58.55877023212733 -8.227166775457587,-58.58067434821267
+        -8.22639648636114,-58.815617853117644 -7.233682824131001,-58.8113792924182
+        -7.234976627227669,-58.36297517059968 -7.234976627227669,-58.36297517059968</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003647_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.36297517059968 -7.234976627227669,-58.36322021862552
+        -7.236099103057056,-58.39583727542166 -7.384872267534232,-58.428474518490894
+        -7.533537708607835,-58.46114719179595 -7.682053737317158,-58.49361359658333
+        -7.830532881551941,-58.52621502832861 -7.978904612992187,-58.55877023212733
+        -8.127278333485156,-58.58067434821267 -8.227166775457587,-58.815617853117644
+        -8.22639648636114,-58.8113792924182 -7.233682824131001,-58.36297517059968
+        -7.234976627227669,-58.36297517059968 -7.234976627227669))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"234.52
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222606_R010_V20160806T142041_20160806T142041","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e721da2b-202e-4458-9519-c4774da90ba5'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e721da2b-202e-4458-9519-c4774da90ba5'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e721da2b-202e-4458-9519-c4774da90ba5'')/Products(''Quicklook'')/$value"}],"id":"e721da2b-202e-4458-9519-c4774da90ba5","summary":"Date:
+        2016-08-06T14:20:41Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.16 GB","date":[{"name":"ingestiondate","content":"2016-08-07T07:09:56.416Z"},{"name":"beginposition","content":"2016-08-06T14:20:41Z"},{"name":"endposition","content":"2016-08-06T14:20:41Z"}],"int":[{"name":"orbitnumber","content":"5870"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.027692307692307697"},"str":[{"name":"uuid","content":"e721da2b-202e-4458-9519-c4774da90ba5"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222606_R010_V20160806T142041_20160806T142041.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.328051502591118,-60.898976714237705
+        -6.441815915086212,-60.924459901996606 -6.590461016536064,-60.95770515016864
+        -6.739028637462429,-60.991073033954535 -6.887597693254861,-61.02441325767604
+        -7.036090793867917,-61.05782053198296 -7.184442349864958,-61.091368265044366
+        -7.233258879175227,-61.102437590870586 -7.233329235829833,-61.10245354449828
+        -7.2751647652046785,-61.11193990316215 -7.321769196013676,-61.12250762759605
+        -7.33273113478843,-61.12499328714004 -7.480949396014731,-61.15863703603368
+        -7.607170832342958,-61.187388514043064 -7.6071708323429625,-61.187388514043064
+        -7.629172227003829,-61.192400124060896 -7.777507877544354,-61.226071537399854
+        -7.925894774668903,-61.25973260777868 -8.07436769706943,-61.29335345298328
+        -8.222896518135014,-61.32696606337318 -8.226798176279523,-61.32784720995371
+        -8.226297324933649,-61.18474557597368 -8.226398126465138,-61.18474514567033
+        -8.226140988458724,-61.140077621706084 -8.225984792224422,-61.09544973653788
+        -8.225884081237991,-61.095450187595624 -8.221174458521304,-60.27734014430516
+        -8.221274538592427,-60.277339503652556 -8.220918997302837,-60.232963895702774
+        -8.220663876926901,-60.18864685496363 -8.220563930551878,-60.18864751558619
+        -8.216833080207858,-59.72299484166875 -8.221272080743814,-59.723023261271635
+        -8.226296312759192,-58.81561742540932 -8.22639648636114,-58.815617853117644
+        -8.226541922193537,-58.77125891780361 -8.226787741770087,-58.72686245728039
+        -8.22668748239152,-58.72686205012567 -8.227128432164438,-58.59236931796299
+        -8.20641079709209,-58.58779891786572 -8.058066756070268,-58.55517482591116
+        -7.909631451837953,-58.52262303947609 -7.76113153461292,-58.49000237342716
+        -7.61244382612859,-58.4575572853472 -7.463728378450838,-58.4250745603622 -7.314958470765046,-58.39272275216517
+        -7.234941198126688,-58.375254129393625 -7.166230358238336,-58.360253821300766
+        -7.017527686177195,-58.32782765005001 -6.868859461457663,-58.29540820123015
+        -6.720394969321127,-58.2627041749827 -6.571970365287938,-58.23009996675289
+        -6.423703068839534,-58.19725542890734 -6.330945947035384,-58.17690710203266
+        -6.275355286109034,-58.16471206064169 -6.12684412905082,-58.13231119447888
+        -5.978282745940644,-58.09977566537265 -5.829612756555214,-58.06725246355714
+        -5.680872864608109,-58.03476736414772 -5.532045503597057,-58.00250034236514
+        -5.427318580265228,-57.97960872289923 -5.42562550187137,-58.76098681421241
+        -5.423640334598856,-59.30349460796113 -5.416924739912873,-59.30353928373773
+        -5.4219309173953585,-60.24899623557721 -5.423630186583651,-60.69564393090553
+        -5.500183801234599,-60.71291597287658 -5.550941220542136,-60.72433596993646
+        -5.699261876296276,-60.757746590304095 -5.847567763864553,-60.79120745240422
+        -5.902799834116351,-60.80365241655455 -5.996129433477907,-60.82462900932474
+        -6.144641244230426,-60.85788791760984 -6.29322659512555,-60.8911759474059
+        -6.328051502591118,-60.898976714237705</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222606_R010_V20160806T142041_20160806T142041"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.898976714237705
+        -6.328051502591118,-60.924459901996606 -6.441815915086212,-60.95770515016864
+        -6.590461016536064,-60.991073033954535 -6.739028637462429,-61.02441325767604
+        -6.887597693254861,-61.05782053198296 -7.036090793867917,-61.091368265044366
+        -7.184442349864958,-61.102437590870586 -7.233258879175227,-61.10245354449828
+        -7.233329235829833,-61.11193990316215 -7.2751647652046785,-61.12250762759605
+        -7.321769196013676,-61.12499328714004 -7.33273113478843,-61.15863703603368
+        -7.480949396014731,-61.187388514043064 -7.607170832342958,-61.187388514043064
+        -7.6071708323429625,-61.192400124060896 -7.629172227003829,-61.226071537399854
+        -7.777507877544354,-61.25973260777868 -7.925894774668903,-61.29335345298328
+        -8.07436769706943,-61.32696606337318 -8.222896518135014,-61.32784720995371
+        -8.226798176279523,-61.18474557597368 -8.226297324933649,-61.18474514567033
+        -8.226398126465138,-61.140077621706084 -8.226140988458724,-61.09544973653788
+        -8.225984792224422,-61.095450187595624 -8.225884081237991,-60.27734014430516
+        -8.221174458521304,-60.277339503652556 -8.221274538592427,-60.232963895702774
+        -8.220918997302837,-60.18864685496363 -8.220663876926901,-60.18864751558619
+        -8.220563930551878,-59.72299484166875 -8.216833080207858,-59.723023261271635
+        -8.221272080743814,-58.81561742540932 -8.226296312759192,-58.815617853117644
+        -8.22639648636114,-58.77125891780361 -8.226541922193537,-58.72686245728039
+        -8.226787741770087,-58.72686205012567 -8.22668748239152,-58.59236931796299
+        -8.227128432164438,-58.58779891786572 -8.20641079709209,-58.55517482591116
+        -8.058066756070268,-58.52262303947609 -7.909631451837953,-58.49000237342716
+        -7.76113153461292,-58.4575572853472 -7.61244382612859,-58.4250745603622 -7.463728378450838,-58.39272275216517
+        -7.314958470765046,-58.375254129393625 -7.234941198126688,-58.360253821300766
+        -7.166230358238336,-58.32782765005001 -7.017527686177195,-58.29540820123015
+        -6.868859461457663,-58.2627041749827 -6.720394969321127,-58.23009996675289
+        -6.571970365287938,-58.19725542890734 -6.423703068839534,-58.17690710203266
+        -6.330945947035384,-58.16471206064169 -6.275355286109034,-58.13231119447888
+        -6.12684412905082,-58.09977566537265 -5.978282745940644,-58.06725246355714
+        -5.829612756555214,-58.03476736414772 -5.680872864608109,-58.00250034236514
+        -5.532045503597057,-57.97960872289923 -5.427318580265228,-58.76098681421241
+        -5.42562550187137,-59.30349460796113 -5.423640334598856,-59.30353928373773
+        -5.416924739912873,-60.24899623557721 -5.4219309173953585,-60.69564393090553
+        -5.423630186583651,-60.71291597287658 -5.500183801234599,-60.72433596993646
+        -5.550941220542136,-60.757746590304095 -5.699261876296276,-60.79120745240422
+        -5.847567763864553,-60.80365241655455 -5.902799834116351,-60.82462900932474
+        -5.996129433477907,-60.85788791760984 -6.144641244230426,-60.8911759474059
+        -6.29322659512555,-60.898976714237705 -6.328051502591118))"},{"name":"s2datatakeid","content":"GS2A_20160806T142042_005870_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.16
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210223_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f366fe32-5264-433d-bc01-27a84a0e52c0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f366fe32-5264-433d-bc01-27a84a0e52c0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f366fe32-5264-433d-bc01-27a84a0e52c0'')/Products(''Quicklook'')/$value"}],"id":"f366fe32-5264-433d-bc01-27a84a0e52c0","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        340.53 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:33:19.116Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.0289"},"str":[{"name":"uuid","content":"f366fe32-5264-433d-bc01-27a84a0e52c0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210223_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.904704380654936,-64.13134288360105
+        0.820849587597856,-64.14977779116401 0.672122861674971,-64.18246555907957
+        0.523384374674541,-64.21521486059603 0.374633086281772,-64.24794255435425
+        0.225877734017831,-64.28069849872033 0.077128452029083,-64.3134185382289 -0.071524433047576,-64.34614954880685
+        -0.088454734941562,-64.34987887828511 -0.088438915806152,-64.79705493951633
+        0.904463466083483,-64.79727531806687 0.904704380654936,-64.13134288360105
+        0.904704380654936,-64.13134288360105</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210223_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.13134288360105 0.904704380654936,-64.14977779116401
+        0.820849587597856,-64.18246555907957 0.672122861674971,-64.21521486059603
+        0.523384374674541,-64.24794255435425 0.374633086281772,-64.28069849872033
+        0.225877734017831,-64.3134185382289 0.077128452029083,-64.34614954880685 -0.071524433047576,-64.34987887828511
+        -0.088454734941562,-64.79705493951633 -0.088438915806152,-64.79727531806687
+        0.904463466083483,-64.13134288360105 0.904704380654936,-64.13134288360105
+        0.904704380654936))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"340.53
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210403_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c31c54c9-6a80-4664-9067-dd2f2fe9ad39'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c31c54c9-6a80-4664-9067-dd2f2fe9ad39'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c31c54c9-6a80-4664-9067-dd2f2fe9ad39'')/Products(''Quicklook'')/$value"}],"id":"c31c54c9-6a80-4664-9067-dd2f2fe9ad39","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        230.89 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:33:33.968Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.0507"},"str":[{"name":"uuid","content":"c31c54c9-6a80-4664-9067-dd2f2fe9ad39"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210403_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-64.33040100162289
+        -0.071524433047576,-64.34614954880685 -0.2200675886381,-64.37886995582652
+        -0.368504315431157,-64.41147131335657 -0.516853467441978,-64.44409643408328
+        -0.665265317943897,-64.47665138109262 -0.813839433854744,-64.50915910760847
+        -0.96246237049776,-64.54172198601243 -0.993000979868068,-64.54841007533682
+        -0.992902127223695,-64.7973209645043 0,-64.7970528123519 0,-64.33040100162289
+        0,-64.33040100162289</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210403_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.33040100162289 0,-64.34614954880685
+        -0.071524433047576,-64.37886995582652 -0.2200675886381,-64.41147131335657
+        -0.368504315431157,-64.44409643408328 -0.516853467441978,-64.47665138109262
+        -0.665265317943897,-64.50915910760847 -0.813839433854744,-64.54172198601243
+        -0.96246237049776,-64.54841007533682 -0.993000979868068,-64.7973209645043
+        -0.992902127223695,-64.7970528123519 0,-64.33040100162289 0,-64.33040100162289
+        0))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"230.89
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160710T210705_R053_V20160710T142756_20160710T142756","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''659ffdd6-4cd8-4f09-b90c-40271a9c64a9'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''659ffdd6-4cd8-4f09-b90c-40271a9c64a9'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''659ffdd6-4cd8-4f09-b90c-40271a9c64a9'')/Products(''Quicklook'')/$value"}],"id":"659ffdd6-4cd8-4f09-b90c-40271a9c64a9","summary":"Date:
+        2016-07-10T14:27:56Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.46 GB","date":[{"name":"ingestiondate","content":"2016-07-10T21:19:23.252Z"},{"name":"beginposition","content":"2016-07-10T14:27:56Z"},{"name":"endposition","content":"2016-07-10T14:27:56Z"}],"int":[{"name":"orbitnumber","content":"5484"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.06798333333333334"},"str":[{"name":"uuid","content":"659ffdd6-4cd8-4f09-b90c-40271a9c64a9"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160710T210705_R053_V20160710T142756_20160710T142756.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.280458254640564,-63.906261799713896
+        -8.22947212599136,-63.90828910774846 -8.230398500927846,-63.00018159295572
+        -8.230498859705568,-63.00018159299859 -8.2304437940123,-62.955781654289254
+        -8.23048908614055,-62.911382652974034 -8.23038872950755,-62.911382673891325
+        -8.22937260678506,-62.09207424566609 -8.229472946800525,-62.09207403140284
+        -8.229317536684688,-62.047670753471174 -8.229262491883746,-62.003287660422316
+        -8.229162198038187,-62.00328789552824 -8.226297324933649,-61.18474557597368
+        -8.226398126465138,-61.18474514567033 -8.226140988458724,-61.140077621706126
+        -8.225984792224422,-61.09544973653788 -8.225884081237991,-61.095450187595624
+        -8.220663876926901,-60.18864685496363 -7.272677254442484,-60.19491282857524
+        -6.369271485814847,-60.20016780456912 -5.42176328831644,-60.204935446218734
+        -5.425362066336241,-61.15086321305924 -5.427449229390539,-62.05319609957077
+        -5.428189238842002,-62.956038252707735 -5.427550802672508,-63.90301909922936
+        -6.3760776819297655,-63.90456160754002 -7.280458254640564,-63.906261799713896</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160710T210705_R053_V20160710T142756_20160710T142756"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.906261799713896
+        -7.280458254640564,-63.90828910774846 -8.22947212599136,-63.00018159295572
+        -8.230398500927846,-63.00018159299859 -8.230498859705568,-62.955781654289254
+        -8.2304437940123,-62.911382652974034 -8.23048908614055,-62.911382673891325
+        -8.23038872950755,-62.09207424566609 -8.22937260678506,-62.09207403140284
+        -8.229472946800525,-62.047670753471174 -8.229317536684688,-62.003287660422316
+        -8.229262491883746,-62.00328789552824 -8.229162198038187,-61.18474557597368
+        -8.226297324933649,-61.18474514567033 -8.226398126465138,-61.140077621706126
+        -8.226140988458724,-61.09544973653788 -8.225984792224422,-61.095450187595624
+        -8.225884081237991,-60.18864685496363 -8.220663876926901,-60.19491282857524
+        -7.272677254442484,-60.20016780456912 -6.369271485814847,-60.204935446218734
+        -5.42176328831644,-61.15086321305924 -5.425362066336241,-62.05319609957077
+        -5.427449229390539,-62.956038252707735 -5.428189238842002,-63.90301909922936
+        -5.427550802672508,-63.90456160754002 -6.3760776819297655,-63.906261799713896
+        -7.280458254640564))"},{"name":"s2datatakeid","content":"GS2A_20160710T142802_005484_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.46
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215841_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ed3e4a53-91db-42d5-a53e-1eea4135cf65'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ed3e4a53-91db-42d5-a53e-1eea4135cf65'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ed3e4a53-91db-42d5-a53e-1eea4135cf65'')/Products(''Quicklook'')/$value"}],"id":"ed3e4a53-91db-42d5-a53e-1eea4135cf65","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        615.59 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:04:26.969Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.0707"},"str":[{"name":"uuid","content":"ed3e4a53-91db-42d5-a53e-1eea4135cf65"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215841_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.903921076504472,-61.20308428515767
+        -0.903295103942012,-60.21702318736773 -1.895504025238056,-60.21585252570553
+        -1.896817942614176,-61.20232771671445 -0.903921076504472,-61.20308428515767
+        -0.903921076504472,-61.20308428515767</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215841_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.20308428515767 -0.903921076504472,-60.21702318736773
+        -0.903295103942012,-60.21585252570553 -1.895504025238056,-61.20232771671445
+        -1.896817942614176,-61.20308428515767 -0.903921076504472,-61.20308428515767
+        -0.903921076504472))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"615.59
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T030119_R110_V20160803T141306_20160803T141306","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''997c2ac6-7bf7-46f8-a81e-9ea4e7b0785a'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''997c2ac6-7bf7-46f8-a81e-9ea4e7b0785a'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''997c2ac6-7bf7-46f8-a81e-9ea4e7b0785a'')/Products(''Quicklook'')/$value"}],"id":"997c2ac6-7bf7-46f8-a81e-9ea4e7b0785a","summary":"Date:
+        2016-08-03T14:13:06Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        2.87 GB","date":[{"name":"ingestiondate","content":"2016-08-06T06:14:48.733Z"},{"name":"beginposition","content":"2016-08-03T14:13:06Z"},{"name":"endposition","content":"2016-08-03T14:13:06Z"}],"int":[{"name":"orbitnumber","content":"5827"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"0.08761250000000001"},"str":[{"name":"uuid","content":"997c2ac6-7bf7-46f8-a81e-9ea4e7b0785a"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T030119_R110_V20160803T141306_20160803T141306.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.087095298238086,-56.97126016377168
+        -4.09960459076112,-56.912062566958376 -4.133776859549961,-56.750349489561486
+        -4.131261406109482,-56.74979625114747 -4.131263530913511,-56.74978648978385
+        -4.131128773404328,-56.749756782225695 -4.174012254450703,-56.552706054665926
+        -4.174694072013738,-56.55285610710765 -4.175145077265305,-56.55078482609193
+        -4.176745880570752,-56.551136104964144 -4.226424816076642,-56.33160139664095
+        -4.224354285199688,-56.331146777472725 -4.271193585665682,-56.13409700352791
+        -4.271362068615981,-56.134133938135136 -4.271363044798569,-56.13412982822844
+        -4.271675483627607,-56.13419815302786 -4.272124553286313,-56.132305770915146
+        -4.272665630980799,-56.13242407526715 -4.272675710026807,-56.13238153371032
+        -4.272965630754033,-56.13244513093388 -4.272977130401373,-56.13239648742669
+        -4.274098367565915,-56.13264151809752 -4.295675564410858,-56.04338187526676
+        -4.327644884725951,-55.91113253197283 -4.325396722594665,-55.91064043542536
+        -4.35070655808685,-55.81246778281274 -4.37686271054473,-55.710813287560555
+        -4.37727006112017,-55.710903383742256 -4.377779612360693,-55.70892000676821
+        -4.378177637333065,-55.70900796005409 -4.378203543702523,-55.70890675001832
+        -4.378353979709618,-55.70894007067009 -4.378392706928942,-55.70878813786008
+        -4.379320864324488,-55.70899274437844 -4.437881777775403,-55.48235055174107
+        -4.435838542676303,-55.481904767613344 -4.435850883047833,-55.481860510081994
+        -4.435759794316402,-55.48184067793328 -4.497697927299994,-55.25915054015656
+        -4.416200836170319,-55.24128476228536 -4.267360021438416,-55.20908138763201
+        -4.21897297423033,-55.19839071322792 -4.218972974230345,-55.19839071322792
+        -4.118784793227455,-55.17625505329328 -3.970211063939352,-55.143645545730806
+        -3.821705056355674,-55.111255939308926 -3.819214862985437,-55.11070737875385
+        -3.8192148629854348,-55.11070737875385 -3.673352155339148,-55.07857552553016
+        -3.525012204925122,-55.045869983750336 -3.376553593878288,-55.01332785228579
+        -3.227922302577158,-54.98087200360673 -3.07919015298988,-54.94841873189628
+        -2.93040727283986,-54.9159293357159 -2.781540605123434,-54.883643235028096
+        -2.712195531763073,-54.86848174840274 -2.7127451087194467,-55.15704255065453
+        -2.713786464257691,-56.05636168750624 -2.7141556791285284,-56.95618526301482
+        -2.713946891340041,-57.574817278226654 -2.801925662898893,-57.59445693630039
+        -2.879748160017294,-57.61184329828043 -2.950143593290936,-57.62754406419285
+        -3.067752688367212,-57.65376870975504 -3.098708449456115,-57.66066432212265
+        -3.247203241691877,-57.69368219676191 -3.395802516452492,-57.72666098998568
+        -3.544480794637863,-57.75954258966623 -3.69316467201968,-57.79246126593393
+        -3.707125706115831,-57.795551916705854 -3.84185323831404,-57.825377483244814
+        -3.922106120838037,-57.84312895816823 -3.964322349436391,-57.60854091326188
+        -3.963907031051373,-57.6084488176513 -3.96392338459629,-57.608359256432514
+        -3.963797781195332,-57.60833133108494 -3.963815619054095,-57.60823338926968
+        -3.963464293611874,-57.60815549564671 -3.963484125699333,-57.608046302317774
+        -3.96199827796555,-57.60771760131366 -3.962004088903701,-57.6076849964057
+        -3.961553593839922,-57.60758515113622 -3.998264607821283,-57.40096600280841
+        -3.998963691885888,-57.40112073377188 -3.999391933800111,-57.39872072254691
+        -4.002352520626087,-57.39937338864706 -4.046559649264977,-57.173541883946314
+        -4.044066929943069,-57.17299292516413 -4.044067765087636,-57.172988701948015
+        -4.043977153672643,-57.172968698432406 -4.083510448920861,-56.972788846913176
+        -4.083997261196788,-56.97289619952933 -4.084437377192985,-56.97067482548664
+        -4.087095298238086,-56.97126016377168</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T030119_R110_V20160803T141306_20160803T141306"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-56.97126016377168 -4.087095298238086,-56.912062566958376
+        -4.09960459076112,-56.750349489561486 -4.133776859549961,-56.74979625114747
+        -4.131261406109482,-56.74978648978385 -4.131263530913511,-56.749756782225695
+        -4.131128773404328,-56.552706054665926 -4.174012254450703,-56.55285610710765
+        -4.174694072013738,-56.55078482609193 -4.175145077265305,-56.551136104964144
+        -4.176745880570752,-56.33160139664095 -4.226424816076642,-56.331146777472725
+        -4.224354285199688,-56.13409700352791 -4.271193585665682,-56.134133938135136
+        -4.271362068615981,-56.13412982822844 -4.271363044798569,-56.13419815302786
+        -4.271675483627607,-56.132305770915146 -4.272124553286313,-56.13242407526715
+        -4.272665630980799,-56.13238153371032 -4.272675710026807,-56.13244513093388
+        -4.272965630754033,-56.13239648742669 -4.272977130401373,-56.13264151809752
+        -4.274098367565915,-56.04338187526676 -4.295675564410858,-55.91113253197283
+        -4.327644884725951,-55.91064043542536 -4.325396722594665,-55.81246778281274
+        -4.35070655808685,-55.710813287560555 -4.37686271054473,-55.710903383742256
+        -4.37727006112017,-55.70892000676821 -4.377779612360693,-55.70900796005409
+        -4.378177637333065,-55.70890675001832 -4.378203543702523,-55.70894007067009
+        -4.378353979709618,-55.70878813786008 -4.378392706928942,-55.70899274437844
+        -4.379320864324488,-55.48235055174107 -4.437881777775403,-55.481904767613344
+        -4.435838542676303,-55.481860510081994 -4.435850883047833,-55.48184067793328
+        -4.435759794316402,-55.25915054015656 -4.497697927299994,-55.24128476228536
+        -4.416200836170319,-55.20908138763201 -4.267360021438416,-55.19839071322792
+        -4.21897297423033,-55.19839071322792 -4.218972974230345,-55.17625505329328
+        -4.118784793227455,-55.143645545730806 -3.970211063939352,-55.111255939308926
+        -3.821705056355674,-55.11070737875385 -3.819214862985437,-55.11070737875385
+        -3.8192148629854348,-55.07857552553016 -3.673352155339148,-55.045869983750336
+        -3.525012204925122,-55.01332785228579 -3.376553593878288,-54.98087200360673
+        -3.227922302577158,-54.94841873189628 -3.07919015298988,-54.9159293357159
+        -2.93040727283986,-54.883643235028096 -2.781540605123434,-54.86848174840274
+        -2.712195531763073,-55.15704255065453 -2.7127451087194467,-56.05636168750624
+        -2.713786464257691,-56.95618526301482 -2.7141556791285284,-57.574817278226654
+        -2.713946891340041,-57.59445693630039 -2.801925662898893,-57.61184329828043
+        -2.879748160017294,-57.62754406419285 -2.950143593290936,-57.65376870975504
+        -3.067752688367212,-57.66066432212265 -3.098708449456115,-57.69368219676191
+        -3.247203241691877,-57.72666098998568 -3.395802516452492,-57.75954258966623
+        -3.544480794637863,-57.79246126593393 -3.69316467201968,-57.795551916705854
+        -3.707125706115831,-57.825377483244814 -3.84185323831404,-57.84312895816823
+        -3.922106120838037,-57.60854091326188 -3.964322349436391,-57.6084488176513
+        -3.963907031051373,-57.608359256432514 -3.96392338459629,-57.60833133108494
+        -3.963797781195332,-57.60823338926968 -3.963815619054095,-57.60815549564671
+        -3.963464293611874,-57.608046302317774 -3.963484125699333,-57.60771760131366
+        -3.96199827796555,-57.6076849964057 -3.962004088903701,-57.60758515113622
+        -3.961553593839922,-57.40096600280841 -3.998264607821283,-57.40112073377188
+        -3.998963691885888,-57.39872072254691 -3.999391933800111,-57.39937338864706
+        -4.002352520626087,-57.173541883946314 -4.046559649264977,-57.17299292516413
+        -4.044066929943069,-57.172988701948015 -4.044067765087636,-57.172968698432406
+        -4.043977153672643,-56.972788846913176 -4.083510448920861,-56.97289619952933
+        -4.083997261196788,-56.97067482548664 -4.084437377192985,-56.97126016377168
+        -4.087095298238086))"},{"name":"s2datatakeid","content":"GS2A_20160803T141312_005827_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"2.87
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T113941_R053_V20160730T142756_20160730T142756","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''63b3b8fe-55e6-40f1-be8c-22494e17b2e2'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''63b3b8fe-55e6-40f1-be8c-22494e17b2e2'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''63b3b8fe-55e6-40f1-be8c-22494e17b2e2'')/Products(''Quicklook'')/$value"}],"id":"63b3b8fe-55e6-40f1-be8c-22494e17b2e2","summary":"Date:
+        2016-07-30T14:27:56Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.35 GB","date":[{"name":"ingestiondate","content":"2016-07-31T11:46:36.04Z"},{"name":"beginposition","content":"2016-07-30T14:27:56Z"},{"name":"endposition","content":"2016-07-30T14:27:56Z"}],"int":[{"name":"orbitnumber","content":"5770"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.09638461538461539"},"str":[{"name":"uuid","content":"63b3b8fe-55e6-40f1-be8c-22494e17b2e2"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T113941_R053_V20160730T142756_20160730T142756.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.611784856753859,-63.03142727044805
+        -4.714078495421723,-63.054170897872375 -4.862723284261516,-63.08731380916897
+        -5.011344535530087,-63.12049829134408 -5.159849024726916,-63.15374164313053
+        -5.308268886915166,-63.18705928245291 -5.456622611922337,-63.220494631722566
+        -5.516472853431456,-63.23399110571804 -5.516633044843839,-63.00018056571296
+        -5.516700066819259,-63.00018056573138 -5.51666329264377,-62.956031791877834
+        -5.516693539799448,-62.91188395837315 -5.51662651925904,-62.91188396736038
+        -5.515947927683427,-62.09720938629529 -5.516014937246069,-62.097209294235604
+        -5.5159111504805916,-62.05305697799958 -5.515874390220655,-62.00892491028778
+        -5.515807411549814,-62.0089250113026 -5.5138941737767615,-61.1950073715956
+        -5.513961491831883,-61.19500718671128 -5.513789767821807,-61.150591643647466
+        -5.513685455771881,-61.10621586418906 -5.51361819829923,-61.1062160579905
+        -5.511332176154395,-60.514948040351 -5.437537291663092,-60.498876626806975
+        -5.288778561120923,-60.46643051918265 -5.140054031187563,-60.43392371962031
+        -4.991422259240365,-60.40142755748252 -4.842901424140503,-60.36890631205959
+        -4.694483848361092,-60.33637430268334 -4.606724391351802,-60.31710928365637
+        -4.546120975163597,-60.30380557821251 -4.518283554045686,-60.297688020206465
+        -4.397775832459472,-60.27120521585985 -4.249314409449857,-60.238635414232846
+        -4.118935344069517,-60.21009852191954 -4.1189353440695164,-60.21009852191954
+        -4.100743422205723,-60.20611674069044 -3.952022478272002,-60.17368086727812
+        -3.803230001076338,-60.14126831713411 -3.654397510306008,-60.10888645053405
+        -3.61377575428337,-60.100043402152224 -3.505613873204075,-60.07649738048541
+        -3.356834084714931,-60.04407805454823 -3.208113281485871,-60.011598075680006
+        -3.05946394713876,-59.9791267920884 -2.910964019670657,-59.946560183895365
+        -2.762585728639492,-59.913919092525965 -2.710089938031192,-59.902328817616144
+        -2.711033187970939,-60.25818167438883 -2.7127451087194467,-61.15704255065438
+        -2.713786464257691,-62.056361687506204 -2.714013404028251,-62.60944275736505
+        -2.782888511281836,-62.624650281469926 -2.931600776325607,-62.657534891559045
+        -3.080306352129553,-62.69039489136208 -3.228975119467584,-62.72328913697544
+        -3.37753387536482,-62.75630195465418 -3.525988313377891,-62.789432907525054
+        -3.674340650810248,-62.82259400413345 -3.707441880314232,-62.82999974800994
+        -3.715582879660453,-62.831821135220025 -3.822565288253561,-62.85569967479644
+        -3.970927242344822,-62.88889728167016 -4.074814870873953,-62.912065286242814
+        -4.074814870873946,-62.912065286242814 -4.078659892783715,-62.91292276548696
+        -4.119550536009309,-62.92201556312354 -4.268122099556085,-62.955054452182246
+        -4.416738034658797,-62.98807334588578 -4.565410367381838,-63.02111652070832
+        -4.611784856753859,-63.03142727044805</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T113941_R053_V20160730T142756_20160730T142756"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.03142727044805 -4.611784856753859,-63.054170897872375
+        -4.714078495421723,-63.08731380916897 -4.862723284261516,-63.12049829134408
+        -5.011344535530087,-63.15374164313053 -5.159849024726916,-63.18705928245291
+        -5.308268886915166,-63.220494631722566 -5.456622611922337,-63.23399110571804
+        -5.516472853431456,-63.00018056571296 -5.516633044843839,-63.00018056573138
+        -5.516700066819259,-62.956031791877834 -5.51666329264377,-62.91188395837315
+        -5.516693539799448,-62.91188396736038 -5.51662651925904,-62.09720938629529
+        -5.515947927683427,-62.097209294235604 -5.516014937246069,-62.05305697799958
+        -5.5159111504805916,-62.00892491028778 -5.515874390220655,-62.0089250113026
+        -5.515807411549814,-61.1950073715956 -5.5138941737767615,-61.19500718671128
+        -5.513961491831883,-61.150591643647466 -5.513789767821807,-61.10621586418906
+        -5.513685455771881,-61.1062160579905 -5.51361819829923,-60.514948040351 -5.511332176154395,-60.498876626806975
+        -5.437537291663092,-60.46643051918265 -5.288778561120923,-60.43392371962031
+        -5.140054031187563,-60.40142755748252 -4.991422259240365,-60.36890631205959
+        -4.842901424140503,-60.33637430268334 -4.694483848361092,-60.31710928365637
+        -4.606724391351802,-60.30380557821251 -4.546120975163597,-60.297688020206465
+        -4.518283554045686,-60.27120521585985 -4.397775832459472,-60.238635414232846
+        -4.249314409449857,-60.21009852191954 -4.118935344069517,-60.21009852191954
+        -4.1189353440695164,-60.20611674069044 -4.100743422205723,-60.17368086727812
+        -3.952022478272002,-60.14126831713411 -3.803230001076338,-60.10888645053405
+        -3.654397510306008,-60.100043402152224 -3.61377575428337,-60.07649738048541
+        -3.505613873204075,-60.04407805454823 -3.356834084714931,-60.011598075680006
+        -3.208113281485871,-59.9791267920884 -3.05946394713876,-59.946560183895365
+        -2.910964019670657,-59.913919092525965 -2.762585728639492,-59.902328817616144
+        -2.710089938031192,-60.25818167438883 -2.711033187970939,-61.15704255065438
+        -2.7127451087194467,-62.056361687506204 -2.713786464257691,-62.60944275736505
+        -2.714013404028251,-62.624650281469926 -2.782888511281836,-62.657534891559045
+        -2.931600776325607,-62.69039489136208 -3.080306352129553,-62.72328913697544
+        -3.228975119467584,-62.75630195465418 -3.37753387536482,-62.789432907525054
+        -3.525988313377891,-62.82259400413345 -3.674340650810248,-62.82999974800994
+        -3.707441880314232,-62.831821135220025 -3.715582879660453,-62.85569967479644
+        -3.822565288253561,-62.88889728167016 -3.970927242344822,-62.912065286242814
+        -4.074814870873953,-62.912065286242814 -4.074814870873946,-62.91292276548696
+        -4.078659892783715,-62.92201556312354 -4.119550536009309,-62.955054452182246
+        -4.268122099556085,-62.98807334588578 -4.416738034658797,-63.02111652070832
+        -4.565410367381838,-63.03142727044805 -4.611784856753859))"},{"name":"s2datatakeid","content":"GS2A_20160730T142802_005770_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.35
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T210109_R110_V20160724T141050_20160724T141050","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bf2b4df2-4819-430b-b1ae-dcdabef5bd05'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bf2b4df2-4819-430b-b1ae-dcdabef5bd05'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bf2b4df2-4819-430b-b1ae-dcdabef5bd05'')/Products(''Quicklook'')/$value"}],"id":"bf2b4df2-4819-430b-b1ae-dcdabef5bd05","summary":"Date:
+        2016-07-24T14:10:50Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.54 GB","date":[{"name":"ingestiondate","content":"2016-07-24T21:19:10.145Z"},{"name":"beginposition","content":"2016-07-24T14:10:50Z"},{"name":"endposition","content":"2016-07-24T14:10:50Z"}],"int":[{"name":"orbitnumber","content":"5684"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"0.120375"},"str":[{"name":"uuid","content":"bf2b4df2-4819-430b-b1ae-dcdabef5bd05"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T210109_R110_V20160724T141050_20160724T141050.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.272429511145873,-58.59158359727802
+        -7.354688862326416,-58.60999044804337 -7.502929672378903,-58.643861186100274
+        -7.651236919045406,-58.67748977590158 -7.79949654060468,-58.71129406988072
+        -7.947812126404428,-58.745051686598046 -8.096212921844161,-58.77875208677228
+        -8.226420432944982,-58.80831397933226 -8.229371267918504,-57.90828889229284
+        -8.22947212599136,-57.908289107748466 -8.229517681770956,-57.863631654094036
+        -8.229664156708726,-57.818955784450985 -8.22956325653525,-57.81895559010358
+        -8.230398500927846,-57.00018159295572 -8.230498859705568,-57.00018159299859
+        -8.2304437940123,-56.95578165428924 -8.23048908614055,-56.911382652974034
+        -8.23038872950755,-56.911382673891325 -8.22937260678506,-56.092074245666105
+        -8.229472946800525,-56.09207403140285 -8.229409834763413,-56.07404186335744
+        -8.229350226179331,-56.074028572150745 -8.228152795845043,-56.07376157547037
+        -8.079794209956953,-56.04088624610974 -7.931270979731828,-56.00828383029192
+        -7.911802550463902,-56.004031840812836 -7.911802550463887,-56.004031840812836
+        -7.782607683360331,-55.97581512090616 -7.633863583815647,-55.943324917575
+        -7.485082256317775,-55.91080402281287 -7.336389434184239,-55.878342280904
+        -7.324160537505286,-55.87566169909415 -7.235651077089067,-55.85626036994565
+        -7.187807568154135,-55.84577304282716 -7.039247848187117,-55.81332496832055
+        -6.890760913855559,-55.7807609865098 -6.742386912696306,-55.748122739958816
+        -6.594001332770723,-55.71563588520981 -6.445638282907001,-55.682973652508565
+        -6.419571204092345,-55.677245115909386 -6.354438688691052,-55.66293150597535
+        -6.33053042238296,-55.657677392940954 -6.297203966278001,-55.65035352574143
+        -6.14858182626376,-55.61802008162492 -5.999855262207127,-55.58569982925993
+        -5.851165497539067,-55.55309359133734 -5.702349617078523,-55.52068203235565
+        -5.553579069658527,-55.48822817392372 -5.426078417339919,-55.46055970158808
+        -5.427449229390539,-56.05319609957075 -5.428189238842002,-56.956038252707735
+        -5.427580735171929,-57.858620763115006 -5.426891698905711,-58.17662012126434
+        -5.573037244094337,-58.20944493754144 -5.721415674786411,-58.24272704972456
+        -5.869749207783717,-58.276115357477074 -6.018062074558989,-58.309564849488666
+        -6.166400354760996,-58.34310538968976 -6.314824041139111,-58.37662206379312
+        -6.330432529000043,-58.38013640324843 -6.463290645705484,-58.41005016079211
+        -6.611850221875092,-58.44340093107544 -6.760500612142352,-58.47666961537779
+        -6.90921842824892,-58.50973691769844 -7.057768728193599,-58.54317578927079
+        -7.20619324938201,-58.57676217007193 -7.272429511145873,-58.59158359727802</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T210109_R110_V20160724T141050_20160724T141050"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.59158359727802 -7.272429511145873,-58.60999044804337
+        -7.354688862326416,-58.643861186100274 -7.502929672378903,-58.67748977590158
+        -7.651236919045406,-58.71129406988072 -7.79949654060468,-58.745051686598046
+        -7.947812126404428,-58.77875208677228 -8.096212921844161,-58.80831397933226
+        -8.226420432944982,-57.90828889229284 -8.229371267918504,-57.908289107748466
+        -8.22947212599136,-57.863631654094036 -8.229517681770956,-57.818955784450985
+        -8.229664156708726,-57.81895559010358 -8.22956325653525,-57.00018159295572
+        -8.230398500927846,-57.00018159299859 -8.230498859705568,-56.95578165428924
+        -8.2304437940123,-56.911382652974034 -8.23048908614055,-56.911382673891325
+        -8.23038872950755,-56.092074245666105 -8.22937260678506,-56.09207403140285
+        -8.229472946800525,-56.07404186335744 -8.229409834763413,-56.074028572150745
+        -8.229350226179331,-56.07376157547037 -8.228152795845043,-56.04088624610974
+        -8.079794209956953,-56.00828383029192 -7.931270979731828,-56.004031840812836
+        -7.911802550463902,-56.004031840812836 -7.911802550463887,-55.97581512090616
+        -7.782607683360331,-55.943324917575 -7.633863583815647,-55.91080402281287
+        -7.485082256317775,-55.878342280904 -7.336389434184239,-55.87566169909415
+        -7.324160537505286,-55.85626036994565 -7.235651077089067,-55.84577304282716
+        -7.187807568154135,-55.81332496832055 -7.039247848187117,-55.7807609865098
+        -6.890760913855559,-55.748122739958816 -6.742386912696306,-55.71563588520981
+        -6.594001332770723,-55.682973652508565 -6.445638282907001,-55.677245115909386
+        -6.419571204092345,-55.66293150597535 -6.354438688691052,-55.657677392940954
+        -6.33053042238296,-55.65035352574143 -6.297203966278001,-55.61802008162492
+        -6.14858182626376,-55.58569982925993 -5.999855262207127,-55.55309359133734
+        -5.851165497539067,-55.52068203235565 -5.702349617078523,-55.48822817392372
+        -5.553579069658527,-55.46055970158808 -5.426078417339919,-56.05319609957075
+        -5.427449229390539,-56.956038252707735 -5.428189238842002,-57.858620763115006
+        -5.427580735171929,-58.17662012126434 -5.426891698905711,-58.20944493754144
+        -5.573037244094337,-58.24272704972456 -5.721415674786411,-58.276115357477074
+        -5.869749207783717,-58.309564849488666 -6.018062074558989,-58.34310538968976
+        -6.166400354760996,-58.37662206379312 -6.314824041139111,-58.38013640324843
+        -6.330432529000043,-58.41005016079211 -6.463290645705484,-58.44340093107544
+        -6.611850221875092,-58.47666961537779 -6.760500612142352,-58.50973691769844
+        -6.90921842824892,-58.54317578927079 -7.057768728193599,-58.57676217007193
+        -7.20619324938201,-58.59158359727802 -7.272429511145873))"},{"name":"s2datatakeid","content":"GS2A_20160724T141052_005684_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.54
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163855_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0dafb37c-97cf-41d3-8a3e-127d090d5bca'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0dafb37c-97cf-41d3-8a3e-127d090d5bca'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0dafb37c-97cf-41d3-8a3e-127d090d5bca'')/Products(''Quicklook'')/$value"}],"id":"0dafb37c-97cf-41d3-8a3e-127d090d5bca","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        545.68 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:34:51.003Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.1291"},"str":[{"name":"uuid","content":"0dafb37c-97cf-41d3-8a3e-127d090d5bca"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163855_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.547830176318592,-63.00018030048188
+        -4.494961818305904,-62.98839426208909 -4.346295796284779,-62.95527827665749
+        -4.197661689932131,-62.92210756231628 -4.049051646939358,-62.88896047654064
+        -3.900427519513336,-62.855893966646335 -3.751923408282848,-62.82275358581608
+        -3.618402076643356,-62.79311285069405 -3.617974654027191,-62.011526836303595
+        -4.611169109777977,-62.01030152037124 -4.611858741453012,-63.00018031487441
+        -4.547830176318592,-63.00018030048188 -4.547830176318592,-63.00018030048188</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163855_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.00018030048188 -4.547830176318592,-62.98839426208909
+        -4.494961818305904,-62.95527827665749 -4.346295796284779,-62.92210756231628
+        -4.197661689932131,-62.88896047654064 -4.049051646939358,-62.855893966646335
+        -3.900427519513336,-62.82275358581608 -3.751923408282848,-62.79311285069405
+        -3.618402076643356,-62.011526836303595 -3.617974654027191,-62.01030152037124
+        -4.611169109777977,-63.00018031487441 -4.611858741453012,-63.00018030048188
+        -4.547830176318592,-63.00018030048188 -4.547830176318592))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"545.68
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164426_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''531465c5-aef1-4cd6-84e5-3a92ee61b345'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''531465c5-aef1-4cd6-84e5-3a92ee61b345'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''531465c5-aef1-4cd6-84e5-3a92ee61b345'')/Products(''Quicklook'')/$value"}],"id":"531465c5-aef1-4cd6-84e5-3a92ee61b345","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        304.52 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:41:07.959Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.1299"},"str":[{"name":"uuid","content":"531465c5-aef1-4cd6-84e5-3a92ee61b345"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164426_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.802489889296027,-62.61189150841514
+        -2.712447883223148,-62.59186571334767 -2.563822344067155,-62.55883037262705
+        -2.415248346411719,-62.525866279851 -2.266663321177563,-62.492966384178246
+        -2.118085548894345,-62.46011019987342 -1.969529619591799,-62.42729202037008
+        -1.939780941553705,-62.420725373909114 -1.82088190783396,-62.39440242124713
+        -1.809109313575265,-62.39179598345459 -1.809005681208331,-62.01299525957096
+        -2.802235856336857,-62.012310655608864 -2.802489889296027,-62.61189150841514
+        -2.802489889296027,-62.61189150841514</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164426_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.61189150841514 -2.802489889296027,-62.59186571334767
+        -2.712447883223148,-62.55883037262705 -2.563822344067155,-62.525866279851
+        -2.415248346411719,-62.492966384178246 -2.266663321177563,-62.46011019987342
+        -2.118085548894345,-62.42729202037008 -1.969529619591799,-62.420725373909114
+        -1.939780941553705,-62.39440242124713 -1.82088190783396,-62.39179598345459
+        -1.809109313575265,-62.01299525957096 -1.809005681208331,-62.012310655608864
+        -2.802235856336857,-62.61189150841514 -2.802489889296027,-62.61189150841514
+        -2.802489889296027))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"304.52
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160718T050345_R010_V20160717T142041_20160717T142041","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f7af783f-ba59-4d01-8f79-523ccbd6addd'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f7af783f-ba59-4d01-8f79-523ccbd6addd'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f7af783f-ba59-4d01-8f79-523ccbd6addd'')/Products(''Quicklook'')/$value"}],"id":"f7af783f-ba59-4d01-8f79-523ccbd6addd","summary":"Date:
+        2016-07-17T14:20:41Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.04 GB","date":[{"name":"ingestiondate","content":"2016-07-18T05:24:37.835Z"},{"name":"beginposition","content":"2016-07-17T14:20:41Z"},{"name":"endposition","content":"2016-07-17T14:20:41Z"}],"int":[{"name":"orbitnumber","content":"5584"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.1338"},"str":[{"name":"uuid","content":"f7af783f-ba59-4d01-8f79-523ccbd6addd"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160718T050345_R010_V20160717T142041_20160717T142041.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.616722069061711,-61.19974375617475
+        -4.521138290585007,-61.19771185555156 -4.521138360525212,-61.19773390587045
+        -4.5652581385101065,-61.19761273399186 -4.609571394393226,-61.19751317791347
+        -4.609571322775516,-61.19749103093647 -5.513961491831883,-61.19500718671128
+        -5.510472970358236,-60.292718824860636 -5.510539807042403,-60.29271854959391
+        -5.510302364769759,-60.24859255586318 -5.510131987398975,-60.204525314213285
+        -5.5100652401698405,-60.204525598059945 -5.507391437327689,-59.70762921084262
+        -5.510538165612144,-59.70764217236141 -5.513893497961508,-58.80535357891916
+        -5.513960396525286,-58.80535376268811 -5.514057522441122,-58.76124545442016
+        -5.514221687588917,-58.7170995025818 -5.514154731632817,-58.71709932764371
+        -5.515947033626909,-57.90315169909761 -5.516014389089381,-57.903151791669515
+        -5.516044812342758,-57.85874693129026 -5.516142631941844,-57.814323596961835
+        -5.516075248310466,-57.81432351345917 -5.516693539799448,-56.91188395837315
+        -4.567517939644129,-56.91201123965434 -3.662943732152377,-56.9121104660506
+        -2.714170526975779,-56.91219153266883 -2.7138520768084997,-57.85574991870128
+        -2.7128765456728288,-58.755101671966266 -2.7118493409356286,-59.31585468578026
+        -2.708535417726956,-59.315866557865895 -2.711149745616365,-60.30215450635603
+        -3.6144376607741897,-60.29978406651288 -3.616722069061711,-61.19974375617475</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160718T050345_R010_V20160717T142041_20160717T142041"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.19974375617475 -3.616722069061711,-61.19771185555156
+        -4.521138290585007,-61.19773390587045 -4.521138360525212,-61.19761273399186
+        -4.5652581385101065,-61.19751317791347 -4.609571394393226,-61.19749103093647
+        -4.609571322775516,-61.19500718671128 -5.513961491831883,-60.292718824860636
+        -5.510472970358236,-60.29271854959391 -5.510539807042403,-60.24859255586318
+        -5.510302364769759,-60.204525314213285 -5.510131987398975,-60.204525598059945
+        -5.5100652401698405,-59.70762921084262 -5.507391437327689,-59.70764217236141
+        -5.510538165612144,-58.80535357891916 -5.513893497961508,-58.80535376268811
+        -5.513960396525286,-58.76124545442016 -5.514057522441122,-58.7170995025818
+        -5.514221687588917,-58.71709932764371 -5.514154731632817,-57.90315169909761
+        -5.515947033626909,-57.903151791669515 -5.516014389089381,-57.85874693129026
+        -5.516044812342758,-57.814323596961835 -5.516142631941844,-57.81432351345917
+        -5.516075248310466,-56.91188395837315 -5.516693539799448,-56.91201123965434
+        -4.567517939644129,-56.9121104660506 -3.662943732152377,-56.91219153266883
+        -2.714170526975779,-57.85574991870128 -2.7138520768084997,-58.755101671966266
+        -2.7128765456728288,-59.31585468578026 -2.7118493409356286,-59.315866557865895
+        -2.708535417726956,-60.30215450635603 -2.711149745616365,-60.29978406651288
+        -3.6144376607741897,-61.19974375617475 -3.616722069061711))"},{"name":"s2datatakeid","content":"GS2A_20160717T142042_005584_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.04
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T064353_R110_V20160803T141306_20160803T141306","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b90c778a-7b2a-40bb-9b34-86e29a0127e2'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b90c778a-7b2a-40bb-9b34-86e29a0127e2'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b90c778a-7b2a-40bb-9b34-86e29a0127e2'')/Products(''Quicklook'')/$value"}],"id":"b90c778a-7b2a-40bb-9b34-86e29a0127e2","summary":"Date:
+        2016-08-03T14:13:06Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        1.73 GB","date":[{"name":"ingestiondate","content":"2016-08-06T11:48:37.496Z"},{"name":"beginposition","content":"2016-08-03T14:13:06Z"},{"name":"endposition","content":"2016-08-03T14:13:06Z"}],"int":[{"name":"orbitnumber","content":"5827"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"0.20361666666666667"},"str":[{"name":"uuid","content":"b90c778a-7b2a-40bb-9b34-86e29a0127e2"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T064353_R110_V20160803T141306_20160803T141306.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.6860846593066794,-56.912249441198064
+        -1.686084659306679,-56.912249441198064 -1.650489265921988,-57.109735150752655
+        -1.651625394025902,-57.10998652112892 -1.65155858842172,-57.110359276713545
+        -1.65292581108755,-57.11066216079392 -1.652805439186362,-57.111328304389886
+        -1.653293555072624,-57.11143650299973 -1.652788443712216,-57.11421072648185
+        -1.653072006890655,-57.114273754459234 -1.65304087302649,-57.11444455760737
+        -1.653464724438978,-57.114538797804805 -1.613803224199209,-57.33140084818868
+        -1.76185631349503,-57.36413625681878 -1.841175117518927,-57.381611242058334
+        -1.910513191099343,-57.3968873399177 -2.059165282559448,-57.4297043598723
+        -2.207881101907123,-57.46248362625659 -2.356521876871973,-57.49537506457361
+        -2.505099658082077,-57.52830623836121 -2.653561295410118,-57.56133729395739
+        -2.801925662898893,-57.59445693630039 -2.802413287900686,-57.59456587683951
+        -2.802620426824397,-57.00017994874974 -2.80265440098957,-57.000179948754 -2.8026357597624734,-56.956182024719375
+        -2.802651092372252,-56.912185042742124 -2.802617118935394,-56.912185044824206
+        -2.8022731333090847,-56.10029356487891 -2.802307101216853,-56.100293543551295
+        -2.802254490521156,-56.05629195689356 -2.802235856336857,-56.01231065560888
+        -2.8022019041077386,-56.01231067901114 -2.801232060899604,-55.20117067407488
+        -2.801266185267337,-55.20117063124223 -2.801179136160849,-55.15690643373674
+        -2.801126259103253,-55.1126820721084 -2.8010921654831153,-55.11268211700687
+        -2.800649892404172,-54.88778764413379 -2.781540605123434,-54.883643235028096
+        -2.632846605440135,-54.85113303670798 -2.484214238999345,-54.81836359862148
+        -2.335565096119548,-54.785794597431085 -2.18797798429044,-54.75344100688873
+        -2.124736084867648,-54.983086107947194 -2.125931896104595,-54.98334940414832
+        -2.125572511133421,-54.98475113394037 -2.12560291685151,-54.98475783046616
+        -2.125503327430271,-54.98514770745604 -2.125669199696302,-54.98518422419907
+        -2.073538013294078,-55.188878498246645 -2.07241032519529,-55.18863031473361
+        -2.072361753293438,-55.18881867374156 -2.072222959935133,-55.18878816506969
+        -2.072170745932346,-55.18899026290048 -2.071761237593389,-55.188900291198095
+        -2.071716034215931,-55.1890746593132 -2.071356770997637,-55.18899567395608
+        -2.071318557714422,-55.18914279976444 -2.071115056735903,-55.18909809675707
+        -2.071051450765665,-55.189342514537095 -2.070663122182747,-55.18925725559339
+        -2.067378945204443,-55.20209180107523 -2.013629979455324,-55.41214246218941
+        -2.015418472199542,-55.412536268609024 -2.015009145736666,-55.414233559064144
+        -2.015197290115801,-55.41427501352073 -2.015138194357366,-55.414520525240704
+        -2.015180772547485,-55.414529905342015 -1.974444850948006,-55.5835799128607
+        -1.967375210746483,-55.612950540659455 -1.96736781391158,-55.61294890998272
+        -1.967322576144587,-55.61313664219915 -1.965469600173469,-55.61272818668188
+        -1.965464097511077,-55.61275082411494 -1.965375212877448,-55.61273126614072
+        -1.965336352110671,-55.61289095581572 -1.964696284473799,-55.612750192358725
+        -1.912579116953623,-55.832753990952334 -1.914636398595533,-55.83320768047088
+        -1.914211040447795,-55.83508504938073 -1.91477157730764,-55.835208743489645
+        -1.8745450875238008,-56.01295586615691 -1.8745450875238,-56.01295586615691
+        -1.870195284939992,-56.03217615849654 -1.869499690735885,-56.032022552221086
+        -1.869479503343496,-56.03211173004561 -1.867386728583877,-56.03164963435117
+        -1.852281763037023,-56.10089004120602 -1.8522817630370236,-56.10089004120602
+        -1.819437383056602,-56.25144703689632 -1.821159899371941,-56.25182733959092
+        -1.821122527911802,-56.252003897827045 -1.821797907832863,-56.252153075621024
+        -1.821330048590985,-56.254359019316965 -1.821498457488793,-56.254396237549386
+        -1.809087759552743,-56.313010951561246 -1.779538239293636,-56.452570925391896
+        -1.779076214073566,-56.4524686371733 -1.779073433442332,-56.45248176556069
+        -1.776568039949187,-56.45192702864299 -1.763036693459855,-56.51954500656288
+        -1.732128814453506,-56.67457039474354 -1.733489685543467,-56.674871610536016
+        -1.733460973071886,-56.675018518526514 -1.734368275755256,-56.67521961540847
+        -1.734287638645929,-56.6756301656782 -1.734981711343568,-56.67578411149617
+        -1.734487050395012,-56.67829069552206 -1.734531036683981,-56.67830044559976
+        -1.71398449266429,-56.782182833859856 -1.695106733595187,-56.87784166738072
+        -1.69507596952691,-56.877834832132976 -1.694448098534272,-56.88101508767961
+        -1.694437273289858,-56.88101268234991 -1.694418300357616,-56.881108608628885
+        -1.691825549967701,-56.88053217161464 -1.689358533922381,-56.894085757923456
+        -1.6860846593066794,-56.912249441198064</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T064353_R110_V20160803T141306_20160803T141306"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-56.912249441198064
+        -1.6860846593066794,-56.912249441198064 -1.686084659306679,-57.109735150752655
+        -1.650489265921988,-57.10998652112892 -1.651625394025902,-57.110359276713545
+        -1.65155858842172,-57.11066216079392 -1.65292581108755,-57.111328304389886
+        -1.652805439186362,-57.11143650299973 -1.653293555072624,-57.11421072648185
+        -1.652788443712216,-57.114273754459234 -1.653072006890655,-57.11444455760737
+        -1.65304087302649,-57.114538797804805 -1.653464724438978,-57.33140084818868
+        -1.613803224199209,-57.36413625681878 -1.76185631349503,-57.381611242058334
+        -1.841175117518927,-57.3968873399177 -1.910513191099343,-57.4297043598723
+        -2.059165282559448,-57.46248362625659 -2.207881101907123,-57.49537506457361
+        -2.356521876871973,-57.52830623836121 -2.505099658082077,-57.56133729395739
+        -2.653561295410118,-57.59445693630039 -2.801925662898893,-57.59456587683951
+        -2.802413287900686,-57.00017994874974 -2.802620426824397,-57.000179948754
+        -2.80265440098957,-56.956182024719375 -2.8026357597624734,-56.912185042742124
+        -2.802651092372252,-56.912185044824206 -2.802617118935394,-56.10029356487891
+        -2.8022731333090847,-56.100293543551295 -2.802307101216853,-56.05629195689356
+        -2.802254490521156,-56.01231065560888 -2.802235856336857,-56.01231067901114
+        -2.8022019041077386,-55.20117067407488 -2.801232060899604,-55.20117063124223
+        -2.801266185267337,-55.15690643373674 -2.801179136160849,-55.1126820721084
+        -2.801126259103253,-55.11268211700687 -2.8010921654831153,-54.88778764413379
+        -2.800649892404172,-54.883643235028096 -2.781540605123434,-54.85113303670798
+        -2.632846605440135,-54.81836359862148 -2.484214238999345,-54.785794597431085
+        -2.335565096119548,-54.75344100688873 -2.18797798429044,-54.983086107947194
+        -2.124736084867648,-54.98334940414832 -2.125931896104595,-54.98475113394037
+        -2.125572511133421,-54.98475783046616 -2.12560291685151,-54.98514770745604
+        -2.125503327430271,-54.98518422419907 -2.125669199696302,-55.188878498246645
+        -2.073538013294078,-55.18863031473361 -2.07241032519529,-55.18881867374156
+        -2.072361753293438,-55.18878816506969 -2.072222959935133,-55.18899026290048
+        -2.072170745932346,-55.188900291198095 -2.071761237593389,-55.1890746593132
+        -2.071716034215931,-55.18899567395608 -2.071356770997637,-55.18914279976444
+        -2.071318557714422,-55.18909809675707 -2.071115056735903,-55.189342514537095
+        -2.071051450765665,-55.18925725559339 -2.070663122182747,-55.20209180107523
+        -2.067378945204443,-55.41214246218941 -2.013629979455324,-55.412536268609024
+        -2.015418472199542,-55.414233559064144 -2.015009145736666,-55.41427501352073
+        -2.015197290115801,-55.414520525240704 -2.015138194357366,-55.414529905342015
+        -2.015180772547485,-55.5835799128607 -1.974444850948006,-55.612950540659455
+        -1.967375210746483,-55.61294890998272 -1.96736781391158,-55.61313664219915
+        -1.967322576144587,-55.61272818668188 -1.965469600173469,-55.61275082411494
+        -1.965464097511077,-55.61273126614072 -1.965375212877448,-55.61289095581572
+        -1.965336352110671,-55.612750192358725 -1.964696284473799,-55.832753990952334
+        -1.912579116953623,-55.83320768047088 -1.914636398595533,-55.83508504938073
+        -1.914211040447795,-55.835208743489645 -1.91477157730764,-56.01295586615691
+        -1.8745450875238008,-56.01295586615691 -1.8745450875238,-56.03217615849654
+        -1.870195284939992,-56.032022552221086 -1.869499690735885,-56.03211173004561
+        -1.869479503343496,-56.03164963435117 -1.867386728583877,-56.10089004120602
+        -1.852281763037023,-56.10089004120602 -1.8522817630370236,-56.25144703689632
+        -1.819437383056602,-56.25182733959092 -1.821159899371941,-56.252003897827045
+        -1.821122527911802,-56.252153075621024 -1.821797907832863,-56.254359019316965
+        -1.821330048590985,-56.254396237549386 -1.821498457488793,-56.313010951561246
+        -1.809087759552743,-56.452570925391896 -1.779538239293636,-56.4524686371733
+        -1.779076214073566,-56.45248176556069 -1.779073433442332,-56.45192702864299
+        -1.776568039949187,-56.51954500656288 -1.763036693459855,-56.67457039474354
+        -1.732128814453506,-56.674871610536016 -1.733489685543467,-56.675018518526514
+        -1.733460973071886,-56.67521961540847 -1.734368275755256,-56.6756301656782
+        -1.734287638645929,-56.67578411149617 -1.734981711343568,-56.67829069552206
+        -1.734487050395012,-56.67830044559976 -1.734531036683981,-56.782182833859856
+        -1.71398449266429,-56.87784166738072 -1.695106733595187,-56.877834832132976
+        -1.69507596952691,-56.88101508767961 -1.694448098534272,-56.88101268234991
+        -1.694437273289858,-56.881108608628885 -1.694418300357616,-56.88053217161464
+        -1.691825549967701,-56.894085757923456 -1.689358533922381,-56.912249441198064
+        -1.6860846593066794))"},{"name":"s2datatakeid","content":"GS2A_20160803T141312_005827_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"1.73
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193806_R010_V20161015T142322_20161015T142317","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f6380619-6c3f-46bf-af74-b74c6a55ee6c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f6380619-6c3f-46bf-af74-b74c6a55ee6c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f6380619-6c3f-46bf-af74-b74c6a55ee6c'')/Products(''Quicklook'')/$value"}],"id":"f6380619-6c3f-46bf-af74-b74c6a55ee6c","summary":"Date:
+        2016-10-15T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        102.04 MB","date":[{"name":"ingestiondate","content":"2016-10-16T19:52:26.381Z"},{"name":"beginposition","content":"2016-10-15T14:23:22Z"},{"name":"endposition","content":"2016-10-15T14:23:17Z"}],"int":[{"name":"orbitnumber","content":"6871"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.2211"},"str":[{"name":"uuid","content":"f6380619-6c3f-46bf-af74-b74c6a55ee6c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193806_R010_V20161015T142322_20161015T142317.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.798966385435297,-60.09541592080038
+        -2.677765400871859,-60.068509022491966 -2.529767284392644,-60.03550398499264
+        -2.569436651477111,-59.819016694782256 -2.569044718095187,-59.81892996795908
+        -2.569125471720553,-59.8184877313173 -2.56883531074019,-59.81842347897812
+        -2.569374463627945,-59.81546703019047 -2.568895900000112,-59.81536098358001
+        -2.568951276817252,-59.815055071298445 -2.567645750046538,-59.81476620479398
+        -2.567789727899592,-59.81396429522115 -2.56684042739517,-59.81375396604502
+        -2.608161357546825,-59.58498560150654 -2.610464597952098,-59.58549533521873
+        -2.61054243667285,-59.58510184457595 -2.610581181053087,-59.58511043151774
+        -2.611236395005303,-59.58179225663756 -2.611266016201589,-59.58179882266673
+        -2.644007541365484,-59.41592890045646 -2.650621645760278,-59.3824932508908
+        -2.650608088284911,-59.38249025645346 -2.651170112134598,-59.3796430203592
+        -2.6505091417208,-59.37949697453256 -2.65051818677036,-59.37945094497835 -2.649670595423973,-59.37926395409495
+        -2.64978329772328,-59.37868761602735 -2.648660786599194,-59.37843954862177
+        -2.661128322634104,-59.3159437166035 -2.7968320051609,-59.31559501298386 -2.798966385435297,-60.09541592080038
+        -2.798966385435297,-60.09541592080038</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193806_R010_V20161015T142322_20161015T142317"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.09541592080038 -2.798966385435297,-60.068509022491966
+        -2.677765400871859,-60.03550398499264 -2.529767284392644,-59.819016694782256
+        -2.569436651477111,-59.81892996795908 -2.569044718095187,-59.8184877313173
+        -2.569125471720553,-59.81842347897812 -2.56883531074019,-59.81546703019047
+        -2.569374463627945,-59.81536098358001 -2.568895900000112,-59.815055071298445
+        -2.568951276817252,-59.81476620479398 -2.567645750046538,-59.81396429522115
+        -2.567789727899592,-59.81375396604502 -2.56684042739517,-59.58498560150654
+        -2.608161357546825,-59.58549533521873 -2.610464597952098,-59.58510184457595
+        -2.61054243667285,-59.58511043151774 -2.610581181053087,-59.58179225663756
+        -2.611236395005303,-59.58179882266673 -2.611266016201589,-59.41592890045646
+        -2.644007541365484,-59.3824932508908 -2.650621645760278,-59.38249025645346
+        -2.650608088284911,-59.3796430203592 -2.651170112134598,-59.37949697453256
+        -2.6505091417208,-59.37945094497835 -2.65051818677036,-59.37926395409495 -2.649670595423973,-59.37868761602735
+        -2.64978329772328,-59.37843954862177 -2.648660786599194,-59.3159437166035
+        -2.661128322634104,-59.31559501298386 -2.7968320051609,-60.09541592080038
+        -2.798966385435297,-60.09541592080038 -2.798966385435297))"},{"name":"s2datatakeid","content":"GS2A_20161015T142322_006871_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"102.04
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220018_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d00208e7-c13e-48da-9b30-5302f0d5c823'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d00208e7-c13e-48da-9b30-5302f0d5c823'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d00208e7-c13e-48da-9b30-5302f0d5c823'')/Products(''Quicklook'')/$value"}],"id":"d00208e7-c13e-48da-9b30-5302f0d5c823","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        614.24 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:12:23.557Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.25"},"str":[{"name":"uuid","content":"d00208e7-c13e-48da-9b30-5302f0d5c823"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220018_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.904256732085073,-62.101251151937454
+        -0.903875955648899,-61.114689730255705 -1.896723233843827,-61.11389599692503
+        -1.897522484501646,-62.100872558955864 -0.904256732085073,-62.101251151937454
+        -0.904256732085073,-62.101251151937454</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220018_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.101251151937454
+        -0.904256732085073,-61.114689730255705 -0.903875955648899,-61.11389599692503
+        -1.896723233843827,-62.100872558955864 -1.897522484501646,-62.101251151937454
+        -0.904256732085073,-62.101251151937454 -0.904256732085073))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"614.24
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160727T191859_R010_V20160727T142326_20160727T142326","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''54d999cf-b953-4cf2-b148-68e9e518ea4f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''54d999cf-b953-4cf2-b148-68e9e518ea4f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''54d999cf-b953-4cf2-b148-68e9e518ea4f'')/Products(''Quicklook'')/$value"}],"id":"54d999cf-b953-4cf2-b148-68e9e518ea4f","summary":"Date:
+        2016-07-27T14:23:26Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        596.03 MB","date":[{"name":"ingestiondate","content":"2016-07-27T23:06:13.373Z"},{"name":"beginposition","content":"2016-07-27T14:23:26Z"},{"name":"endposition","content":"2016-07-27T14:23:26Z"}],"int":[{"name":"orbitnumber","content":"5727"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.2547333333333333"},"str":[{"name":"uuid","content":"54d999cf-b953-4cf2-b148-68e9e518ea4f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160727T191859_R010_V20160727T142326_20160727T142326.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.7860520822395385,-58.799184370351455
+        -2.748355514641529,-58.971921307520326 -2.749601091698336,-58.97219519459416
+        -2.749557554948416,-58.97240113189071 -2.750262535781412,-58.97255597336516
+        -2.750245077886669,-58.972638383106315 -2.75091145244562,-58.97278488407336
+        -2.750430951687926,-58.9750483188196 -2.750616608551828,-58.975089076090725
+        -2.712141103521456,-59.156580936939925 -2.711148939858159,-59.69820496206522
+        -3.000867112397821,-59.6989653518891 -3.001392379876331,-59.696006541321005
+        -3.002092044133554,-59.696161427863245 -3.002496828072319,-59.69389207660643
+        -3.003226551375936,-59.69405518010494 -3.003247481899026,-59.693938651728985
+        -3.005151590781848,-59.69436072295332 -3.049255908369305,-59.46894227209764
+        -3.047102749488145,-59.46846317236939 -3.047127140681824,-59.468339835810674
+        -3.047037539987824,-59.46831999252919 -3.086514437265176,-59.26843001584578
+        -3.087004239713479,-59.26853832546782 -3.087428297804199,-59.26639865274629
+        -3.088132155924769,-59.26655590383427 -3.088169598435498,-59.266367623014254
+        -3.089767887403561,-59.266721497450014 -3.136361123705435,-59.04627857333516
+        -3.134221715612425,-59.04580446706474 -3.134247189364947,-59.04568754647071
+        -3.134115433562038,-59.045658491865815 -3.176987884267224,-58.84883912392687
+        -3.177654857605959,-58.848986007036494 -3.178083253228948,-58.8470202576987
+        -3.178503143882553,-58.84711363540916 -3.178555106847948,-58.846875342409525
+        -3.179366315331282,-58.84705412353748 -3.209970740138917,-58.71193684424249
+        -3.209970740138916,-58.71193684424249 -3.228972646302269,-58.62804420850929
+        -3.227483873230541,-58.6277148772893 -3.227510468902322,-58.62760304381662
+        -3.227309230388423,-58.62755876645701 -3.274142066731425,-58.43077693269098
+        -3.274614590068184,-58.430880730418686 -3.275037945556924,-58.42909923226088
+        -3.275537732618843,-58.42921009145404 -3.275613670982724,-58.42889002354298
+        -3.276694447088384,-58.429127703823674 -3.330195839861518,-58.2081680288204
+        -3.328361800473598,-58.207763682861994 -3.328385454241266,-58.20767201049422
+        -3.328337370138689,-58.20766146193851 -3.353820205784081,-58.109097274735525
+        -3.379920759778986,-58.00794215989698 -3.379970095906968,-58.007953010365725
+        -3.379995776317013,-58.00785368198727 -3.380340011738218,-58.00792907449597
+        -3.380821003517933,-58.00606173521784 -3.381171540017488,-58.006139271750826
+        -3.381271478479638,-58.00574979501972 -3.381390217203484,-58.00577586387092
+        -3.381398086170577,-58.00574506634885 -3.38195941539495,-58.005869096552416
+        -3.432152937626066,-57.8120486614793 -3.4321529376260647,-57.8120486614793
+        -3.439738638643811,-57.782756756742586 -3.440583368371469,-57.77968246562504
+        -3.438881181509928,-57.77930741286881 -3.500985638598513,-57.556476677603904
+        -3.413484676521393,-57.537304772264335 -3.264808391912054,-57.50484977496711
+        -3.116939592495079,-57.47265546055139 -3.053712093449041,-57.70260486711159
+        -3.055086526312516,-57.702904634438 -3.054673491261925,-57.70451772489823
+        -3.054684413764881,-57.70452010429628 -3.054618585199178,-57.70477818012788
+        -3.054803467418738,-57.70481845700344 -3.0274804001187063,-57.811729131570885
+        -3.027480400118706,-57.811729131570885 -3.0185278552882804,-57.84675896904872
+        -3.004856010072952,-57.90025465379385 -3.0048560100729524,-57.90025465379385
+        -3.002700914093451,-57.90868719038998 -3.001598680724995,-57.90844666845618
+        -3.001562994052521,-57.908585244717855 -3.001410092269989,-57.90855188547846
+        -3.001389179292392,-57.908632936291966 -3.000981009053779,-57.90854383435055
+        -3.000910040903306,-57.908817935459645 -3.000553735918373,-57.90874008231593
+        -3.00051924264845,-57.9088730549644 -3.000294030565108,-57.90882386113712
+        -3.000256779231528,-57.908967187500615 -2.99969084576446,-57.908843607505375
+        -2.942631729950926,-58.13205362367859 -2.94460603288033,-58.13248539473989
+        -2.94415055024515,-58.134375270127606 -2.944325240548796,-58.134413424663194
+        -2.944297901518101,-58.13452708357098 -2.944355150666089,-58.134539590089176
+        -2.896489801571379,-58.33331343429104 -2.894539698250777,-58.332886975352416
+        -2.894539605921161,-58.33288735502394 -2.893725085020073,-58.33270913792697
+        -2.841541183907823,-58.55304628889258 -2.843803428444923,-58.553542060572966
+        -2.843335944390534,-58.55560557406276 -2.843892276240271,-58.555727321145575
+        -2.79928625380438,-58.75283651830932 -2.796308993542353,-58.75218413780629
+        -2.786052082239538,-58.799184370351455 -2.7860520822395385,-58.799184370351455</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160727T191859_R010_V20160727T142326_20160727T142326"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.799184370351455
+        -2.7860520822395385,-58.971921307520326 -2.748355514641529,-58.97219519459416
+        -2.749601091698336,-58.97240113189071 -2.749557554948416,-58.97255597336516
+        -2.750262535781412,-58.972638383106315 -2.750245077886669,-58.97278488407336
+        -2.75091145244562,-58.9750483188196 -2.750430951687926,-58.975089076090725
+        -2.750616608551828,-59.156580936939925 -2.712141103521456,-59.69820496206522
+        -2.711148939858159,-59.6989653518891 -3.000867112397821,-59.696006541321005
+        -3.001392379876331,-59.696161427863245 -3.002092044133554,-59.69389207660643
+        -3.002496828072319,-59.69405518010494 -3.003226551375936,-59.693938651728985
+        -3.003247481899026,-59.69436072295332 -3.005151590781848,-59.46894227209764
+        -3.049255908369305,-59.46846317236939 -3.047102749488145,-59.468339835810674
+        -3.047127140681824,-59.46831999252919 -3.047037539987824,-59.26843001584578
+        -3.086514437265176,-59.26853832546782 -3.087004239713479,-59.26639865274629
+        -3.087428297804199,-59.26655590383427 -3.088132155924769,-59.266367623014254
+        -3.088169598435498,-59.266721497450014 -3.089767887403561,-59.04627857333516
+        -3.136361123705435,-59.04580446706474 -3.134221715612425,-59.04568754647071
+        -3.134247189364947,-59.045658491865815 -3.134115433562038,-58.84883912392687
+        -3.176987884267224,-58.848986007036494 -3.177654857605959,-58.8470202576987
+        -3.178083253228948,-58.84711363540916 -3.178503143882553,-58.846875342409525
+        -3.178555106847948,-58.84705412353748 -3.179366315331282,-58.71193684424249
+        -3.209970740138917,-58.71193684424249 -3.209970740138916,-58.62804420850929
+        -3.228972646302269,-58.6277148772893 -3.227483873230541,-58.62760304381662
+        -3.227510468902322,-58.62755876645701 -3.227309230388423,-58.43077693269098
+        -3.274142066731425,-58.430880730418686 -3.274614590068184,-58.42909923226088
+        -3.275037945556924,-58.42921009145404 -3.275537732618843,-58.42889002354298
+        -3.275613670982724,-58.429127703823674 -3.276694447088384,-58.2081680288204
+        -3.330195839861518,-58.207763682861994 -3.328361800473598,-58.20767201049422
+        -3.328385454241266,-58.20766146193851 -3.328337370138689,-58.109097274735525
+        -3.353820205784081,-58.00794215989698 -3.379920759778986,-58.007953010365725
+        -3.379970095906968,-58.00785368198727 -3.379995776317013,-58.00792907449597
+        -3.380340011738218,-58.00606173521784 -3.380821003517933,-58.006139271750826
+        -3.381171540017488,-58.00574979501972 -3.381271478479638,-58.00577586387092
+        -3.381390217203484,-58.00574506634885 -3.381398086170577,-58.005869096552416
+        -3.38195941539495,-57.8120486614793 -3.432152937626066,-57.8120486614793 -3.4321529376260647,-57.782756756742586
+        -3.439738638643811,-57.77968246562504 -3.440583368371469,-57.77930741286881
+        -3.438881181509928,-57.556476677603904 -3.500985638598513,-57.537304772264335
+        -3.413484676521393,-57.50484977496711 -3.264808391912054,-57.47265546055139
+        -3.116939592495079,-57.70260486711159 -3.053712093449041,-57.702904634438
+        -3.055086526312516,-57.70451772489823 -3.054673491261925,-57.70452010429628
+        -3.054684413764881,-57.70477818012788 -3.054618585199178,-57.70481845700344
+        -3.054803467418738,-57.811729131570885 -3.0274804001187063,-57.811729131570885
+        -3.027480400118706,-57.84675896904872 -3.0185278552882804,-57.90025465379385
+        -3.004856010072952,-57.90025465379385 -3.0048560100729524,-57.90868719038998
+        -3.002700914093451,-57.90844666845618 -3.001598680724995,-57.908585244717855
+        -3.001562994052521,-57.90855188547846 -3.001410092269989,-57.908632936291966
+        -3.001389179292392,-57.90854383435055 -3.000981009053779,-57.908817935459645
+        -3.000910040903306,-57.90874008231593 -3.000553735918373,-57.9088730549644
+        -3.00051924264845,-57.90882386113712 -3.000294030565108,-57.908967187500615
+        -3.000256779231528,-57.908843607505375 -2.99969084576446,-58.13205362367859
+        -2.942631729950926,-58.13248539473989 -2.94460603288033,-58.134375270127606
+        -2.94415055024515,-58.134413424663194 -2.944325240548796,-58.13452708357098
+        -2.944297901518101,-58.134539590089176 -2.944355150666089,-58.33331343429104
+        -2.896489801571379,-58.332886975352416 -2.894539698250777,-58.33288735502394
+        -2.894539605921161,-58.33270913792697 -2.893725085020073,-58.55304628889258
+        -2.841541183907823,-58.553542060572966 -2.843803428444923,-58.55560557406276
+        -2.843335944390534,-58.555727321145575 -2.843892276240271,-58.75283651830932
+        -2.79928625380438,-58.75218413780629 -2.796308993542353,-58.799184370351455
+        -2.786052082239538,-58.799184370351455 -2.7860520822395385))"},{"name":"s2datatakeid","content":"GS2A_20160727T142332_005727_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"596.03
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164222_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''333bb323-3e8a-46df-a8ad-2398a7e8b2b8'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''333bb323-3e8a-46df-a8ad-2398a7e8b2b8'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''333bb323-3e8a-46df-a8ad-2398a7e8b2b8'')/Products(''Quicklook'')/$value"}],"id":"333bb323-3e8a-46df-a8ad-2398a7e8b2b8","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        77.49 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:38:33.66Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.264"},"str":[{"name":"uuid","content":"333bb323-3e8a-46df-a8ad-2398a7e8b2b8"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164222_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.993275531734507,-62.21130198920302
+        -0.929802146898312,-62.19726130779766 -0.781065029722639,-62.16443668766816
+        -0.632406219118014,-62.131703455631815 -0.49206513731478,-62.10081083410424
+        -0.483559119663311,-62.09893450675754 -0.463507526857866,-62.09452325275858
+        -0.33515730355075,-62.06626170094086 -0.186577212254185,-62.03348893381526
+        -0.09582631457351,-62.013469722026784 -0.993245791526875,-62.01333665746029
+        -0.993275531734507,-62.21130198920302 -0.993275531734507,-62.21130198920302</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164222_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.21130198920302 -0.993275531734507,-62.19726130779766
+        -0.929802146898312,-62.16443668766816 -0.781065029722639,-62.131703455631815
+        -0.632406219118014,-62.10081083410424 -0.49206513731478,-62.09893450675754
+        -0.483559119663311,-62.09452325275858 -0.463507526857866,-62.06626170094086
+        -0.33515730355075,-62.03348893381526 -0.186577212254185,-62.013469722026784
+        -0.09582631457351,-62.01333665746029 -0.993245791526875,-62.21130198920302
+        -0.993275531734507,-62.21130198920302 -0.993275531734507))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"77.49
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225433_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5120dc19-cafe-4f93-8a9a-844d7dd70c6d'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5120dc19-cafe-4f93-8a9a-844d7dd70c6d'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5120dc19-cafe-4f93-8a9a-844d7dd70c6d'')/Products(''Quicklook'')/$value"}],"id":"5120dc19-cafe-4f93-8a9a-844d7dd70c6d","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        83.19 MB","date":[{"name":"ingestiondate","content":"2016-09-28T23:02:20.722Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.2829"},"str":[{"name":"uuid","content":"5120dc19-cafe-4f93-8a9a-844d7dd70c6d"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225433_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.903483671344604,-59.49544366401566
+        -0.942163808181498,-59.503857841941446 -1.090798435629983,-59.53642193822896
+        -1.239372324355128,-59.568972070497054 -1.387867942090785,-59.60160424194908
+        -1.536229233054455,-59.63440507484706 -1.68476392238876,-59.66676648883468
+        -1.820797627378976,-59.69658425101958 -0.903361498199144,-59.695535795558214
+        -0.903483671344604,-59.49544366401566 -0.903483671344604,-59.49544366401566</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225433_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.49544366401566 -0.903483671344604,-59.503857841941446
+        -0.942163808181498,-59.53642193822896 -1.090798435629983,-59.568972070497054
+        -1.239372324355128,-59.60160424194908 -1.387867942090785,-59.63440507484706
+        -1.536229233054455,-59.66676648883468 -1.68476392238876,-59.69658425101958
+        -1.820797627378976,-59.695535795558214 -0.903361498199144,-59.49544366401566
+        -0.903483671344604,-59.49544366401566 -0.903483671344604))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"83.19
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205908_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6e0b21e7-c682-4ff2-bb05-fe98c8a07fcd'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6e0b21e7-c682-4ff2-bb05-fe98c8a07fcd'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6e0b21e7-c682-4ff2-bb05-fe98c8a07fcd'')/Products(''Quicklook'')/$value"}],"id":"6e0b21e7-c682-4ff2-bb05-fe98c8a07fcd","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        588.47 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:26:12.612Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.2924"},"str":[{"name":"uuid","content":"6e0b21e7-c682-4ff2-bb05-fe98c8a07fcd"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205908_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-66.30515631259404
+        0,-65.31996054306997 -0.991331687867875,-65.31941256579155 -0.992287945780174,-66.30475452350714
+        0,-66.30515631259404 0,-66.30515631259404</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205908_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-66.30515631259404 0,-65.31996054306997
+        0,-65.31941256579155 -0.991331687867875,-66.30475452350714 -0.992287945780174,-66.30515631259404
+        0,-66.30515631259404 0))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"588.47
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160727T200421_R010_V20160727T142330_20160727T142330","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a3a69c4f-2bb1-4153-ae5f-5a08377cc544'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a3a69c4f-2bb1-4153-ae5f-5a08377cc544'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a3a69c4f-2bb1-4153-ae5f-5a08377cc544'')/Products(''Quicklook'')/$value"}],"id":"a3a69c4f-2bb1-4153-ae5f-5a08377cc544","summary":"Date:
+        2016-07-27T14:23:30Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        1.96 GB","date":[{"name":"ingestiondate","content":"2016-07-27T23:10:25.582Z"},{"name":"beginposition","content":"2016-07-27T14:23:30Z"},{"name":"endposition","content":"2016-07-27T14:23:30Z"}],"int":[{"name":"orbitnumber","content":"5727"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.3291"},"str":[{"name":"uuid","content":"a3a69c4f-2bb1-4153-ae5f-5a08377cc544"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160727T200421_R010_V20160727T142330_20160727T142330.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.945214464723971,-59.45610226796373
+        -3.97587038822427,-59.311000441271595 -3.975870388224269,-59.311000441271595
+        -3.991849221553863,-59.23536879688448 -3.989414960776083,-59.234831576501776
+        -4.032296653432473,-59.03779192545504 -4.032459037856555,-59.03782771649784
+        -4.032464072819334,-59.03780458698226 -4.032919539934513,-59.03790468464257
+        -4.032940996560039,-59.03780615389683 -4.032989017756024,-59.037816690552994
+        -4.033443027349744,-59.03573163174147 -4.034846750485285,-59.03603968717861
+        -4.084490351479197,-58.81667793589176 -4.082619550978238,-58.81626614832866
+        -4.107006726548541,-58.713640805747154 -4.10700672654854,-58.713640805747154
+        -4.129433132869008,-58.619266710441394 -4.129624096219573,-58.619308675988655
+        -4.129630124858542,-58.6192832882163 -4.129914669086591,-58.619345643038365
+        -4.13038803845556,-58.61735086258902 -4.131147452912892,-58.61751704556137
+        -4.131175494202131,-58.61739843321868 -4.132192548967025,-58.61762136988092
+        -4.18569150390656,-58.39633077904892 -4.183616861857668,-58.39587530049966
+        -4.220693217014779,-58.25220290085153 -4.235208297840847,-58.19584517245087
+        -4.235582764961074,-58.1959270903511 -4.236123736998409,-58.19382304621464
+        -4.236440427817029,-58.19389217872124 -4.23645910320006,-58.19381926026273
+        -4.236609555857184,-58.19385224209865 -4.236663402436925,-58.193641116601206
+        -4.237430488985433,-58.19380884372286 -4.29596454409904,-57.96734273217746
+        -4.294198181246456,-57.96695573138854 -4.29420991693923,-57.9669136250893
+        -4.294132701991173,-57.96689675421111 -4.312299022521748,-57.90156112246214
+        -4.336946953226968,-57.81291421560943 -4.356071004405667,-57.7441340813353
+        -4.220988904521057,-57.714608499544255 -4.072479096245393,-57.681957110005854
+        -3.924088036071911,-57.649341227197766 -3.775737936609473,-57.61674432960978
+        -3.707215066496256,-57.601653816068044 -3.627384502753227,-57.58407305505763
+        -3.478854276321882,-57.551615925860126 -3.331220037488175,-57.51935671798436
+        -3.267993669980101,-57.749373084467386 -3.269075438191028,-57.74960911820396
+        -3.268602950027699,-57.75145508170414 -3.268767132008132,-57.75149088770455
+        -3.230709072374195,-57.9004524392063 -3.6180222056692726,-57.900791619410604
+        -3.616848574177958,-58.71261420771363 -3.033190317672156,-58.71164254312659
+        -3.013261136054951,-58.79973931179431 -3.010587862385217,-58.79915224667162
+        -2.962623246702396,-59.019014199912135 -2.963640011568585,-59.01923815099057
+        -2.963602098248116,-59.01941752652813 -2.964267472934122,-59.019564070106405
+        -2.96424756137485,-59.01965809022475 -2.96488598317793,-59.01979849724163
+        -2.964411663062211,-59.02203371706812 -2.964564303228152,-59.022067262793975
+        -2.92253206230501,-59.220460709622365 -2.922047942258788,-59.220354070380615
+        -2.922017105836557,-59.22049958141163 -2.919685010680969,-59.21998581677216
+        -2.9006181338423693,-59.31517842410082 -2.900618133842369,-59.31517842410082
+        -2.892668566879801,-59.3548671477815 -2.875157641411163,-59.442616655242645
+        -2.876504695248683,-59.44291412323149 -2.876432606403632,-59.4432825482195
+        -2.877294873562879,-59.443472898445634 -2.877231049623046,-59.443797527906405
+        -2.877883424557454,-59.44394131078824 -2.877362137911285,-59.446580510204974
+        -2.877363539625154,-59.44658081913454 -2.876681435205707,-59.450026810233446
+        -2.837934960588945,-59.64619464603097 -2.837885166062844,-59.646183650201856
+        -2.837245421229112,-59.64942124967944 -2.837214370358803,-59.64941439706742
+        -2.837164561338402,-59.649666032207215 -2.834740625822576,-59.64913090660608
+        -2.826991718505546,-59.69160829816253 -2.793293412837095,-59.8781123151571
+        -2.794442475218082,-59.878366073691645 -2.79433356880352,-59.8789722296939
+        -2.795662626666201,-59.87926567492941 -2.795560145311955,-59.87983149435971
+        -2.796011130571653,-59.879930909057705 -2.795485105373793,-59.88281350350406
+        -2.795754825919833,-59.88287295995724 -2.795696560597531,-59.8831919123553
+        -2.796101895307176,-59.88328133884399 -2.756404888372362,-60.09989542000485
+        -2.904261639602721,-60.13291449483005 -3.052597181038808,-60.1660414922216
+        -3.20103287603882,-60.19900467502149 -3.349430566557731,-60.232177351684754
+        -3.497966078795119,-60.26523785464074 -3.614415568752822,-60.29108074985884
+        -3.614450674430159,-60.291088540638704 -3.646542794301208,-60.298210540842014
+        -3.653186220103897,-60.29968238118381 -3.653186220103903,-60.29968238118381
+        -3.780294454599981,-60.32784300687026 -3.801276332016826,-60.211203562158694
+        -3.801276332016825,-60.211203562158694 -3.822467249731403,-60.0934020505946
+        -3.82213844390087,-60.09332909341219 -3.822166859407266,-60.09317343534595
+        -3.822035515934778,-60.09314429900696 -3.822055471585073,-60.09303469552536
+        -3.820336401785011,-60.09265396735721 -3.820344968034056,-60.09260589172076
+        -3.819888845638499,-60.09250461570474 -3.85658294441639,-59.88592611459144
+        -3.85727931365941,-59.88608051260292 -3.857726127857261,-59.883576124872896
+        -3.860491909745857,-59.88418661775219 -3.8962493537252825,-59.701492185900406
+        -3.896249353725283,-59.701492185900406 -3.904664837864827,-59.65849520618014
+        -3.902275214509469,-59.65796634415775 -3.941787673061249,-59.45783013750594
+        -3.94194808778821,-59.45786557768326 -3.941951911871185,-59.45784623503549
+        -3.942285662889833,-59.45791976509581 -3.942753070855688,-59.45556068874827
+        -3.945214464723971,-59.45610226796373</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160727T200421_R010_V20160727T142330_20160727T142330"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.45610226796373 -3.945214464723971,-59.311000441271595
+        -3.97587038822427,-59.311000441271595 -3.975870388224269,-59.23536879688448
+        -3.991849221553863,-59.234831576501776 -3.989414960776083,-59.03779192545504
+        -4.032296653432473,-59.03782771649784 -4.032459037856555,-59.03780458698226
+        -4.032464072819334,-59.03790468464257 -4.032919539934513,-59.03780615389683
+        -4.032940996560039,-59.037816690552994 -4.032989017756024,-59.03573163174147
+        -4.033443027349744,-59.03603968717861 -4.034846750485285,-58.81667793589176
+        -4.084490351479197,-58.81626614832866 -4.082619550978238,-58.713640805747154
+        -4.107006726548541,-58.713640805747154 -4.10700672654854,-58.619266710441394
+        -4.129433132869008,-58.619308675988655 -4.129624096219573,-58.6192832882163
+        -4.129630124858542,-58.619345643038365 -4.129914669086591,-58.61735086258902
+        -4.13038803845556,-58.61751704556137 -4.131147452912892,-58.61739843321868
+        -4.131175494202131,-58.61762136988092 -4.132192548967025,-58.39633077904892
+        -4.18569150390656,-58.39587530049966 -4.183616861857668,-58.25220290085153
+        -4.220693217014779,-58.19584517245087 -4.235208297840847,-58.1959270903511
+        -4.235582764961074,-58.19382304621464 -4.236123736998409,-58.19389217872124
+        -4.236440427817029,-58.19381926026273 -4.23645910320006,-58.19385224209865
+        -4.236609555857184,-58.193641116601206 -4.236663402436925,-58.19380884372286
+        -4.237430488985433,-57.96734273217746 -4.29596454409904,-57.96695573138854
+        -4.294198181246456,-57.9669136250893 -4.29420991693923,-57.96689675421111
+        -4.294132701991173,-57.90156112246214 -4.312299022521748,-57.81291421560943
+        -4.336946953226968,-57.7441340813353 -4.356071004405667,-57.714608499544255
+        -4.220988904521057,-57.681957110005854 -4.072479096245393,-57.649341227197766
+        -3.924088036071911,-57.61674432960978 -3.775737936609473,-57.601653816068044
+        -3.707215066496256,-57.58407305505763 -3.627384502753227,-57.551615925860126
+        -3.478854276321882,-57.51935671798436 -3.331220037488175,-57.749373084467386
+        -3.267993669980101,-57.74960911820396 -3.269075438191028,-57.75145508170414
+        -3.268602950027699,-57.75149088770455 -3.268767132008132,-57.9004524392063
+        -3.230709072374195,-57.900791619410604 -3.6180222056692726,-58.71261420771363
+        -3.616848574177958,-58.71164254312659 -3.033190317672156,-58.79973931179431
+        -3.013261136054951,-58.79915224667162 -3.010587862385217,-59.019014199912135
+        -2.962623246702396,-59.01923815099057 -2.963640011568585,-59.01941752652813
+        -2.963602098248116,-59.019564070106405 -2.964267472934122,-59.01965809022475
+        -2.96424756137485,-59.01979849724163 -2.96488598317793,-59.02203371706812
+        -2.964411663062211,-59.022067262793975 -2.964564303228152,-59.220460709622365
+        -2.92253206230501,-59.220354070380615 -2.922047942258788,-59.22049958141163
+        -2.922017105836557,-59.21998581677216 -2.919685010680969,-59.31517842410082
+        -2.9006181338423693,-59.31517842410082 -2.900618133842369,-59.3548671477815
+        -2.892668566879801,-59.442616655242645 -2.875157641411163,-59.44291412323149
+        -2.876504695248683,-59.4432825482195 -2.876432606403632,-59.443472898445634
+        -2.877294873562879,-59.443797527906405 -2.877231049623046,-59.44394131078824
+        -2.877883424557454,-59.446580510204974 -2.877362137911285,-59.44658081913454
+        -2.877363539625154,-59.450026810233446 -2.876681435205707,-59.64619464603097
+        -2.837934960588945,-59.646183650201856 -2.837885166062844,-59.64942124967944
+        -2.837245421229112,-59.64941439706742 -2.837214370358803,-59.649666032207215
+        -2.837164561338402,-59.64913090660608 -2.834740625822576,-59.69160829816253
+        -2.826991718505546,-59.8781123151571 -2.793293412837095,-59.878366073691645
+        -2.794442475218082,-59.8789722296939 -2.79433356880352,-59.87926567492941
+        -2.795662626666201,-59.87983149435971 -2.795560145311955,-59.879930909057705
+        -2.796011130571653,-59.88281350350406 -2.795485105373793,-59.88287295995724
+        -2.795754825919833,-59.8831919123553 -2.795696560597531,-59.88328133884399
+        -2.796101895307176,-60.09989542000485 -2.756404888372362,-60.13291449483005
+        -2.904261639602721,-60.1660414922216 -3.052597181038808,-60.19900467502149
+        -3.20103287603882,-60.232177351684754 -3.349430566557731,-60.26523785464074
+        -3.497966078795119,-60.29108074985884 -3.614415568752822,-60.291088540638704
+        -3.614450674430159,-60.298210540842014 -3.646542794301208,-60.29968238118381
+        -3.653186220103897,-60.29968238118381 -3.653186220103903,-60.32784300687026
+        -3.780294454599981,-60.211203562158694 -3.801276332016826,-60.211203562158694
+        -3.801276332016825,-60.0934020505946 -3.822467249731403,-60.09332909341219
+        -3.82213844390087,-60.09317343534595 -3.822166859407266,-60.09314429900696
+        -3.822035515934778,-60.09303469552536 -3.822055471585073,-60.09265396735721
+        -3.820336401785011,-60.09260589172076 -3.820344968034056,-60.09250461570474
+        -3.819888845638499,-59.88592611459144 -3.85658294441639,-59.88608051260292
+        -3.85727931365941,-59.883576124872896 -3.857726127857261,-59.88418661775219
+        -3.860491909745857,-59.701492185900406 -3.8962493537252825,-59.701492185900406
+        -3.896249353725283,-59.65849520618014 -3.904664837864827,-59.65796634415775
+        -3.902275214509469,-59.45783013750594 -3.941787673061249,-59.45786557768326
+        -3.94194808778821,-59.45784623503549 -3.941951911871185,-59.45791976509581
+        -3.942285662889833,-59.45556068874827 -3.942753070855688,-59.45610226796373
+        -3.945214464723971))"},{"name":"s2datatakeid","content":"GS2A_20160727T142332_005727_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"1.96
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003016_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''cfb6b62c-15fa-4139-9e2b-d622fc42eea5'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''cfb6b62c-15fa-4139-9e2b-d622fc42eea5'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''cfb6b62c-15fa-4139-9e2b-d622fc42eea5'')/Products(''Quicklook'')/$value"}],"id":"cfb6b62c-15fa-4139-9e2b-d622fc42eea5","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        507.23 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:06:23.457Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.3968"},"str":[{"name":"uuid","content":"cfb6b62c-15fa-4139-9e2b-d622fc42eea5"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003016_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.321708565898457,-61.11068374171924
+        -7.253398061821803,-61.095233629290725 -7.105116116711677,-61.061629611661125
+        -6.95676757772301,-61.02817183638405 -6.808388272339928,-60.994580709659886
+        -6.659914644828212,-60.96104575252234 -6.511307962252662,-60.927647967659766
+        -6.36266659378869,-60.89423431090301 -6.327995920744091,-60.886446279303094
+        -6.324952906139793,-60.200425599106595 -7.317011384941738,-60.19465494358095
+        -7.321708565898457,-61.11068374171924 -7.321708565898457,-61.11068374171924</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003016_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.11068374171924 -7.321708565898457,-61.095233629290725
+        -7.253398061821803,-61.061629611661125 -7.105116116711677,-61.02817183638405
+        -6.95676757772301,-60.994580709659886 -6.808388272339928,-60.96104575252234
+        -6.659914644828212,-60.927647967659766 -6.511307962252662,-60.89423431090301
+        -6.36266659378869,-60.886446279303094 -6.327995920744091,-60.200425599106595
+        -6.324952906139793,-60.19465494358095 -7.317011384941738,-61.11068374171924
+        -7.321708565898457,-61.11068374171924 -7.321708565898457))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"507.23
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164415_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''01fbb832-b177-4f15-bf6d-5358d87a14ab'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''01fbb832-b177-4f15-bf6d-5358d87a14ab'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''01fbb832-b177-4f15-bf6d-5358d87a14ab'')/Products(''Quicklook'')/$value"}],"id":"01fbb832-b177-4f15-bf6d-5358d87a14ab","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        191.92 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:39:17.711Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.3998"},"str":[{"name":"uuid","content":"01fbb832-b177-4f15-bf6d-5358d87a14ab"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164415_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.897588596151643,-62.411384447612484
+        -1.82088190783396,-62.39440242124713 -1.672439857262355,-62.36153753504541
+        -1.643557908423539,-62.35516093156875 -1.524185100487675,-62.3287174674008
+        -1.375711625723825,-62.29586545735825 -1.227164669103384,-62.2630512708942
+        -1.07850984679115,-62.2301563147696 -0.929802146898312,-62.19726130779766
+        -0.90425813880707,-62.19162403057929 -0.904233758344445,-62.01336187375579
+        -1.897474262556893,-62.01294627189677 -1.897588596151643,-62.411384447612484
+        -1.897588596151643,-62.411384447612484</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164415_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.411384447612484
+        -1.897588596151643,-62.39440242124713 -1.82088190783396,-62.36153753504541
+        -1.672439857262355,-62.35516093156875 -1.643557908423539,-62.3287174674008
+        -1.524185100487675,-62.29586545735825 -1.375711625723825,-62.2630512708942
+        -1.227164669103384,-62.2301563147696 -1.07850984679115,-62.19726130779766
+        -0.929802146898312,-62.19162403057929 -0.90425813880707,-62.01336187375579
+        -0.904233758344445,-62.01294627189677 -1.897474262556893,-62.411384447612484
+        -1.897588596151643,-62.411384447612484 -1.897588596151643))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"191.92
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193820_R010_V20161015T142322_20161015T142317","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c6b78330-8ce4-4da4-864d-c33a4ccb019a'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c6b78330-8ce4-4da4-864d-c33a4ccb019a'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c6b78330-8ce4-4da4-864d-c33a4ccb019a'')/Products(''Quicklook'')/$value"}],"id":"c6b78330-8ce4-4da4-864d-c33a4ccb019a","summary":"Date:
+        2016-10-15T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        75.42 MB","date":[{"name":"ingestiondate","content":"2016-10-16T19:52:27.014Z"},{"name":"beginposition","content":"2016-10-15T14:23:22Z"},{"name":"endposition","content":"2016-10-15T14:23:17Z"}],"int":[{"name":"orbitnumber","content":"6871"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.4326"},"str":[{"name":"uuid","content":"c6b78330-8ce4-4da4-864d-c33a4ccb019a"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193820_R010_V20161015T142322_20161015T142317.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.587747331296319,-59.69800540483221
+        -2.608161357546825,-59.58498560150654 -2.610464597952098,-59.58549533521873
+        -2.61054243667285,-59.58510184457595 -2.610581181053087,-59.58511043151774
+        -2.611236395005303,-59.58179225663756 -2.611266016201589,-59.58179882266673
+        -2.644007541365484,-59.41592890045646 -2.650621645760278,-59.3824932508908
+        -2.650608088284911,-59.38249025645346 -2.651170112134598,-59.3796430203592
+        -2.6505091417208,-59.37949697453256 -2.65051818677036,-59.37945094497835 -2.649670595423973,-59.37926395409495
+        -2.64978329772328,-59.37868761602735 -2.648660786599194,-59.37843954862177
+        -2.693043127505194,-59.15596485000672 -2.695284002204227,-59.15645993725311
+        -2.695344758290738,-59.1561734212123 -2.695827580150281,-59.15628020025268
+        -2.737873132646051,-58.95792086032721 -2.737698660009153,-58.9578823317476
+        -2.738187449672275,-58.95557988758511 -2.736873188669129,-58.95528959578663
+        -2.736919022368514,-58.95507278339885 -2.736092459187875,-58.954890170425536
+        -2.78402743298413,-58.73526571108647 -2.786516064869562,-58.73581399446269
+        -2.792080694085622,-58.71122469159749 -2.801398081739323,-58.71123581739256
+        -2.799530854700205,-59.698404092062326 -2.587747331296319,-59.69800540483221
+        -2.587747331296319,-59.69800540483221</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193820_R010_V20161015T142322_20161015T142317"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.69800540483221 -2.587747331296319,-59.58498560150654
+        -2.608161357546825,-59.58549533521873 -2.610464597952098,-59.58510184457595
+        -2.61054243667285,-59.58511043151774 -2.610581181053087,-59.58179225663756
+        -2.611236395005303,-59.58179882266673 -2.611266016201589,-59.41592890045646
+        -2.644007541365484,-59.3824932508908 -2.650621645760278,-59.38249025645346
+        -2.650608088284911,-59.3796430203592 -2.651170112134598,-59.37949697453256
+        -2.6505091417208,-59.37945094497835 -2.65051818677036,-59.37926395409495 -2.649670595423973,-59.37868761602735
+        -2.64978329772328,-59.37843954862177 -2.648660786599194,-59.15596485000672
+        -2.693043127505194,-59.15645993725311 -2.695284002204227,-59.1561734212123
+        -2.695344758290738,-59.15628020025268 -2.695827580150281,-58.95792086032721
+        -2.737873132646051,-58.9578823317476 -2.737698660009153,-58.95557988758511
+        -2.738187449672275,-58.95528959578663 -2.736873188669129,-58.95507278339885
+        -2.736919022368514,-58.954890170425536 -2.736092459187875,-58.73526571108647
+        -2.78402743298413,-58.73581399446269 -2.786516064869562,-58.71122469159749
+        -2.792080694085622,-58.71123581739256 -2.801398081739323,-59.698404092062326
+        -2.799530854700205,-59.69800540483221 -2.587747331296319,-59.69800540483221
+        -2.587747331296319))"},{"name":"s2datatakeid","content":"GS2A_20161015T142322_006871_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"75.42
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002513_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''10c9e321-4f68-43c7-abd4-222120df8651'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''10c9e321-4f68-43c7-abd4-222120df8651'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''10c9e321-4f68-43c7-abd4-222120df8651'')/Products(''Quicklook'')/$value"}],"id":"10c9e321-4f68-43c7-abd4-222120df8651","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        603.02 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:06:11.499Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"0.4506"},"str":[{"name":"uuid","content":"10c9e321-4f68-43c7-abd4-222120df8651"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002513_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.659387590087318,-61.18716561022849
+        -7.550073316116086,-61.16239301893552 -7.401733259591292,-61.12878330826942
+        -7.253398061821803,-61.095233629290725 -7.233186107062227,-61.090653146592274
+        -7.228649590132115,-60.1952038413134 -8.220663876926901,-60.18864685496363
+        -8.226398126465138,-61.18474514567033 -7.659387590087318,-61.18716561022849
+        -7.659387590087318,-61.18716561022849</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002513_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.18716561022849 -7.659387590087318,-61.16239301893552
+        -7.550073316116086,-61.12878330826942 -7.401733259591292,-61.095233629290725
+        -7.253398061821803,-61.090653146592274 -7.233186107062227,-60.1952038413134
+        -7.228649590132115,-60.18864685496363 -8.220663876926901,-61.18474514567033
+        -8.226398126465138,-61.18716561022849 -7.659387590087318,-61.18716561022849
+        -7.659387590087318))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"603.02
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T224807_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2874c065-5cfd-4d08-9286-2c627431f6f7'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2874c065-5cfd-4d08-9286-2c627431f6f7'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2874c065-5cfd-4d08-9286-2c627431f6f7'')/Products(''Quicklook'')/$value"}],"id":"2874c065-5cfd-4d08-9286-2c627431f6f7","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        202.99 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:56:27.491Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.4801"},"str":[{"name":"uuid","content":"2874c065-5cfd-4d08-9286-2c627431f6f7"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T224807_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.897590348842293,-62.41749235375235
+        -1.854255039274884,-62.40792999056831 -1.705607977168931,-62.37509945554116
+        -1.556896939579887,-62.3422822351844 -1.408141933187951,-62.30945341318604
+        -1.259445058982617,-62.276684841367775 -1.110844440515696,-62.24382275917092
+        -0.962246444953023,-62.211006273910414 -0.904259033021237,-62.19816223900444
+        -0.904233758344445,-62.01336187375579 -1.897474262556893,-62.01294627189677
+        -1.897590348842293,-62.41749235375235 -1.897590348842293,-62.41749235375235</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T224807_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.41749235375235 -1.897590348842293,-62.40792999056831
+        -1.854255039274884,-62.37509945554116 -1.705607977168931,-62.3422822351844
+        -1.556896939579887,-62.30945341318604 -1.408141933187951,-62.276684841367775
+        -1.259445058982617,-62.24382275917092 -1.110844440515696,-62.211006273910414
+        -0.962246444953023,-62.19816223900444 -0.904259033021237,-62.01336187375579
+        -0.904233758344445,-62.01294627189677 -1.897474262556893,-62.41749235375235
+        -1.897590348842293,-62.41749235375235 -1.897590348842293))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"202.99
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215159_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bf522273-6948-401e-9791-3677e5c2480e'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bf522273-6948-401e-9791-3677e5c2480e'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bf522273-6948-401e-9791-3677e5c2480e'')/Products(''Quicklook'')/$value"}],"id":"bf522273-6948-401e-9791-3677e5c2480e","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        618.61 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:02:24.835Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.493"},"str":[{"name":"uuid","content":"bf522273-6948-401e-9791-3677e5c2480e"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215159_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-61.2033064795971
+        0,-60.21736699592725 -0.992214719802887,-60.21695215839168 -0.992902323890143,-61.20303838098712
+        0,-61.2033064795971 0,-61.2033064795971</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215159_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.2033064795971 0,-60.21736699592725
+        0,-60.21695215839168 -0.992214719802887,-61.20303838098712 -0.992902323890143,-61.2033064795971
+        0,-61.2033064795971 0))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"618.61
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205834_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7976c690-d9fe-4a6b-943d-554d88c49342'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7976c690-d9fe-4a6b-943d-554d88c49342'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7976c690-d9fe-4a6b-943d-554d88c49342'')/Products(''Quicklook'')/$value"}],"id":"7976c690-d9fe-4a6b-943d-554d88c49342","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        605.28 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:23:27.41Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.5054"},"str":[{"name":"uuid","content":"7976c690-d9fe-4a6b-943d-554d88c49342"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205834_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.903361766508728,-66.30482331831355
+        -0.90249122014477,-65.3195063910922 -1.893816672990543,-65.31796001365792
+        -1.895643950033409,-66.30368947897708 -0.903361766508728,-66.30482331831355
+        -0.903361766508728,-66.30482331831355</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205834_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-66.30482331831355 -0.903361766508728,-65.3195063910922
+        -0.90249122014477,-65.31796001365792 -1.893816672990543,-66.30368947897708
+        -1.895643950033409,-66.30482331831355 -0.903361766508728,-66.30482331831355
+        -0.903361766508728))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"605.28
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164319_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d9ffbd25-c90b-42a9-bc3a-d538865ba4b8'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d9ffbd25-c90b-42a9-bc3a-d538865ba4b8'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''d9ffbd25-c90b-42a9-bc3a-d538865ba4b8'')/Products(''Quicklook'')/$value"}],"id":"d9ffbd25-c90b-42a9-bc3a-d538865ba4b8","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        334.44 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:41:49.511Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.6909"},"str":[{"name":"uuid","content":"d9ffbd25-c90b-42a9-bc3a-d538865ba4b8"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164319_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.904272241077684,-59.092361579319615
+        0.874791447123172,-59.09886693980568 0.726168647822785,-59.13149384827148
+        0.577534579640477,-59.164230407703705 0.428905108877973,-59.197049039232326
+        0.280180459309973,-59.229708551294834 0.13135663349316,-59.26234485983518
+        -0.017471451431342,-59.29502033442963 -0.088407165723147,-59.310603686137
+        -0.088384188930846,-59.69520594472657 0.903903730990171,-59.69553619552531
+        0.904272241077684,-59.092361579319615 0.904272241077684,-59.092361579319615</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164319_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.092361579319615
+        0.904272241077684,-59.09886693980568 0.874791447123172,-59.13149384827148
+        0.726168647822785,-59.164230407703705 0.577534579640477,-59.197049039232326
+        0.428905108877973,-59.229708551294834 0.280180459309973,-59.26234485983518
+        0.13135663349316,-59.29502033442963 -0.017471451431342,-59.310603686137 -0.088407165723147,-59.69520594472657
+        -0.088384188930846,-59.69553619552531 0.903903730990171,-59.092361579319615
+        0.904272241077684,-59.092361579319615 0.904272241077684))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"334.44
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T205938_R110_V20160724T141050_20160724T141050","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f2700741-5bbf-4d13-bd16-ae993666b39f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f2700741-5bbf-4d13-bd16-ae993666b39f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f2700741-5bbf-4d13-bd16-ae993666b39f'')/Products(''Quicklook'')/$value"}],"id":"f2700741-5bbf-4d13-bd16-ae993666b39f","summary":"Date:
+        2016-07-24T14:10:50Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.54 GB","date":[{"name":"ingestiondate","content":"2016-07-24T21:12:19.135Z"},{"name":"beginposition","content":"2016-07-24T14:10:50Z"},{"name":"endposition","content":"2016-07-24T14:10:50Z"}],"int":[{"name":"orbitnumber","content":"5684"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"0.7402307692307691"},"str":[{"name":"uuid","content":"f2700741-5bbf-4d13-bd16-ae993666b39f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T205938_R110_V20160724T141050_20160724T141050.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.611058230046773,-57.995045555221544
+        -4.681438031461836,-58.01067955693393 -4.830076192047458,-58.04377656168517
+        -4.978774838206845,-58.0768126471179 -5.127472949452315,-58.10979325972762
+        -5.276093999657361,-58.14290370439953 -5.424624372505357,-58.17611087158153
+        -5.515301134725798,-58.196477199249244 -5.515947033626909,-57.90315169909761
+        -5.516014389089381,-57.903151791669515 -5.516044812342758,-57.85874693129025
+        -5.516142631941844,-57.814323596961835 -5.516075248310466,-57.81432351345917
+        -5.516633044843839,-57.00018056571297 -5.516700066819259,-57.000180565731384
+        -5.51666329264377,-56.95603179187787 -5.516693539799448,-56.91188395837315
+        -5.51662651925904,-56.91188396736038 -5.515947927683427,-56.097209386295305
+        -5.516014937246069,-56.09720929423562 -5.5159111504805916,-56.05305697799961
+        -5.515874390220655,-56.00892491028779 -5.515807411549814,-56.00892501130261
+        -5.514563531976905,-55.47976154802517 -5.404818680012737,-55.4559462000616
+        -5.256243617206335,-55.42337027641448 -5.107791217041989,-55.3906224748515
+        -4.959387287688347,-55.35801505720557 -4.811044882038143,-55.325434429739765
+        -4.66261399867936,-55.292972719327615 -4.609679828616631,-55.28126437621711
+        -4.535566472047135,-55.26487147524674 -4.521206562392629,-55.261695251853205
+        -4.514215653957941,-55.260148954735286 -4.365629196592943,-55.227628650447215
+        -4.216925197007872,-55.195147926990735 -4.068221257403678,-55.16255140531853
+        -3.91936775943278,-55.130241324174015 -3.829290685059748,-55.110683628809575
+        -3.8292906850597412,-55.110683628809575 -3.770555880314316,-55.09793102303839
+        -3.621816411250613,-55.06535853871049 -3.616377919738933,-55.0641635626441
+        -3.473218270754421,-55.032707716139214 -3.324607174167137,-55.00031075324591
+        -3.176181909914479,-54.967705249286645 -3.027795765602404,-54.93507620718264
+        -2.879433359073463,-54.90240660593943 -2.730956403242931,-54.86980689043512
+        -2.712190230575868,-54.86569830776688 -2.7127451087194467,-55.15704255065448
+        -2.713786464257691,-56.05636168750623 -2.7141556791285284,-56.956185263014824
+        -2.713947548464798,-57.57287023709122 -2.750560991303983,-57.5809755165752
+        -2.899206591013651,-57.613810536491606 -3.047903990799158,-57.64667715914472
+        -3.196607748606181,-57.67950700036652 -3.345279181543642,-57.71250699260928
+        -3.493915606626109,-57.74542358401316 -3.618123786766848,-57.7730381461307
+        -3.64244565168022,-57.77844550053122 -3.790862515033066,-57.81164505743352
+        -3.7940730971052634,-57.81236390232887 -3.794073097105248,-57.81236390232887
+        -3.93924773075224,-57.84486830246071 -4.087559882219281,-57.87816314786238
+        -4.191395229731363,-57.9014251936686 -4.19139522973137,-57.9014251936686 -4.235898672005146,-57.91139521965216
+        -4.384336839021287,-57.94452506509823 -4.532835634233785,-57.977669373812965
+        -4.611058230046773,-57.995045555221544</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T205938_R110_V20160724T141050_20160724T141050"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.995045555221544
+        -4.611058230046773,-58.01067955693393 -4.681438031461836,-58.04377656168517
+        -4.830076192047458,-58.0768126471179 -4.978774838206845,-58.10979325972762
+        -5.127472949452315,-58.14290370439953 -5.276093999657361,-58.17611087158153
+        -5.424624372505357,-58.196477199249244 -5.515301134725798,-57.90315169909761
+        -5.515947033626909,-57.903151791669515 -5.516014389089381,-57.85874693129025
+        -5.516044812342758,-57.814323596961835 -5.516142631941844,-57.81432351345917
+        -5.516075248310466,-57.00018056571297 -5.516633044843839,-57.000180565731384
+        -5.516700066819259,-56.95603179187787 -5.51666329264377,-56.91188395837315
+        -5.516693539799448,-56.91188396736038 -5.51662651925904,-56.097209386295305
+        -5.515947927683427,-56.09720929423562 -5.516014937246069,-56.05305697799961
+        -5.5159111504805916,-56.00892491028779 -5.515874390220655,-56.00892501130261
+        -5.515807411549814,-55.47976154802517 -5.514563531976905,-55.4559462000616
+        -5.404818680012737,-55.42337027641448 -5.256243617206335,-55.3906224748515
+        -5.107791217041989,-55.35801505720557 -4.959387287688347,-55.325434429739765
+        -4.811044882038143,-55.292972719327615 -4.66261399867936,-55.28126437621711
+        -4.609679828616631,-55.26487147524674 -4.535566472047135,-55.261695251853205
+        -4.521206562392629,-55.260148954735286 -4.514215653957941,-55.227628650447215
+        -4.365629196592943,-55.195147926990735 -4.216925197007872,-55.16255140531853
+        -4.068221257403678,-55.130241324174015 -3.91936775943278,-55.110683628809575
+        -3.829290685059748,-55.110683628809575 -3.8292906850597412,-55.09793102303839
+        -3.770555880314316,-55.06535853871049 -3.621816411250613,-55.0641635626441
+        -3.616377919738933,-55.032707716139214 -3.473218270754421,-55.00031075324591
+        -3.324607174167137,-54.967705249286645 -3.176181909914479,-54.93507620718264
+        -3.027795765602404,-54.90240660593943 -2.879433359073463,-54.86980689043512
+        -2.730956403242931,-54.86569830776688 -2.712190230575868,-55.15704255065448
+        -2.7127451087194467,-56.05636168750623 -2.713786464257691,-56.956185263014824
+        -2.7141556791285284,-57.57287023709122 -2.713947548464798,-57.5809755165752
+        -2.750560991303983,-57.613810536491606 -2.899206591013651,-57.64667715914472
+        -3.047903990799158,-57.67950700036652 -3.196607748606181,-57.71250699260928
+        -3.345279181543642,-57.74542358401316 -3.493915606626109,-57.7730381461307
+        -3.618123786766848,-57.77844550053122 -3.64244565168022,-57.81164505743352
+        -3.790862515033066,-57.81236390232887 -3.7940730971052634,-57.81236390232887
+        -3.794073097105248,-57.84486830246071 -3.93924773075224,-57.87816314786238
+        -4.087559882219281,-57.9014251936686 -4.191395229731363,-57.9014251936686
+        -4.19139522973137,-57.91139521965216 -4.235898672005146,-57.94452506509823
+        -4.384336839021287,-57.977669373812965 -4.532835634233785,-57.995045555221544
+        -4.611058230046773))"},{"name":"s2datatakeid","content":"GS2A_20160724T141052_005684_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.54
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163015_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7b22d1f5-ab36-4b2a-a6fc-29881f3966e9'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7b22d1f5-ab36-4b2a-a6fc-29881f3966e9'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7b22d1f5-ab36-4b2a-a6fc-29881f3966e9'')/Products(''Quicklook'')/$value"}],"id":"7b22d1f5-ab36-4b2a-a6fc-29881f3966e9","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        625.75 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:21:40.422Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.7946"},"str":[{"name":"uuid","content":"7b22d1f5-ab36-4b2a-a6fc-29881f3966e9"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163015_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.903903999460832,-60.30482291839957
+        0.903032930477922,-59.319505845672396 -0.088299048298173,-59.31995619614116
+        -0.08838421517998,-60.30515312533039 0.903903999460832,-60.30482291839957
+        0.903903999460832,-60.30482291839957</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163015_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.30482291839957 0.903903999460832,-59.319505845672396
+        0.903032930477922,-59.31995619614116 -0.088299048298173,-60.30515312533039
+        -0.08838421517998,-60.30482291839957 0.903903999460832,-60.30482291839957
+        0.903903999460832))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"625.75
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205408_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4373d554-30f2-4901-8888-1660568d8a95'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4373d554-30f2-4901-8888-1660568d8a95'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4373d554-30f2-4901-8888-1660568d8a95'')/Products(''Quicklook'')/$value"}],"id":"4373d554-30f2-4901-8888-1660568d8a95","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        611.28 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:18:23.937Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"0.8489"},"str":[{"name":"uuid","content":"4373d554-30f2-4901-8888-1660568d8a95"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205408_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.72881160305398,-64.71001315683178
+        -1.854827472075815,-64.73770980421178 -1.896860073700952,-64.7469342765243
+        -1.895643386851301,-65.69666978552469 -0.903361498199144,-65.69553579555821
+        -0.903963608086094,-64.70941523486894 -1.72881160305398,-64.71001315683178
+        -1.72881160305398,-64.71001315683178</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205408_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.71001315683178 -1.72881160305398,-64.73770980421178
+        -1.854827472075815,-64.7469342765243 -1.896860073700952,-65.69666978552469
+        -1.895643386851301,-65.69553579555821 -0.903361498199144,-64.70941523486894
+        -0.903963608086094,-64.71001315683178 -1.72881160305398,-64.71001315683178
+        -1.72881160305398))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"611.28
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220346_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''51bec5bd-50a7-499d-a02f-1cbe76a886c0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''51bec5bd-50a7-499d-a02f-1cbe76a886c0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''51bec5bd-50a7-499d-a02f-1cbe76a886c0'')/Products(''Quicklook'')/$value"}],"id":"51bec5bd-50a7-499d-a02f-1cbe76a886c0","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        474.43 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:14:23.125Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.8631"},"str":[{"name":"uuid","content":"51bec5bd-50a7-499d-a02f-1cbe76a886c0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220346_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.90264650319417,-59.49526155292848
+        -0.942163808181498,-59.503857841941446 -1.090798435629983,-59.53642193822896
+        -1.239372324355128,-59.568972070497054 -1.387867942090785,-59.60160424194908
+        -1.536229233054455,-59.63440507484706 -1.68476392238876,-59.66676648883468
+        -1.833341963874607,-59.69933389341461 -1.894548629269244,-59.7128157768047
+        -1.895643950033409,-60.30368947897708 -0.903361766508728,-60.30482331831355
+        -0.90264650319417,-59.49526155292848 -0.90264650319417,-59.49526155292848</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220346_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.49526155292848 -0.90264650319417,-59.503857841941446
+        -0.942163808181498,-59.53642193822896 -1.090798435629983,-59.568972070497054
+        -1.239372324355128,-59.60160424194908 -1.387867942090785,-59.63440507484706
+        -1.536229233054455,-59.66676648883468 -1.68476392238876,-59.69933389341461
+        -1.833341963874607,-59.7128157768047 -1.894548629269244,-60.30368947897708
+        -1.895643950033409,-60.30482331831355 -0.903361766508728,-59.49526155292848
+        -0.90264650319417,-59.49526155292848 -0.90264650319417))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"474.43
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T214944_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bb335cdb-c2e8-4e9e-acaa-dc32221bba2f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bb335cdb-c2e8-4e9e-acaa-dc32221bba2f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bb335cdb-c2e8-4e9e-acaa-dc32221bba2f'')/Products(''Quicklook'')/$value"}],"id":"bb335cdb-c2e8-4e9e-acaa-dc32221bba2f","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        623.89 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:02:24.169Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"0.8679"},"str":[{"name":"uuid","content":"bb335cdb-c2e8-4e9e-acaa-dc32221bba2f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T214944_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.809051653364241,-62.10091718433367
+        -1.808289691632107,-61.113989555549914 -2.801126259103253,-61.112682072108385
+        -2.802307101216853,-62.100293543551295 -1.809051653364241,-62.10091718433367
+        -1.809051653364241,-62.10091718433367</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T214944_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.10091718433367 -1.809051653364241,-61.113989555549914
+        -1.808289691632107,-61.112682072108385 -2.801126259103253,-62.100293543551295
+        -2.802307101216853,-62.10091718433367 -1.809051653364241,-62.10091718433367
+        -1.809051653364241))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"623.89
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161002T211938_R110_V20161002T141302_20161002T141258","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e2847745-056d-4ee1-984d-66cd3b7548c7'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e2847745-056d-4ee1-984d-66cd3b7548c7'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e2847745-056d-4ee1-984d-66cd3b7548c7'')/Products(''Quicklook'')/$value"}],"id":"e2847745-056d-4ee1-984d-66cd3b7548c7","summary":"Date:
+        2016-10-02T14:13:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        70.23 MB","date":[{"name":"ingestiondate","content":"2016-10-02T21:37:02.98Z"},{"name":"beginposition","content":"2016-10-02T14:13:02Z"},{"name":"endposition","content":"2016-10-02T14:12:58Z"}],"int":[{"name":"orbitnumber","content":"6685"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"0.9669"},"str":[{"name":"uuid","content":"e2847745-056d-4ee1-984d-66cd3b7548c7"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161002T211938_R110_V20161002T141302_20161002T141258.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.897644556725453,-57.38149674569595
+        -1.778200731800699,-57.35517597628301 -1.630054597278005,-57.3225068495927
+        -1.669752496484169,-57.10563931914936 -1.669337203967383,-57.10554719976703
+        -1.669358518907489,-57.105430374552 -1.669051379724787,-57.10536238774032
+        -1.669545416167408,-57.10265146217203 -1.669032434840299,-57.10253795824077
+        -1.669183288248166,-57.10170388928832 -1.667808424061405,-57.101398706362026
+        -1.667856978497607,-57.101128038094586 -1.666432605193603,-57.10081311117658
+        -1.695757848431348,-56.93828060820141 -1.700500381809687,-56.91224890487263
+        -1.89775531415847,-56.91224156616041 -1.897644556725453,-57.38149674569595
+        -1.897644556725453,-57.38149674569595</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161002T211938_R110_V20161002T141302_20161002T141258"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.38149674569595 -1.897644556725453,-57.35517597628301
+        -1.778200731800699,-57.3225068495927 -1.630054597278005,-57.10563931914936
+        -1.669752496484169,-57.10554719976703 -1.669337203967383,-57.105430374552
+        -1.669358518907489,-57.10536238774032 -1.669051379724787,-57.10265146217203
+        -1.669545416167408,-57.10253795824077 -1.669032434840299,-57.10170388928832
+        -1.669183288248166,-57.101398706362026 -1.667808424061405,-57.101128038094586
+        -1.667856978497607,-57.10081311117658 -1.666432605193603,-56.93828060820141
+        -1.695757848431348,-56.91224890487263 -1.700500381809687,-56.91224156616041
+        -1.89775531415847,-57.38149674569595 -1.897644556725453,-57.38149674569595
+        -1.897644556725453))"},{"name":"s2datatakeid","content":"GS2A_20161002T141302_006685_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"70.23
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T222237_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bac28123-4346-48f3-b64d-c4086a9d707b'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bac28123-4346-48f3-b64d-c4086a9d707b'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bac28123-4346-48f3-b64d-c4086a9d707b'')/Products(''Quicklook'')/$value"}],"id":"bac28123-4346-48f3-b64d-c4086a9d707b","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        612.90 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:34:19.914Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"1.1886"},"str":[{"name":"uuid","content":"bac28123-4346-48f3-b64d-c4086a9d707b"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T222237_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.465668049130628,-62.101299443157224
+        -0.368279118567406,-62.07984467844377 -0.219709234559883,-62.04712522750268
+        -0.07109140869026,-62.01438693062904 0,-61.998746298277034 0,-61.11492283955807
+        -0.992852760559312,-61.11464157113414 -0.993271027199255,-62.10122818112512
+        -0.465668049130628,-62.101299443157224 -0.465668049130628,-62.101299443157224</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T222237_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.101299443157224
+        -0.465668049130628,-62.07984467844377 -0.368279118567406,-62.04712522750268
+        -0.219709234559883,-62.01438693062904 -0.07109140869026,-61.998746298277034
+        0,-61.11492283955807 0,-61.11464157113414 -0.992852760559312,-62.10122818112512
+        -0.993271027199255,-62.101299443157224 -0.465668049130628,-62.101299443157224
+        -0.465668049130628))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"612.90
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000857_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''3fc25a10-300d-4177-97ab-1affbe186b4e'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''3fc25a10-300d-4177-97ab-1affbe186b4e'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''3fc25a10-300d-4177-97ab-1affbe186b4e'')/Products(''Quicklook'')/$value"}],"id":"3fc25a10-300d-4177-97ab-1affbe186b4e","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        618.63 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:43:58.906Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"1.3542"},"str":[{"name":"uuid","content":"3fc25a10-300d-4177-97ab-1affbe186b4e"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000857_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.229183594153009,-59.7166716601426
+        -7.23402634599441,-58.72283083952535 -8.226787741770087,-58.72686245728039
+        -8.221272080743814,-59.723023261271635 -7.229183594153009,-59.7166716601426
+        -7.229183594153009,-59.7166716601426</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000857_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.7166716601426 -7.229183594153009,-58.72283083952535
+        -7.23402634599441,-58.72686245728039 -8.226787741770087,-59.723023261271635
+        -8.221272080743814,-59.7166716601426 -7.229183594153009,-59.7166716601426
+        -7.229183594153009))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"618.63
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T004128_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''25b75353-8fb6-4969-a159-95e4c2e7bfbf'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''25b75353-8fb6-4969-a159-95e4c2e7bfbf'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''25b75353-8fb6-4969-a159-95e4c2e7bfbf'')/Products(''Quicklook'')/$value"}],"id":"25b75353-8fb6-4969-a159-95e4c2e7bfbf","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        90.28 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:04:18.785Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"1.467"},"str":[{"name":"uuid","content":"25b75353-8fb6-4969-a159-95e4c2e7bfbf"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T004128_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-8.226755550066397,-61.315668185580584
+        -8.143916390978882,-61.296830713061134 -7.995344686046336,-61.2632984873897
+        -7.846889967756262,-61.22961736882687 -7.69845599424505,-61.19601921711356
+        -7.550073316116086,-61.16239301893552 -7.401733259591292,-61.12878330826942
+        -7.273220282957482,-61.09971691556227 -8.225984792224422,-61.09544973653788
+        -8.226755550066397,-61.315668185580584 -8.226755550066397,-61.315668185580584</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T004128_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.315668185580584
+        -8.226755550066397,-61.296830713061134 -8.143916390978882,-61.2632984873897
+        -7.995344686046336,-61.22961736882687 -7.846889967756262,-61.19601921711356
+        -7.69845599424505,-61.16239301893552 -7.550073316116086,-61.12878330826942
+        -7.401733259591292,-61.09971691556227 -7.273220282957482,-61.09544973653788
+        -8.225984792224422,-61.315668185580584 -8.226755550066397,-61.315668185580584
+        -8.226755550066397))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"90.28
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193844_R010_V20161015T142322_20161015T142317","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''56e3a3ef-f166-4d84-b488-8a215747d5f2'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''56e3a3ef-f166-4d84-b488-8a215747d5f2'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''56e3a3ef-f166-4d84-b488-8a215747d5f2'')/Products(''Quicklook'')/$value"}],"id":"56e3a3ef-f166-4d84-b488-8a215747d5f2","summary":"Date:
+        2016-10-15T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        609.39 MB","date":[{"name":"ingestiondate","content":"2016-10-16T19:54:27.341Z"},{"name":"beginposition","content":"2016-10-15T14:23:22Z"},{"name":"endposition","content":"2016-10-15T14:23:17Z"}],"int":[{"name":"orbitnumber","content":"6871"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"1.4954"},"str":[{"name":"uuid","content":"56e3a3ef-f166-4d84-b488-8a215747d5f2"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193844_R010_V20161015T142322_20161015T142317.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.712283870905056,-59.07864395151823
+        -2.737873132646051,-58.95792086032721 -2.737698660009153,-58.9578823317476
+        -2.738187449672275,-58.95557988758511 -2.736873188669129,-58.95528959578663
+        -2.736919022368514,-58.95507278339885 -2.736092459187875,-58.954890170425536
+        -2.78402743298413,-58.73526571108647 -2.786516064869562,-58.73581399446269
+        -2.792076971397373,-58.71124114162592 -3.705874334456282,-58.71276241632309
+        -3.703402824973188,-59.70080921622827 -2.711148939858159,-59.69820496206522
+        -2.712283870905056,-59.07864395151823 -2.712283870905056,-59.07864395151823</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193844_R010_V20161015T142322_20161015T142317"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.07864395151823 -2.712283870905056,-58.95792086032721
+        -2.737873132646051,-58.9578823317476 -2.737698660009153,-58.95557988758511
+        -2.738187449672275,-58.95528959578663 -2.736873188669129,-58.95507278339885
+        -2.736919022368514,-58.954890170425536 -2.736092459187875,-58.73526571108647
+        -2.78402743298413,-58.73581399446269 -2.786516064869562,-58.71124114162592
+        -2.792076971397373,-58.71276241632309 -3.705874334456282,-59.70080921622827
+        -3.703402824973188,-59.69820496206522 -2.711148939858159,-59.07864395151823
+        -2.712283870905056,-59.07864395151823 -2.712283870905056))"},{"name":"s2datatakeid","content":"GS2A_20161015T142322_006871_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"609.39
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T224321_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2042722c-3b90-4309-8f0a-a6bda0be2b7c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2042722c-3b90-4309-8f0a-a6bda0be2b7c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2042722c-3b90-4309-8f0a-a6bda0be2b7c'')/Products(''Quicklook'')/$value"}],"id":"2042722c-3b90-4309-8f0a-a6bda0be2b7c","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        332.98 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:54:23.325Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"1.5761"},"str":[{"name":"uuid","content":"2042722c-3b90-4309-8f0a-a6bda0be2b7c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T224321_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.80249252679068,-62.61811665060947
+        -2.745049716917918,-62.60536435447126 -2.596604003810307,-62.57240674093227
+        -2.448199946236569,-62.539442109279726 -2.29977102975041,-62.50649452226557
+        -2.151331523681611,-62.473562240206334 -2.002843439627696,-62.44071748564548
+        -1.854255039274884,-62.40792999056831 -1.809110999756503,-62.39795937325723
+        -1.809005681208331,-62.01299525957096 -2.802235856336857,-62.012310655608864
+        -2.80249252679068,-62.61811665060947 -2.80249252679068,-62.61811665060947</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T224321_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.61811665060947 -2.80249252679068,-62.60536435447126
+        -2.745049716917918,-62.57240674093227 -2.596604003810307,-62.539442109279726
+        -2.448199946236569,-62.50649452226557 -2.29977102975041,-62.473562240206334
+        -2.151331523681611,-62.44071748564548 -2.002843439627696,-62.40792999056831
+        -1.854255039274884,-62.39795937325723 -1.809110999756503,-62.01299525957096
+        -1.809005681208331,-62.012310655608864 -2.802235856336857,-62.61811665060947
+        -2.80249252679068,-62.61811665060947 -2.80249252679068))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"332.98
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205920_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''25f652b7-b798-4301-be14-7409f2aef918'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''25f652b7-b798-4301-be14-7409f2aef918'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''25f652b7-b798-4301-be14-7409f2aef918'')/Products(''Quicklook'')/$value"}],"id":"25f652b7-b798-4301-be14-7409f2aef918","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        628.19 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:26:05.218Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"1.5947"},"str":[{"name":"uuid","content":"25f652b7-b798-4301-be14-7409f2aef918"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205920_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.807260761605379,-66.30382312638804
+        -1.805518735702188,-65.31814228744848 -2.7968320051609,-65.31559501298386
+        -2.799531686765212,-66.30195540280954 -1.807260761605379,-66.30382312638804
+        -1.807260761605379,-66.30382312638804</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205920_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-66.30382312638804 -1.807260761605379,-65.31814228744848
+        -1.805518735702188,-65.31559501298386 -2.7968320051609,-66.30195540280954
+        -2.799531686765212,-66.30382312638804 -1.807260761605379,-66.30382312638804
+        -1.807260761605379))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"628.19
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003231_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''84322973-5ff3-4c27-a560-aad4291c939c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''84322973-5ff3-4c27-a560-aad4291c939c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''84322973-5ff3-4c27-a560-aad4291c939c'')/Products(''Quicklook'')/$value"}],"id":"84322973-5ff3-4c27-a560-aad4291c939c","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        441.93 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:10:22.019Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"1.6542"},"str":[{"name":"uuid","content":"84322973-5ff3-4c27-a560-aad4291c939c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003231_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.798975290702342,-60.09866956473371
+        -2.798418603696909,-60.09854601291832 -2.649702751627792,-60.065594530898274
+        -2.501076852570674,-60.032504751282914 -2.352464329641706,-59.999532100503366
+        -2.203909116957583,-59.966607002754245 -2.055406079642594,-59.93369825413533
+        -1.90700200986938,-59.900798667456655 -1.806509473267804,-59.878725820136594
+        -1.805518735702188,-59.31814228744849 -2.7968320051609,-59.31559501298386
+        -2.798975290702342,-60.09866956473371 -2.798975290702342,-60.09866956473371</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003231_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.09866956473371 -2.798975290702342,-60.09854601291832
+        -2.798418603696909,-60.065594530898274 -2.649702751627792,-60.032504751282914
+        -2.501076852570674,-59.999532100503366 -2.352464329641706,-59.966607002754245
+        -2.203909116957583,-59.93369825413533 -2.055406079642594,-59.900798667456655
+        -1.90700200986938,-59.878725820136594 -1.806509473267804,-59.31814228744849
+        -1.805518735702188,-59.31559501298386 -2.7968320051609,-60.09866956473371
+        -2.798975290702342,-60.09866956473371 -2.798975290702342))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"441.93
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T101822_R053_V20160730T142756_20160730T142756","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''3e918ac0-67d9-4ab8-8890-fea2afffff8f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''3e918ac0-67d9-4ab8-8890-fea2afffff8f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''3e918ac0-67d9-4ab8-8890-fea2afffff8f'')/Products(''Quicklook'')/$value"}],"id":"3e918ac0-67d9-4ab8-8890-fea2afffff8f","summary":"Date:
+        2016-07-30T14:27:56Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.57 GB","date":[{"name":"ingestiondate","content":"2016-07-31T10:26:40.878Z"},{"name":"beginposition","content":"2016-07-30T14:27:56Z"},{"name":"endposition","content":"2016-07-30T14:27:56Z"}],"int":[{"name":"orbitnumber","content":"5770"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"1.6974428571428568"},"str":[{"name":"uuid","content":"3e918ac0-67d9-4ab8-8890-fea2afffff8f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T101822_R053_V20160730T142756_20160730T142756.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.897593459721509,-62.428333375958935
+        -2.039936133385297,-62.46005561211047 -2.188380602029265,-62.49308768751673
+        -2.336908403486101,-62.526059784861154 -2.485525071046996,-62.55895697378331
+        -2.634203649988531,-62.591820879058645 -2.782888511281836,-62.624650281469926
+        -2.802497132097573,-62.6289863182435 -2.8022731333090847,-62.10029356487891
+        -2.802307101216853,-62.100293543551295 -2.802254490521156,-62.05629195689363
+        -2.802235856336857,-62.012310655608864 -2.8022019041077386,-62.01231067901112
+        -2.801232060899604,-61.20117067407488 -2.801266185267337,-61.20117063124223
+        -2.801179136160849,-61.15690643373672 -2.801126259103253,-61.112682072108385
+        -2.8010921654831153,-61.112682117006855 -2.7994978062830684,-60.301955466581816
+        -2.799531686765212,-60.30195540280954 -2.799411323689234,-60.25797933898327
+        -2.799324956972109,-60.21406213432756 -2.799291121891581,-60.21406220008751
+        -2.798491245025214,-59.9218177900569 -2.762585728639492,-59.913919092525965
+        -2.614230765951109,-59.881164565317775 -2.465838772231483,-59.848515310742926
+        -2.317295025943806,-59.815946993774894 -2.168640483114903,-59.78333382432146
+        -2.019822172084209,-59.75095272218833 -1.871051316437875,-59.718265707132254
+        -1.722356060876078,-59.685642618706815 -1.573628532059589,-59.65314037278458
+        -1.424926690384003,-59.62058879730052 -1.276211570331545,-59.588144449724055
+        -1.127659221691473,-59.55550845681231 -0.991532011362674,-59.52582878677432
+        -0.979149093869985,-59.523128952520736 -0.830813603149752,-59.490291835089565
+        -0.682325659981097,-59.45776587169263 -0.533843406435435,-59.42503149750375
+        -0.385127331638691,-59.392536814370125 -0.236368349764194,-59.359825728122665
+        -0.087492129583607,-59.32735935865762 0,-59.308267369584875 0,-59.319960543069975
+        0,-59.69520275703949 0,-60.21736699592725 0,-60.30515631259404 0,-61.11492283955807
+        0,-61.2033064795971 0,-62.00939084176496 -0.0185053262612031,-62.01348118676992
+        -0.018505326261184,-62.01348118676992 -0.108561811587891,-62.033386920379854
+        -0.257018404342163,-62.06616691477325 -0.405548326886262,-62.09894993216837
+        -0.554145084868732,-62.13169290628873 -0.702800767402865,-62.16443639337795
+        -0.851448850408985,-62.19722121709983 -0.9441924316294104,-62.217678632256735
+        -1.000100634214669,-62.23001088529153 -1.148808723789379,-62.26273151477491
+        -1.297545059576767,-62.29542093235829 -1.446196570544136,-62.32818106749952
+        -1.594748340420329,-62.3610139395635 -1.743184025549142,-62.39396745273898
+        -1.891561582901472,-62.426989122573794 -1.897593459721509,-62.428333375958935</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160731T101822_R053_V20160730T142756_20160730T142756"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.428333375958935
+        -1.897593459721509,-62.46005561211047 -2.039936133385297,-62.49308768751673
+        -2.188380602029265,-62.526059784861154 -2.336908403486101,-62.55895697378331
+        -2.485525071046996,-62.591820879058645 -2.634203649988531,-62.624650281469926
+        -2.782888511281836,-62.6289863182435 -2.802497132097573,-62.10029356487891
+        -2.8022731333090847,-62.100293543551295 -2.802307101216853,-62.05629195689363
+        -2.802254490521156,-62.012310655608864 -2.802235856336857,-62.01231067901112
+        -2.8022019041077386,-61.20117067407488 -2.801232060899604,-61.20117063124223
+        -2.801266185267337,-61.15690643373672 -2.801179136160849,-61.112682072108385
+        -2.801126259103253,-61.112682117006855 -2.8010921654831153,-60.301955466581816
+        -2.7994978062830684,-60.30195540280954 -2.799531686765212,-60.25797933898327
+        -2.799411323689234,-60.21406213432756 -2.799324956972109,-60.21406220008751
+        -2.799291121891581,-59.9218177900569 -2.798491245025214,-59.913919092525965
+        -2.762585728639492,-59.881164565317775 -2.614230765951109,-59.848515310742926
+        -2.465838772231483,-59.815946993774894 -2.317295025943806,-59.78333382432146
+        -2.168640483114903,-59.75095272218833 -2.019822172084209,-59.718265707132254
+        -1.871051316437875,-59.685642618706815 -1.722356060876078,-59.65314037278458
+        -1.573628532059589,-59.62058879730052 -1.424926690384003,-59.588144449724055
+        -1.276211570331545,-59.55550845681231 -1.127659221691473,-59.52582878677432
+        -0.991532011362674,-59.523128952520736 -0.979149093869985,-59.490291835089565
+        -0.830813603149752,-59.45776587169263 -0.682325659981097,-59.42503149750375
+        -0.533843406435435,-59.392536814370125 -0.385127331638691,-59.359825728122665
+        -0.236368349764194,-59.32735935865762 -0.087492129583607,-59.308267369584875
+        0,-59.319960543069975 0,-59.69520275703949 0,-60.21736699592725 0,-60.30515631259404
+        0,-61.11492283955807 0,-61.2033064795971 0,-62.00939084176496 0,-62.01348118676992
+        -0.0185053262612031,-62.01348118676992 -0.018505326261184,-62.033386920379854
+        -0.108561811587891,-62.06616691477325 -0.257018404342163,-62.09894993216837
+        -0.405548326886262,-62.13169290628873 -0.554145084868732,-62.16443639337795
+        -0.702800767402865,-62.19722121709983 -0.851448850408985,-62.217678632256735
+        -0.9441924316294104,-62.23001088529153 -1.000100634214669,-62.26273151477491
+        -1.148808723789379,-62.29542093235829 -1.297545059576767,-62.32818106749952
+        -1.446196570544136,-62.3610139395635 -1.594748340420329,-62.39396745273898
+        -1.743184025549142,-62.426989122573794 -1.891561582901472,-62.428333375958935
+        -1.897593459721509))"},{"name":"s2datatakeid","content":"GS2A_20160730T142802_005770_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.57
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210510_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1ee9e6f2-5f18-4009-887d-99e1bcefe506'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1ee9e6f2-5f18-4009-887d-99e1bcefe506'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1ee9e6f2-5f18-4009-887d-99e1bcefe506'')/Products(''Quicklook'')/$value"}],"id":"1ee9e6f2-5f18-4009-887d-99e1bcefe506","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        112.54 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:35:00.001Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"1.9602"},"str":[{"name":"uuid","content":"1ee9e6f2-5f18-4009-887d-99e1bcefe506"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210510_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.90401792321447,-64.52891696766696
+        -0.96246237049776,-64.54172198601243 -1.111195140169527,-64.57429511457127
+        -1.259947569037366,-64.6069607865475 -1.408715033373311,-64.63963860999614
+        -1.557467789140331,-64.67234644038986 -1.706190183762468,-64.70504126338521
+        -1.854827472075815,-64.73770980421178 -1.896856329074243,-64.74693345472873
+        -1.89681756681139,-64.7980317707047 -0.90392089746569,-64.79727505116614 -0.90401792321447,-64.52891696766696
+        -0.90401792321447,-64.52891696766696</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210510_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.52891696766696 -0.90401792321447,-64.54172198601243
+        -0.96246237049776,-64.57429511457127 -1.111195140169527,-64.6069607865475
+        -1.259947569037366,-64.63963860999614 -1.408715033373311,-64.67234644038986
+        -1.557467789140331,-64.70504126338521 -1.706190183762468,-64.73770980421178
+        -1.854827472075815,-64.74693345472873 -1.896856329074243,-64.7980317707047
+        -1.89681756681139,-64.79727505116614 -0.90392089746569,-64.52891696766696
+        -0.90401792321447,-64.52891696766696 -0.90401792321447))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"112.54
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222929_R010_V20160806T142041_20160806T142041","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f574cb09-1821-44fd-b08c-9e0b2059dfe9'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f574cb09-1821-44fd-b08c-9e0b2059dfe9'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f574cb09-1821-44fd-b08c-9e0b2059dfe9'')/Products(''Quicklook'')/$value"}],"id":"f574cb09-1821-44fd-b08c-9e0b2059dfe9","summary":"Date:
+        2016-08-06T14:20:41Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.11 GB","date":[{"name":"ingestiondate","content":"2016-08-07T07:18:45.109Z"},{"name":"beginposition","content":"2016-08-06T14:20:41Z"},{"name":"endposition","content":"2016-08-06T14:20:41Z"}],"int":[{"name":"orbitnumber","content":"5870"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"1.9756571428571428"},"str":[{"name":"uuid","content":"f574cb09-1821-44fd-b08c-9e0b2059dfe9"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222929_R010_V20160806T142041_20160806T142041.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.6491645746554884,-60.299700159560864
+        -3.768875503590013,-60.32648596269672 -3.917215715028899,-60.359609578048655
+        -4.065635520005394,-60.39275063177801 -4.21410843009932,-60.42586355319917
+        -4.362687622322367,-60.45889793586307 -4.511271803307749,-60.49198412175704
+        -4.607358917483015,-60.51332940312894 -4.659914564056013,-60.52500438237472
+        -4.808541248135085,-60.55809432580004 -4.957191503650709,-60.59121408836626
+        -5.105803590258348,-60.62435327321282 -5.254283782691414,-60.65764838527944
+        -5.402730505405359,-60.69092854062463 -5.500183801234599,-60.71291597287658
+        -5.512107953101867,-60.715598807841864 -5.510472970358236,-60.292718824860636
+        -5.510539807042403,-60.29271854959391 -5.510302364769758,-60.248592555863176
+        -5.510131987398975,-60.204525314213285 -5.5100652401698405,-60.204525598059945
+        -5.507391437327689,-59.70762921084262 -5.510538165612144,-59.70764217236141
+        -5.513893497961508,-58.80535357891916 -5.513960396525286,-58.80535376268811
+        -5.514057522441122,-58.76124545442017 -5.514221687588917,-58.7170995025818
+        -5.514154731632817,-58.71709932764371 -5.515736119233132,-57.998935373504175
+        -5.383369354123499,-57.97000212959304 -5.234626700638916,-57.93762055038725
+        -5.08595741194604,-57.90522842953568 -5.073672054692432,-57.902543845873275
+        -5.073672054692443,-57.902543845873275 -4.93737455932937,-57.87276025702637
+        -4.788945328509349,-57.84016587021392 -4.640623077495734,-57.807466445022136
+        -4.611343839357285,-57.801035456795255 -4.492276635381166,-57.77488314424678
+        -4.343890261285238,-57.74228625350817 -4.19535397231931,-57.709738609102565
+        -4.046674970642967,-57.677288033482704 -3.89787838526008,-57.64481385719901
+        -3.749047238521012,-57.61244336357908 -3.707214309352218,-57.60329670064608
+        -3.600336651337518,-57.579928174168174 -3.451593524572092,-57.54751953195158
+        -3.302875822646202,-57.51505543563553 -3.154222205703343,-57.482557956045135
+        -3.005692444643809,-57.44995672698038 -2.857290106182686,-57.41730472907834
+        -2.714010715320826,-57.38570871906214 -2.7138520768084997,-57.85574991870128
+        -2.7128765456728288,-58.755101671966266 -2.7118493409356286,-59.31585468578026
+        -2.708535417726956,-59.315866557865895 -2.710591435393545,-60.091524980305714
+        -2.728912193520602,-60.095584915392 -2.877575652035104,-60.12843631184101
+        -3.026210166509378,-60.161468559615 -3.174941233043862,-60.1942181529891 -3.323558848338683,-60.22726181378689
+        -3.472111464329229,-60.260243281821054 -3.614453682444709,-60.29193999922829
+        -3.620542643781284,-60.29329588709729 -3.649132660664731,-60.29969301867673
+        -3.6491326606647405,-60.29969301867673 -3.649164574655486,-60.299700159560864
+        -3.6491645746554884,-60.299700159560864</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222929_R010_V20160806T142041_20160806T142041"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.299700159560864
+        -3.6491645746554884,-60.32648596269672 -3.768875503590013,-60.359609578048655
+        -3.917215715028899,-60.39275063177801 -4.065635520005394,-60.42586355319917
+        -4.21410843009932,-60.45889793586307 -4.362687622322367,-60.49198412175704
+        -4.511271803307749,-60.51332940312894 -4.607358917483015,-60.52500438237472
+        -4.659914564056013,-60.55809432580004 -4.808541248135085,-60.59121408836626
+        -4.957191503650709,-60.62435327321282 -5.105803590258348,-60.65764838527944
+        -5.254283782691414,-60.69092854062463 -5.402730505405359,-60.71291597287658
+        -5.500183801234599,-60.715598807841864 -5.512107953101867,-60.292718824860636
+        -5.510472970358236,-60.29271854959391 -5.510539807042403,-60.248592555863176
+        -5.510302364769758,-60.204525314213285 -5.510131987398975,-60.204525598059945
+        -5.5100652401698405,-59.70762921084262 -5.507391437327689,-59.70764217236141
+        -5.510538165612144,-58.80535357891916 -5.513893497961508,-58.80535376268811
+        -5.513960396525286,-58.76124545442017 -5.514057522441122,-58.7170995025818
+        -5.514221687588917,-58.71709932764371 -5.514154731632817,-57.998935373504175
+        -5.515736119233132,-57.97000212959304 -5.383369354123499,-57.93762055038725
+        -5.234626700638916,-57.90522842953568 -5.08595741194604,-57.902543845873275
+        -5.073672054692432,-57.902543845873275 -5.073672054692443,-57.87276025702637
+        -4.93737455932937,-57.84016587021392 -4.788945328509349,-57.807466445022136
+        -4.640623077495734,-57.801035456795255 -4.611343839357285,-57.77488314424678
+        -4.492276635381166,-57.74228625350817 -4.343890261285238,-57.709738609102565
+        -4.19535397231931,-57.677288033482704 -4.046674970642967,-57.64481385719901
+        -3.89787838526008,-57.61244336357908 -3.749047238521012,-57.60329670064608
+        -3.707214309352218,-57.579928174168174 -3.600336651337518,-57.54751953195158
+        -3.451593524572092,-57.51505543563553 -3.302875822646202,-57.482557956045135
+        -3.154222205703343,-57.44995672698038 -3.005692444643809,-57.41730472907834
+        -2.857290106182686,-57.38570871906214 -2.714010715320826,-57.85574991870128
+        -2.7138520768084997,-58.755101671966266 -2.7128765456728288,-59.31585468578026
+        -2.7118493409356286,-59.315866557865895 -2.708535417726956,-60.091524980305714
+        -2.710591435393545,-60.095584915392 -2.728912193520602,-60.12843631184101
+        -2.877575652035104,-60.161468559615 -3.026210166509378,-60.1942181529891 -3.174941233043862,-60.22726181378689
+        -3.323558848338683,-60.260243281821054 -3.472111464329229,-60.29193999922829
+        -3.614453682444709,-60.29329588709729 -3.620542643781284,-60.29969301867673
+        -3.649132660664731,-60.29969301867673 -3.6491326606647405,-60.299700159560864
+        -3.649164574655486,-60.299700159560864 -3.6491645746554884))"},{"name":"s2datatakeid","content":"GS2A_20160806T142042_005870_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.11
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160805T214709_R139_V20160805T144734_20160805T144734","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9d4114a5-b82d-42bb-99b9-072c34207a1e'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9d4114a5-b82d-42bb-99b9-072c34207a1e'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9d4114a5-b82d-42bb-99b9-072c34207a1e'')/Products(''Quicklook'')/$value"}],"id":"9d4114a5-b82d-42bb-99b9-072c34207a1e","summary":"Date:
+        2016-08-05T14:47:34Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.50 GB","date":[{"name":"ingestiondate","content":"2016-08-05T22:39:21.766Z"},{"name":"beginposition","content":"2016-08-05T14:47:34Z"},{"name":"endposition","content":"2016-08-05T14:47:34Z"}],"int":[{"name":"orbitnumber","content":"5856"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"2.0551999999999997"},"str":[{"name":"uuid","content":"9d4114a5-b82d-42bb-99b9-072c34207a1e"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160805T214709_R139_V20160805T144734_20160805T144734.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.325395067077409,-68.6760387531828
+        -7.379619185380627,-68.68831519427052 -7.527940918902414,-68.72198687792718
+        -7.676401441831889,-68.75545524014795 -7.824899475210096,-68.78897119430337
+        -7.973468155018147,-68.82252351619137 -8.122060197630764,-68.85607492438238
+        -8.230350566198629,-68.88061127201603 -8.22937260678506,-68.09207424566608
+        -8.229472946800525,-68.09207403140283 -8.229317536684688,-68.04767075347118
+        -8.229262491883746,-68.0032876604223 -8.229162198038187,-68.00328789552823
+        -8.226297324933649,-67.18474557597366 -8.226398126465138,-67.18474514567032
+        -8.226140988458724,-67.14007762170615 -8.225984792224422,-67.09544973653786
+        -8.225884081237991,-67.0954501875956 -8.221174458521304,-66.27734014430516
+        -8.221274538592427,-66.27733950365256 -8.220918997302837,-66.23296389570278
+        -8.220663876926901,-66.18864685496362 -8.220563930551878,-66.18864751558618
+        -8.220205017320911,-66.14385105089504 -8.104776397228735,-66.11843798817954
+        -7.956487992432917,-66.085696972981 -7.80816093096043,-66.05294494426433 -7.65975535413104,-66.02023728688327
+        -7.511248018658296,-65.98769825978398 -7.362637349511756,-65.95521848712507
+        -7.315139738716602,-65.94484716620714 -7.213922703823321,-65.9227459629326
+        -7.065166155412364,-65.89025016481344 -6.916391847218555,-65.85782475233422
+        -6.767631422498091,-65.8254367276103 -6.618971096876218,-65.79300950468857
+        -6.470420492391524,-65.76049169806848 -6.321969445885601,-65.72794347399967
+        -6.321959305552728,-65.7279412397367 -6.246256641423771,-65.71126134748938
+        -6.246256641423793,-65.71126134748938 -6.173659491366048,-65.69526570645934
+        -6.025383962894904,-65.66262002031625 -5.877018055294132,-65.63001580443229
+        -5.72853870553026,-65.59741241748799 -5.579898408141128,-65.56495969547345
+        -5.431179241234243,-65.53252195874249 -5.422808947143679,-65.53069670841046
+        -5.418122122783504,-65.52967468605056 -5.4219309173953585,-66.24899623557717
+        -5.425362066336241,-67.15086321305921 -5.427449229390539,-68.05319609957084
+        -5.427609703835691,-68.24898156325384 -5.449620554096636,-68.25393456707188
+        -5.597996197742424,-68.28730077912314 -5.746423468002243,-68.32068213514077
+        -5.894943317192443,-68.35402808587793 -6.043535645314887,-68.38728071589223
+        -6.192160237996466,-68.42055546584663 -6.34078858511316,-68.45382474592769
+        -6.421001956791667,-68.47183381225649 -6.489352411935613,-68.48717948161975
+        -6.637909838584367,-68.5205142387293 -6.786345494802027,-68.5539568718754
+        -6.934737952645203,-68.58745172905216 -7.083070541137671,-68.62098556129902
+        -7.231294088196419,-68.65473411680182 -7.325395067077409,-68.6760387531828</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160805T214709_R139_V20160805T144734_20160805T144734"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-68.6760387531828 -7.325395067077409,-68.68831519427052
+        -7.379619185380627,-68.72198687792718 -7.527940918902414,-68.75545524014795
+        -7.676401441831889,-68.78897119430337 -7.824899475210096,-68.82252351619137
+        -7.973468155018147,-68.85607492438238 -8.122060197630764,-68.88061127201603
+        -8.230350566198629,-68.09207424566608 -8.22937260678506,-68.09207403140283
+        -8.229472946800525,-68.04767075347118 -8.229317536684688,-68.0032876604223
+        -8.229262491883746,-68.00328789552823 -8.229162198038187,-67.18474557597366
+        -8.226297324933649,-67.18474514567032 -8.226398126465138,-67.14007762170615
+        -8.226140988458724,-67.09544973653786 -8.225984792224422,-67.0954501875956
+        -8.225884081237991,-66.27734014430516 -8.221174458521304,-66.27733950365256
+        -8.221274538592427,-66.23296389570278 -8.220918997302837,-66.18864685496362
+        -8.220663876926901,-66.18864751558618 -8.220563930551878,-66.14385105089504
+        -8.220205017320911,-66.11843798817954 -8.104776397228735,-66.085696972981
+        -7.956487992432917,-66.05294494426433 -7.80816093096043,-66.02023728688327
+        -7.65975535413104,-65.98769825978398 -7.511248018658296,-65.95521848712507
+        -7.362637349511756,-65.94484716620714 -7.315139738716602,-65.9227459629326
+        -7.213922703823321,-65.89025016481344 -7.065166155412364,-65.85782475233422
+        -6.916391847218555,-65.8254367276103 -6.767631422498091,-65.79300950468857
+        -6.618971096876218,-65.76049169806848 -6.470420492391524,-65.72794347399967
+        -6.321969445885601,-65.7279412397367 -6.321959305552728,-65.71126134748938
+        -6.246256641423771,-65.71126134748938 -6.246256641423793,-65.69526570645934
+        -6.173659491366048,-65.66262002031625 -6.025383962894904,-65.63001580443229
+        -5.877018055294132,-65.59741241748799 -5.72853870553026,-65.56495969547345
+        -5.579898408141128,-65.53252195874249 -5.431179241234243,-65.53069670841046
+        -5.422808947143679,-65.52967468605056 -5.418122122783504,-66.24899623557717
+        -5.4219309173953585,-67.15086321305921 -5.425362066336241,-68.05319609957084
+        -5.427449229390539,-68.24898156325384 -5.427609703835691,-68.25393456707188
+        -5.449620554096636,-68.28730077912314 -5.597996197742424,-68.32068213514077
+        -5.746423468002243,-68.35402808587793 -5.894943317192443,-68.38728071589223
+        -6.043535645314887,-68.42055546584663 -6.192160237996466,-68.45382474592769
+        -6.34078858511316,-68.47183381225649 -6.421001956791667,-68.48717948161975
+        -6.489352411935613,-68.5205142387293 -6.637909838584367,-68.5539568718754
+        -6.786345494802027,-68.58745172905216 -6.934737952645203,-68.62098556129902
+        -7.083070541137671,-68.65473411680182 -7.231294088196419,-68.6760387531828
+        -7.325395067077409))"},{"name":"s2datatakeid","content":"GS2A_20160805T144732_005856_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.50
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205534_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6d6fdaa6-2117-4bae-970c-4f20f3c9f1fd'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6d6fdaa6-2117-4bae-970c-4f20f3c9f1fd'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6d6fdaa6-2117-4bae-970c-4f20f3c9f1fd'')/Products(''Quicklook'')/$value"}],"id":"6d6fdaa6-2117-4bae-970c-4f20f3c9f1fd","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        603.54 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:17:06.155Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"2.0587"},"str":[{"name":"uuid","content":"6d6fdaa6-2117-4bae-970c-4f20f3c9f1fd"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205534_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.903903730990171,-65.6955361955253
+        0.904506202344557,-64.70941548873812 -0.088443094250338,-64.70920587028088
+        -0.088384188930846,-65.69520594472657 0.903903730990171,-65.6955361955253
+        0.903903730990171,-65.6955361955253</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205534_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.6955361955253 0.903903730990171,-64.70941548873812
+        0.904506202344557,-64.70920587028088 -0.088443094250338,-65.69520594472657
+        -0.088384188930846,-65.6955361955253 0.903903730990171,-65.6955361955253 0.903903730990171))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"603.54
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160716T235558_R139_V20160716T145212_20160716T145212","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5dccb497-3275-4839-9ff5-60b72cefe38c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5dccb497-3275-4839-9ff5-60b72cefe38c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5dccb497-3275-4839-9ff5-60b72cefe38c'')/Products(''Quicklook'')/$value"}],"id":"5dccb497-3275-4839-9ff5-60b72cefe38c","summary":"Date:
+        2016-07-16T14:52:12Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.71 GB","date":[{"name":"ingestiondate","content":"2016-07-17T00:12:46.763Z"},{"name":"beginposition","content":"2016-07-16T14:52:12Z"},{"name":"endposition","content":"2016-07-16T14:52:12Z"}],"int":[{"name":"orbitnumber","content":"5570"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"2.0676923076923073"},"str":[{"name":"uuid","content":"5dccb497-3275-4839-9ff5-60b72cefe38c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160716T235558_R139_V20160716T145212_20160716T145212.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.376870942991099,-69.00018084764044
+        -7.281365177888992,-69.00018118761395 -8.230498859705568,-69.00018159299859
+        -8.22937260678506,-68.09207424566608 -8.229472946800525,-68.09207403140283
+        -8.229317536684688,-68.04767075347118 -8.229262491883746,-68.0032876604223
+        -8.229162198038187,-68.00328789552823 -8.226297324933649,-67.18474557597366
+        -8.226398126465138,-67.18474514567032 -8.226140988458724,-67.14007762170615
+        -8.225984792224422,-67.09544973653786 -8.225884081237991,-67.0954501875956
+        -8.221174458521304,-66.27734014430516 -8.221274538592427,-66.27733950365256
+        -8.220918997302837,-66.2329638957028 -8.220663876926901,-66.18864685496362
+        -8.220563930551878,-66.18864751558618 -8.213299979039988,-65.28202352029784
+        -7.2661721315466945,-65.29030025371527 -6.416130193837673,-65.29683748483669
+        -6.418626011330089,-64.719916673474 -5.425787018912554,-64.71684733293108
+        -5.423640334598856,-65.30349460796113 -5.416924739912873,-65.30353928373772
+        -5.4219309173953585,-66.24899623557717 -5.425362066336241,-67.15086321305921
+        -5.427449229390539,-68.05319609957077 -5.428225419816825,-69.000180539198
+        -6.376870942991099,-69.00018084764044</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160716T235558_R139_V20160716T145212_20160716T145212"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-69.00018084764044 -6.376870942991099,-69.00018118761395
+        -7.281365177888992,-69.00018159299859 -8.230498859705568,-68.09207424566608
+        -8.22937260678506,-68.09207403140283 -8.229472946800525,-68.04767075347118
+        -8.229317536684688,-68.0032876604223 -8.229262491883746,-68.00328789552823
+        -8.229162198038187,-67.18474557597366 -8.226297324933649,-67.18474514567032
+        -8.226398126465138,-67.14007762170615 -8.226140988458724,-67.09544973653786
+        -8.225984792224422,-67.0954501875956 -8.225884081237991,-66.27734014430516
+        -8.221174458521304,-66.27733950365256 -8.221274538592427,-66.2329638957028
+        -8.220918997302837,-66.18864685496362 -8.220663876926901,-66.18864751558618
+        -8.220563930551878,-65.28202352029784 -8.213299979039988,-65.29030025371527
+        -7.2661721315466945,-65.29683748483669 -6.416130193837673,-64.719916673474
+        -6.418626011330089,-64.71684733293108 -5.425787018912554,-65.30349460796113
+        -5.423640334598856,-65.30353928373772 -5.416924739912873,-66.24899623557717
+        -5.4219309173953585,-67.15086321305921 -5.425362066336241,-68.05319609957077
+        -5.427449229390539,-69.000180539198 -5.428225419816825,-69.00018084764044
+        -6.376870942991099))"},{"name":"s2datatakeid","content":"GS2A_20160716T144732_005570_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.71
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160816T235748_R010_V20160816T142322_20160816T142325","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a6517401-62a6-46e8-8e93-d75d28bc2cbb'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a6517401-62a6-46e8-8e93-d75d28bc2cbb'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a6517401-62a6-46e8-8e93-d75d28bc2cbb'')/Products(''Quicklook'')/$value"}],"id":"a6517401-62a6-46e8-8e93-d75d28bc2cbb","summary":"Date:
+        2016-08-16T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        2.70 GB","date":[{"name":"ingestiondate","content":"2016-08-16T22:04:32.907Z"},{"name":"beginposition","content":"2016-08-16T14:23:22Z"},{"name":"endposition","content":"2016-08-16T14:23:25Z"}],"int":[{"name":"orbitnumber","content":"6013"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"2.0923000000000003"},"str":[{"name":"uuid","content":"a6517401-62a6-46e8-8e93-d75d28bc2cbb"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160816T235748_R010_V20160816T142322_20160816T142325.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.6474507790081057,-60.29970593339301
+        -3.74894336141875,-60.32228848393955 -3.799480612799753,-60.33347787851682
+        -3.8056518648435698,-60.299172948894174 -3.80565186484357,-60.299172948894174
+        -3.84167744754722,-60.09891292540322 -3.841437236349124,-60.09885977328816
+        -3.84144434845584,-60.09882082064731 -3.841344942753639,-60.09879857730468
+        -3.841372219042527,-60.09864880399101 -3.839309509760402,-60.09819216769712
+        -3.876024604408537,-59.891578322014496 -3.876567580518472,-59.89169831028434
+        -3.876570843119903,-59.89168000605068 -3.87670807854257,-59.891710189289086
+        -3.877140833396628,-59.889285322376686 -3.879673847541471,-59.88984711325656
+        -3.92385830764203,-59.66410304912357 -3.921714595358844,-59.663629475571454
+        -3.961241837643089,-59.46347250475815 -3.961382844328629,-59.46350355690405
+        -3.961390294473744,-59.46346588213856 -3.961728662690197,-59.4635401339989
+        -3.9621786031773,-59.46126976775808 -3.964399671613783,-59.4617605810805 -4.011057212160541,-59.240938711076474
+        -4.008872666994577,-59.240458427140126 -4.051757938583113,-59.04342510503318
+        -4.05190322243396,-59.04345702722666 -4.05191281667248,-59.043412957067616
+        -4.0524232317561,-59.04352469824524 -4.052878744144999,-59.04143294369698
+        -4.053682109072776,-59.04161003223018 -4.053689457213352,-59.0415763240741
+        -4.054042818999525,-59.041654087118985 -4.103696558060415,-58.82224810564975
+        -4.102084684516104,-58.82189442611895 -4.127802714065139,-58.71368525252306
+        -4.14890413829158,-58.62490054711295 -4.149075587123679,-58.62493811061182
+        -4.149088698221001,-58.62488290394501 -4.149379054191813,-58.62494624423578
+        -4.149831922013479,-58.62303801698251 -4.150517886703191,-58.62318866576846
+        -4.150563019221726,-58.622997768351695 -4.151404025430935,-58.62318212479559
+        -4.204903177268869,-58.40189696030316 -4.203097165369142,-58.40150144266597
+        -4.227241881182794,-58.30795178536695 -4.254680493069832,-58.20142696160542
+        -4.255067702834343,-58.20151114925592 -4.255587096963994,-58.19949136956094
+        -4.25588074091246,-58.199555593545305 -4.255893219071098,-58.19950687979726
+        -4.255987740854009,-58.19952772055769 -4.256061578533347,-58.19923823745405
+        -4.256646848807737,-58.19936606858267 -4.314762000059691,-57.97452474711089
+        -4.315197740154131,-57.97293550912185 -4.313689843613362,-57.97260594036862
+        -4.313717701751496,-57.97250601154676 -4.3136078657917,-57.972482151434875
+        -4.33332399427085,-57.90158476025694 -4.357976799013676,-57.81293553364362
+        -4.375578858381863,-57.74964014125037 -4.323657395111784,-57.73819056594879
+        -4.17526532259738,-57.70555435535962 -4.02688760031203,-57.672972748086174
+        -3.878465260399632,-57.640369399044175 -3.729899198610871,-57.60782449490896
+        -3.707214506718782,-57.6028684459584 -3.6618090610083778,-57.592948469410636
+        -3.618209078070418,-57.58342294220877 -3.581201012581982,-57.57533758733604
+        -3.432407133906726,-57.54286544031389 -3.28353686865665,-57.510409197845306
+        -3.135759005108527,-57.478135876922586 -3.072565476026819,-57.70801690528361
+        -3.07398074827941,-57.70832665629224 -3.073602543819774,-57.7098038558966
+        -3.073647844492304,-57.709813781069975 -3.073558102893753,-57.71016561307318
+        -3.073733168687259,-57.710203939309295 -3.0477835243231386,-57.81174516294148
+        -3.047783524323138,-57.81174516294148 -3.032873349432237,-57.87008882968881
+        -3.025159696038548,-57.90027243426077 -3.021622075765748,-57.91411517854681
+        -3.020449794112127,-57.9138582375714 -3.020410566263432,-57.91401058245679
+        -3.020226310017451,-57.91397019359776 -3.02018752245066,-57.914120543073274
+        -3.019758112731905,-57.91402644985608 -3.019714138934137,-57.91419632651503
+        -3.019351685061434,-57.91411694880848 -3.019311985057468,-57.91427002299248
+        -3.019103490287539,-57.91422433764694 -3.019043418788706,-57.91445550958167
+        -3.018531761375086,-57.91434339181636 -2.961504550782492,-58.137489176132135
+        -2.963499762857833,-58.13792663609459 -2.963073819274137,-58.13969446498282
+        -2.96328277300265,-58.13974033014501 -2.963233010035823,-58.13994726454021
+        -2.963283262253997,-58.13995828733729 -2.915427247942062,-58.33874507404536
+        -2.913365688565518,-58.338292402533774 -2.91334490163172,-58.338377898316445
+        -2.9125924955585,-58.338212713585975 -2.860439197031867,-58.55848723102416
+        -2.862713954043619,-58.558987004503216 -2.862272303401799,-58.560937203957046
+        -2.862859496834424,-58.56106636268085 -2.81826799260109,-58.75818438922949
+        -2.817576265676578,-58.75803207088633 -2.817564895974785,-58.75808231625576
+        -2.815224562194891,-58.75756731890407 -2.767259540230614,-58.97743204440437
+        -2.768437025938038,-58.97769127160042 -2.768420181556519,-58.97777094756575
+        -2.769161654372879,-58.9779343544391 -2.769127743289777,-58.97809440176981
+        -2.76983747293264,-58.97825074328711 -2.76936330244998,-58.98048389158082
+        -2.769565357155406,-58.98052842776734 -2.727509884122038,-59.178904146856446
+        -2.727038107809402,-59.17880010537361 -2.727027254178514,-59.178851280361926
+        -2.724373471592952,-59.178265616600186 -2.711988062743612,-59.24012618775933
+        -2.711849340935629,-59.31585468578026 -2.708535417726956,-59.315866557865895
+        -2.710590109180902,-60.091024649971416 -2.858288753470545,-60.12378087939207
+        -3.006830962288565,-60.15677562469352 -3.155276756112816,-60.1898118504494
+        -3.303627445186806,-60.22300363349406 -3.452008151816722,-60.25613595410572
+        -3.600432213545654,-60.28924409366086 -3.614418806216109,-60.29235617267641
+        -3.614455181286243,-60.292364266291145 -3.647413018099611,-60.299697531423085
+        -3.64745077900809,-60.29970593339301 -3.6474507790081057,-60.29970593339301</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160816T235748_R010_V20160816T142322_20160816T142325"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.29970593339301 -3.6474507790081057,-60.32228848393955
+        -3.74894336141875,-60.33347787851682 -3.799480612799753,-60.299172948894174
+        -3.8056518648435698,-60.299172948894174 -3.80565186484357,-60.09891292540322
+        -3.84167744754722,-60.09885977328816 -3.841437236349124,-60.09882082064731
+        -3.84144434845584,-60.09879857730468 -3.841344942753639,-60.09864880399101
+        -3.841372219042527,-60.09819216769712 -3.839309509760402,-59.891578322014496
+        -3.876024604408537,-59.89169831028434 -3.876567580518472,-59.89168000605068
+        -3.876570843119903,-59.891710189289086 -3.87670807854257,-59.889285322376686
+        -3.877140833396628,-59.88984711325656 -3.879673847541471,-59.66410304912357
+        -3.92385830764203,-59.663629475571454 -3.921714595358844,-59.46347250475815
+        -3.961241837643089,-59.46350355690405 -3.961382844328629,-59.46346588213856
+        -3.961390294473744,-59.4635401339989 -3.961728662690197,-59.46126976775808
+        -3.9621786031773,-59.4617605810805 -3.964399671613783,-59.240938711076474
+        -4.011057212160541,-59.240458427140126 -4.008872666994577,-59.04342510503318
+        -4.051757938583113,-59.04345702722666 -4.05190322243396,-59.043412957067616
+        -4.05191281667248,-59.04352469824524 -4.0524232317561,-59.04143294369698 -4.052878744144999,-59.04161003223018
+        -4.053682109072776,-59.0415763240741 -4.053689457213352,-59.041654087118985
+        -4.054042818999525,-58.82224810564975 -4.103696558060415,-58.82189442611895
+        -4.102084684516104,-58.71368525252306 -4.127802714065139,-58.62490054711295
+        -4.14890413829158,-58.62493811061182 -4.149075587123679,-58.62488290394501
+        -4.149088698221001,-58.62494624423578 -4.149379054191813,-58.62303801698251
+        -4.149831922013479,-58.62318866576846 -4.150517886703191,-58.622997768351695
+        -4.150563019221726,-58.62318212479559 -4.151404025430935,-58.40189696030316
+        -4.204903177268869,-58.40150144266597 -4.203097165369142,-58.30795178536695
+        -4.227241881182794,-58.20142696160542 -4.254680493069832,-58.20151114925592
+        -4.255067702834343,-58.19949136956094 -4.255587096963994,-58.199555593545305
+        -4.25588074091246,-58.19950687979726 -4.255893219071098,-58.19952772055769
+        -4.255987740854009,-58.19923823745405 -4.256061578533347,-58.19936606858267
+        -4.256646848807737,-57.97452474711089 -4.314762000059691,-57.97293550912185
+        -4.315197740154131,-57.97260594036862 -4.313689843613362,-57.97250601154676
+        -4.313717701751496,-57.972482151434875 -4.3136078657917,-57.90158476025694
+        -4.33332399427085,-57.81293553364362 -4.357976799013676,-57.74964014125037
+        -4.375578858381863,-57.73819056594879 -4.323657395111784,-57.70555435535962
+        -4.17526532259738,-57.672972748086174 -4.02688760031203,-57.640369399044175
+        -3.878465260399632,-57.60782449490896 -3.729899198610871,-57.6028684459584
+        -3.707214506718782,-57.592948469410636 -3.6618090610083778,-57.58342294220877
+        -3.618209078070418,-57.57533758733604 -3.581201012581982,-57.54286544031389
+        -3.432407133906726,-57.510409197845306 -3.28353686865665,-57.478135876922586
+        -3.135759005108527,-57.70801690528361 -3.072565476026819,-57.70832665629224
+        -3.07398074827941,-57.7098038558966 -3.073602543819774,-57.709813781069975
+        -3.073647844492304,-57.71016561307318 -3.073558102893753,-57.710203939309295
+        -3.073733168687259,-57.81174516294148 -3.0477835243231386,-57.81174516294148
+        -3.047783524323138,-57.87008882968881 -3.032873349432237,-57.90027243426077
+        -3.025159696038548,-57.91411517854681 -3.021622075765748,-57.9138582375714
+        -3.020449794112127,-57.91401058245679 -3.020410566263432,-57.91397019359776
+        -3.020226310017451,-57.914120543073274 -3.02018752245066,-57.91402644985608
+        -3.019758112731905,-57.91419632651503 -3.019714138934137,-57.91411694880848
+        -3.019351685061434,-57.91427002299248 -3.019311985057468,-57.91422433764694
+        -3.019103490287539,-57.91445550958167 -3.019043418788706,-57.91434339181636
+        -3.018531761375086,-58.137489176132135 -2.961504550782492,-58.13792663609459
+        -2.963499762857833,-58.13969446498282 -2.963073819274137,-58.13974033014501
+        -2.96328277300265,-58.13994726454021 -2.963233010035823,-58.13995828733729
+        -2.963283262253997,-58.33874507404536 -2.915427247942062,-58.338292402533774
+        -2.913365688565518,-58.338377898316445 -2.91334490163172,-58.338212713585975
+        -2.9125924955585,-58.55848723102416 -2.860439197031867,-58.558987004503216
+        -2.862713954043619,-58.560937203957046 -2.862272303401799,-58.56106636268085
+        -2.862859496834424,-58.75818438922949 -2.81826799260109,-58.75803207088633
+        -2.817576265676578,-58.75808231625576 -2.817564895974785,-58.75756731890407
+        -2.815224562194891,-58.97743204440437 -2.767259540230614,-58.97769127160042
+        -2.768437025938038,-58.97777094756575 -2.768420181556519,-58.9779343544391
+        -2.769161654372879,-58.97809440176981 -2.769127743289777,-58.97825074328711
+        -2.76983747293264,-58.98048389158082 -2.76936330244998,-58.98052842776734
+        -2.769565357155406,-59.178904146856446 -2.727509884122038,-59.17880010537361
+        -2.727038107809402,-59.178851280361926 -2.727027254178514,-59.178265616600186
+        -2.724373471592952,-59.24012618775933 -2.711988062743612,-59.31585468578026
+        -2.711849340935629,-59.315866557865895 -2.708535417726956,-60.091024649971416
+        -2.710590109180902,-60.12378087939207 -2.858288753470545,-60.15677562469352
+        -3.006830962288565,-60.1898118504494 -3.155276756112816,-60.22300363349406
+        -3.303627445186806,-60.25613595410572 -3.452008151816722,-60.28924409366086
+        -3.600432213545654,-60.29235617267641 -3.614418806216109,-60.292364266291145
+        -3.614455181286243,-60.299697531423085 -3.647413018099611,-60.29970593339301
+        -3.64745077900809,-60.29970593339301 -3.6474507790081057))"},{"name":"s2datatakeid","content":"GS2A_20160816T142322_006013_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"2.70
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210308_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4249c4fa-3e5b-4458-9271-65c4e453e1d0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4249c4fa-3e5b-4458-9271-65c4e453e1d0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4249c4fa-3e5b-4458-9271-65c4e453e1d0'')/Products(''Quicklook'')/$value"}],"id":"4249c4fa-3e5b-4458-9271-65c4e453e1d0","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        628.74 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:32:24.767Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"2.1311"},"str":[{"name":"uuid","content":"4249c4fa-3e5b-4458-9271-65c4e453e1d0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210308_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.711149745616365,-66.30215450635603
+        -2.708535417726956,-65.31586655786589 -3.699830563697336,-65.31231525624496
+        -3.703403926315087,-66.29955059811704 -2.711149745616365,-66.30215450635603
+        -2.711149745616365,-66.30215450635603</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210308_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-66.30215450635603 -2.711149745616365,-65.31586655786589
+        -2.708535417726956,-65.31231525624496 -3.699830563697336,-66.29955059811704
+        -3.703403926315087,-66.30215450635603 -2.711149745616365,-66.30215450635603
+        -2.711149745616365))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"628.74
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T231959_R010_V20160627T142038_20160627T142038","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb17aadb-a487-416d-b4db-fc585669f1b2'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb17aadb-a487-416d-b4db-fc585669f1b2'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb17aadb-a487-416d-b4db-fc585669f1b2'')/Products(''Quicklook'')/$value"}],"id":"eb17aadb-a487-416d-b4db-fc585669f1b2","summary":"Date:
+        2016-06-27T14:20:38Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.16 GB","date":[{"name":"ingestiondate","content":"2016-06-28T00:09:25.425Z"},{"name":"beginposition","content":"2016-06-27T14:20:38Z"},{"name":"endposition","content":"2016-06-27T14:20:38Z"}],"int":[{"name":"orbitnumber","content":"5298"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"2.164846153846154"},"str":[{"name":"uuid","content":"eb17aadb-a487-416d-b4db-fc585669f1b2"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T231959_R010_V20160627T142038_20160627T142038.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.236383951347981,-62.09419464575659
+        -8.229472946800525,-62.09207403140284 -8.226297324933649,-61.18474557597368
+        -8.226398126465138,-61.18474514567033 -8.226140988458724,-61.140077621706126
+        -8.225984792224422,-61.09544973653788 -8.225884081237991,-61.095450187595624
+        -8.221174458521304,-60.27734014430516 -8.221274538592427,-60.277339503652556
+        -8.220918997302837,-60.232963895702774 -8.220663876926901,-60.18864685496363
+        -8.220563930551878,-60.18864751558619 -8.216833080207858,-59.72299484166875
+        -8.221272080743814,-59.723023261271635 -8.226296312759192,-58.81561742540932
+        -8.22639648636114,-58.815617853117644 -8.226541922193537,-58.771258917803664
+        -8.226787741770087,-58.72686245728039 -8.22668748239152,-58.72686205012567
+        -8.229664156708726,-57.818955784450985 -7.325011205780803,-57.81721330024698
+        -7.325011235731498,-57.81720304463014 -7.280627889666042,-57.81712781196424
+        -7.236551833181055,-57.8170429155052 -7.236551803794858,-57.81705310012441
+        -6.420864357044481,-57.81567045670977 -6.420864383205277,-57.8156602442492
+        -6.376226064789988,-57.81559479189346 -6.331858920051649,-57.81551958668987
+        -6.331858894408632,-57.81552973711715 -5.427676976856658,-57.81420395158968
+        -5.42562550187137,-58.76098681421245 -5.423640334598856,-59.30349460796113
+        -5.416924739912873,-59.30353928373773 -5.4219309173953585,-60.2489962355772
+        -5.425531020312141,-61.19527224752645 -6.329352766457671,-61.192335123226385
+        -6.329352866202743,-61.192357609869305 -6.373702387567744,-61.192191001500596
+        -6.418322819571477,-61.1920459997282 -6.418322717812893,-61.19202337578098
+        -7.2335956909932015,-61.18896063021043 -7.236383951347981,-62.09419464575659</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T231959_R010_V20160627T142038_20160627T142038"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.09419464575659 -7.236383951347981,-62.09207403140284
+        -8.229472946800525,-61.18474557597368 -8.226297324933649,-61.18474514567033
+        -8.226398126465138,-61.140077621706126 -8.226140988458724,-61.09544973653788
+        -8.225984792224422,-61.095450187595624 -8.225884081237991,-60.27734014430516
+        -8.221174458521304,-60.277339503652556 -8.221274538592427,-60.232963895702774
+        -8.220918997302837,-60.18864685496363 -8.220663876926901,-60.18864751558619
+        -8.220563930551878,-59.72299484166875 -8.216833080207858,-59.723023261271635
+        -8.221272080743814,-58.81561742540932 -8.226296312759192,-58.815617853117644
+        -8.22639648636114,-58.771258917803664 -8.226541922193537,-58.72686245728039
+        -8.226787741770087,-58.72686205012567 -8.22668748239152,-57.818955784450985
+        -8.229664156708726,-57.81721330024698 -7.325011205780803,-57.81720304463014
+        -7.325011235731498,-57.81712781196424 -7.280627889666042,-57.8170429155052
+        -7.236551833181055,-57.81705310012441 -7.236551803794858,-57.81567045670977
+        -6.420864357044481,-57.8156602442492 -6.420864383205277,-57.81559479189346
+        -6.376226064789988,-57.81551958668987 -6.331858920051649,-57.81552973711715
+        -6.331858894408632,-57.81420395158968 -5.427676976856658,-58.76098681421245
+        -5.42562550187137,-59.30349460796113 -5.423640334598856,-59.30353928373773
+        -5.416924739912873,-60.2489962355772 -5.4219309173953585,-61.19527224752645
+        -5.425531020312141,-61.192335123226385 -6.329352766457671,-61.192357609869305
+        -6.329352866202743,-61.192191001500596 -6.373702387567744,-61.1920459997282
+        -6.418322819571477,-61.19202337578098 -6.418322717812893,-61.18896063021043
+        -7.2335956909932015,-62.09419464575659 -7.236383951347981))"},{"name":"s2datatakeid","content":"GS2A_20160627T142042_005298_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.16
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210411_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f9980c83-d1b1-4746-82da-1b4b78857d8a'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f9980c83-d1b1-4746-82da-1b4b78857d8a'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f9980c83-d1b1-4746-82da-1b4b78857d8a'')/Products(''Quicklook'')/$value"}],"id":"f9980c83-d1b1-4746-82da-1b4b78857d8a","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        572.78 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:29:23.544Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"2.2007"},"str":[{"name":"uuid","content":"f9980c83-d1b1-4746-82da-1b4b78857d8a"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210411_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.808443759224569,-64.72751526800782
+        -1.854827472075815,-64.73770980421178 -2.003396645126754,-64.77031478630461
+        -2.151896957403622,-64.80283461471504 -2.300292283972443,-64.83532877944576
+        -2.448693378196944,-64.86778702787839 -2.59720068434536,-64.90023268635333
+        -2.745781310451184,-64.93280424980706 -2.800956112560689,-64.94489671796227
+        -2.799530854700205,-65.69840409206232 -1.807260224698412,-65.69653612035876
+        -1.808443759224569,-64.72751526800782 -1.808443759224569,-64.72751526800782</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210411_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.72751526800782 -1.808443759224569,-64.73770980421178
+        -1.854827472075815,-64.77031478630461 -2.003396645126754,-64.80283461471504
+        -2.151896957403622,-64.83532877944576 -2.300292283972443,-64.86778702787839
+        -2.448693378196944,-64.90023268635333 -2.59720068434536,-64.93280424980706
+        -2.745781310451184,-64.94489671796227 -2.800956112560689,-65.69840409206232
+        -2.799530854700205,-65.69653612035876 -1.807260224698412,-64.72751526800782
+        -1.808443759224569,-64.72751526800782 -1.808443759224569))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"572.78
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163722_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e4f07ab2-313e-4d9d-9ab9-3a74fead82f5'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e4f07ab2-313e-4d9d-9ab9-3a74fead82f5'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e4f07ab2-313e-4d9d-9ab9-3a74fead82f5'')/Products(''Quicklook'')/$value"}],"id":"e4f07ab2-313e-4d9d-9ab9-3a74fead82f5","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        580.39 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:30:20.603Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"2.309"},"str":[{"name":"uuid","content":"e4f07ab2-313e-4d9d-9ab9-3a74fead82f5"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163722_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.13067096085671,-59.31988831223303
+        -0.166224174051098,-59.32769873933688 -0.314833324465859,-59.36033614654004
+        -0.463285033661429,-59.39297780161835 -0.611662472205021,-59.425688119733714
+        -0.760181804165623,-59.45793154433354 -0.908658574549098,-59.490390737689474
+        -0.99151521594926,-59.50852255032778 -0.992287945780174,-60.30475452350715
+        0,-60.30515631259404 0,-59.319960543069975 -0.13067096085671,-59.31988831223303
+        -0.13067096085671,-59.31988831223303</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163722_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.31988831223303 -0.13067096085671,-59.32769873933688
+        -0.166224174051098,-59.36033614654004 -0.314833324465859,-59.39297780161835
+        -0.463285033661429,-59.425688119733714 -0.611662472205021,-59.45793154433354
+        -0.760181804165623,-59.490390737689474 -0.908658574549098,-59.50852255032778
+        -0.99151521594926,-60.30475452350715 -0.992287945780174,-60.30515631259404
+        0,-59.319960543069975 0,-59.31988831223303 -0.13067096085671,-59.31988831223303
+        -0.13067096085671))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"580.39
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164156_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''04c36116-4a04-4678-b4b2-9bb167e37f89'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''04c36116-4a04-4678-b4b2-9bb167e37f89'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''04c36116-4a04-4678-b4b2-9bb167e37f89'')/Products(''Quicklook'')/$value"}],"id":"04c36116-4a04-4678-b4b2-9bb167e37f89","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        208.46 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:42:55.466Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"2.4307"},"str":[{"name":"uuid","content":"04c36116-4a04-4678-b4b2-9bb167e37f89"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164156_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-59.29118444574193
+        -0.017471451431342,-59.29502033442963 -0.166224174051098,-59.32769873933688
+        -0.314833324465859,-59.36033614654004 -0.463285033661429,-59.39297780161835
+        -0.611662472205021,-59.425688119733714 -0.760181804165623,-59.45793154433354
+        -0.908658574549098,-59.490390737689474 -0.992412992192095,-59.50871901388642
+        -0.992287651053575,-59.695604599503994 0,-59.69520275703949 0,-59.29118444574193
+        0,-59.29118444574193</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164156_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.29118444574193 0,-59.29502033442963
+        -0.017471451431342,-59.32769873933688 -0.166224174051098,-59.36033614654004
+        -0.314833324465859,-59.39297780161835 -0.463285033661429,-59.425688119733714
+        -0.611662472205021,-59.45793154433354 -0.760181804165623,-59.490390737689474
+        -0.908658574549098,-59.50871901388642 -0.992412992192095,-59.695604599503994
+        -0.992287651053575,-59.69520275703949 0,-59.29118444574193 0,-59.29118444574193
+        0))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"208.46
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003200_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f5abe44e-f73b-4bcf-8e38-9b9f3a82ad06'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f5abe44e-f73b-4bcf-8e38-9b9f3a82ad06'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f5abe44e-f73b-4bcf-8e38-9b9f3a82ad06'')/Products(''Quicklook'')/$value"}],"id":"f5abe44e-f73b-4bcf-8e38-9b9f3a82ad06","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        425.08 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:59:58.931Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"2.5422"},"str":[{"name":"uuid","content":"f5abe44e-f73b-4bcf-8e38-9b9f3a82ad06"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003200_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.809214418670571,-57.17533253167107
+        -1.886712333619381,-57.192381299703634 -2.035491432840277,-57.22497662604318
+        -2.184243275977929,-57.25741590431945 -2.33281961481213,-57.290070082185466
+        -2.481377450749515,-57.322530089178414 -2.629765200316431,-57.35511353102968
+        -2.778142151508841,-57.38769577094944 -2.802483516119453,-57.39304573643276
+        -2.802306823350039,-57.9000663091644 -1.809051474065233,-57.899442419028375
+        -1.809214418670571,-57.17533253167107 -1.809214418670571,-57.17533253167107</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003200_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.17533253167107 -1.809214418670571,-57.192381299703634
+        -1.886712333619381,-57.22497662604318 -2.035491432840277,-57.25741590431945
+        -2.184243275977929,-57.290070082185466 -2.33281961481213,-57.322530089178414
+        -2.481377450749515,-57.35511353102968 -2.629765200316431,-57.38769577094944
+        -2.778142151508841,-57.39304573643276 -2.802483516119453,-57.9000663091644
+        -2.802306823350039,-57.899442419028375 -1.809051474065233,-57.17533253167107
+        -1.809214418670571,-57.17533253167107 -1.809214418670571))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"425.08
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222902_R010_V20160806T142041_20160806T142041","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7027599f-e820-4e4e-ad5e-14b8c3c1cb63'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7027599f-e820-4e4e-ad5e-14b8c3c1cb63'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7027599f-e820-4e4e-ad5e-14b8c3c1cb63'')/Products(''Quicklook'')/$value"}],"id":"7027599f-e820-4e4e-ad5e-14b8c3c1cb63","summary":"Date:
+        2016-08-06T14:20:41Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.06 GB","date":[{"name":"ingestiondate","content":"2016-08-07T07:18:41.635Z"},{"name":"beginposition","content":"2016-08-06T14:20:41Z"},{"name":"endposition","content":"2016-08-06T14:20:41Z"}],"int":[{"name":"orbitnumber","content":"5870"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"2.563542857142857"},"str":[{"name":"uuid","content":"7027599f-e820-4e4e-ad5e-14b8c3c1cb63"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222902_R010_V20160806T142041_20160806T142041.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.837949532365655,-59.89782063678086
+        -1.894914917008778,-59.91041067302115 -1.986381888307138,-59.930625975536
+        -2.134700670107271,-59.96376998410072 -2.283142078619617,-59.99678172145568
+        -2.431686688617026,-60.02971223928548 -2.580297433136881,-60.06265143764845
+        -2.728912193520602,-60.095584915392 -2.799009244111295,-60.111074841577434
+        -2.797879750232732,-59.69840098382115 -2.799530854700205,-59.698404092062326
+        -2.8012317183660334,-58.799189044685384 -2.801265630042686,-58.79918908725958
+        -2.8013148643462156,-58.755231308382875 -2.801398081739323,-58.71123581739256
+        -2.801364140934071,-58.7112357768642 -2.8022726801247053,-57.90006628771813
+        -2.802306823350039,-57.9000663091644 -2.8023222452332335,-57.85581315678163
+        -2.802371831094856,-57.811541496895146 -2.802337673572892,-57.81154147754995
+        -2.802479274238617,-57.40521782959696 -2.708968116529134,-57.384596723813054
+        -2.560577408441857,-57.35194453634374 -2.412061256621638,-57.31939182241491
+        -2.263378086233008,-57.28689534067605 -2.114623924479994,-57.254239207167885
+        -1.965750111737202,-57.22184906083665 -1.897685749875135,-57.206970320487706
+        -1.816992032598411,-57.1893308270097 -1.809211651958075,-57.187627531371966
+        -1.668286571035048,-57.15677594625305 -1.519546085084426,-57.12446464698439
+        -1.370937733712771,-57.09170145021835 -1.222402107786372,-57.05900308808605
+        -1.073936157875208,-57.02641114620954 -0.993380963046348,-57.00865529926839
+        -0.9549289176484967,-57.00017976104756 -0.9549289176485,-57.00017976104756
+        -0.925532291478548,-56.99370020382014 -0.904367199033058,-56.989037574687785
+        -0.777130291938801,-56.961007528929365 -0.628610729254802,-56.92836864679177
+        -0.479951882818819,-56.895767997952255 -0.331134774826241,-56.863306079564666
+        -0.18228678632609,-56.83067118580243 -0.033409207256527,-56.79821137089437
+        0,-56.79087435071384 0,-56.91228937849629 0,-57.000179734950805 0,-57.81057740574848
+        0,-57.89899708558173 0,-58.70920384697636 0,-58.7970528123519 0,-59.319960543069975
+        0,-59.49202163366726 -0.054890062927321,-59.504207787714144 -0.203362757392473,-59.53686294569464
+        -0.351824391286966,-59.56968518077159 -0.500354302162794,-59.60252912107872
+        -0.648978844534048,-59.63524985407324 -0.79757109940077,-59.668156574308405
+        -0.946268948061766,-59.700811770703126 -1.094885257247882,-59.733753332305206
+        -1.243644836478163,-59.766444344519535 -1.392351714635398,-59.799268741299606
+        -1.541019333928938,-59.83204462488607 -1.689524523510054,-59.86490545704108
+        -1.837949532365655,-59.89782063678086</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160806T222902_R010_V20160806T142041_20160806T142041"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.89782063678086 -1.837949532365655,-59.91041067302115
+        -1.894914917008778,-59.930625975536 -1.986381888307138,-59.96376998410072
+        -2.134700670107271,-59.99678172145568 -2.283142078619617,-60.02971223928548
+        -2.431686688617026,-60.06265143764845 -2.580297433136881,-60.095584915392
+        -2.728912193520602,-60.111074841577434 -2.799009244111295,-59.69840098382115
+        -2.797879750232732,-59.698404092062326 -2.799530854700205,-58.799189044685384
+        -2.8012317183660334,-58.79918908725958 -2.801265630042686,-58.755231308382875
+        -2.8013148643462156,-58.71123581739256 -2.801398081739323,-58.7112357768642
+        -2.801364140934071,-57.90006628771813 -2.8022726801247053,-57.9000663091644
+        -2.802306823350039,-57.85581315678163 -2.8023222452332335,-57.811541496895146
+        -2.802371831094856,-57.81154147754995 -2.802337673572892,-57.40521782959696
+        -2.802479274238617,-57.384596723813054 -2.708968116529134,-57.35194453634374
+        -2.560577408441857,-57.31939182241491 -2.412061256621638,-57.28689534067605
+        -2.263378086233008,-57.254239207167885 -2.114623924479994,-57.22184906083665
+        -1.965750111737202,-57.206970320487706 -1.897685749875135,-57.1893308270097
+        -1.816992032598411,-57.187627531371966 -1.809211651958075,-57.15677594625305
+        -1.668286571035048,-57.12446464698439 -1.519546085084426,-57.09170145021835
+        -1.370937733712771,-57.05900308808605 -1.222402107786372,-57.02641114620954
+        -1.073936157875208,-57.00865529926839 -0.993380963046348,-57.00017976104756
+        -0.9549289176484967,-57.00017976104756 -0.9549289176485,-56.99370020382014
+        -0.925532291478548,-56.989037574687785 -0.904367199033058,-56.961007528929365
+        -0.777130291938801,-56.92836864679177 -0.628610729254802,-56.895767997952255
+        -0.479951882818819,-56.863306079564666 -0.331134774826241,-56.83067118580243
+        -0.18228678632609,-56.79821137089437 -0.033409207256527,-56.79087435071384
+        0,-56.91228937849629 0,-57.000179734950805 0,-57.81057740574848 0,-57.89899708558173
+        0,-58.70920384697636 0,-58.7970528123519 0,-59.319960543069975 0,-59.49202163366726
+        0,-59.504207787714144 -0.054890062927321,-59.53686294569464 -0.203362757392473,-59.56968518077159
+        -0.351824391286966,-59.60252912107872 -0.500354302162794,-59.63524985407324
+        -0.648978844534048,-59.668156574308405 -0.79757109940077,-59.700811770703126
+        -0.946268948061766,-59.733753332305206 -1.094885257247882,-59.766444344519535
+        -1.243644836478163,-59.799268741299606 -1.392351714635398,-59.83204462488607
+        -1.541019333928938,-59.86490545704108 -1.689524523510054,-59.89782063678086
+        -1.837949532365655))"},{"name":"s2datatakeid","content":"GS2A_20160806T142042_005870_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.06
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002238_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''70e7b477-7c98-4df9-8d3f-455aeff0d44d'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''70e7b477-7c98-4df9-8d3f-455aeff0d44d'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''70e7b477-7c98-4df9-8d3f-455aeff0d44d'')/Products(''Quicklook'')/$value"}],"id":"70e7b477-7c98-4df9-8d3f-455aeff0d44d","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        635.18 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:39:25.025Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"2.6151"},"str":[{"name":"uuid","content":"70e7b477-7c98-4df9-8d3f-455aeff0d44d"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002238_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.904799412660897,-57.89910845147845
+        0.90491049284172,-56.9122785113194 -0.088482622864584,-56.91228927460561 -0.088471762244608,-57.89899815024451
+        0.904799412660897,-57.89910845147845 0.904799412660897,-57.89910845147845</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002238_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.89910845147845 0.904799412660897,-56.9122785113194
+        0.90491049284172,-56.91228927460561 -0.088482622864584,-57.89899815024451
+        -0.088471762244608,-57.89910845147845 0.904799412660897,-57.89910845147845
+        0.904799412660897))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"635.18
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000448_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b0563b3f-6875-4dc3-84b4-441d495de834'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b0563b3f-6875-4dc3-84b4-441d495de834'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b0563b3f-6875-4dc3-84b4-441d495de834'')/Products(''Quicklook'')/$value"}],"id":"b0563b3f-6875-4dc3-84b4-441d495de834","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        613.15 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:50:09.324Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"3.0129"},"str":[{"name":"uuid","content":"b0563b3f-6875-4dc3-84b4-441d495de834"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000448_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.32541958958744,-59.711613467205204
+        -6.329651821896023,-58.71962021832075 -7.322454553607849,-58.72316833279473
+        -7.317551984823172,-59.7172033645207 -6.32541958958744,-59.711613467205204
+        -6.32541958958744,-59.711613467205204</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000448_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.711613467205204
+        -6.32541958958744,-58.71962021832075 -6.329651821896023,-58.72316833279473
+        -7.322454553607849,-59.7172033645207 -7.317551984823172,-59.711613467205204
+        -6.32541958958744,-59.711613467205204 -6.32541958958744))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"613.15
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205941_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''68a04175-880c-498a-a346-879bd9c5890a'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''68a04175-880c-498a-a346-879bd9c5890a'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''68a04175-880c-498a-a346-879bd9c5890a'')/Products(''Quicklook'')/$value"}],"id":"68a04175-880c-498a-a346-879bd9c5890a","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        611.17 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:24:47.81Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"3.0441"},"str":[{"name":"uuid","content":"68a04175-880c-498a-a346-879bd9c5890a"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205941_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.903903999460832,-66.30482291839957
+        0.903032930477922,-65.3195058456724 -0.088299048298173,-65.31995619614115
+        -0.08838421517998,-66.30515312533039 0.903903999460832,-66.30482291839957
+        0.903903999460832,-66.30482291839957</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205941_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-66.30482291839957 0.903903999460832,-65.3195058456724
+        0.903032930477922,-65.31995619614115 -0.088299048298173,-66.30515312533039
+        -0.08838421517998,-66.30482291839957 0.903903999460832,-66.30482291839957
+        0.903903999460832))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"611.17
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T232301_R010_V20160627T142038_20160627T142038","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''095292ae-9d38-4c49-b261-8f358e616b3c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''095292ae-9d38-4c49-b261-8f358e616b3c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''095292ae-9d38-4c49-b261-8f358e616b3c'')/Products(''Quicklook'')/$value"}],"id":"095292ae-9d38-4c49-b261-8f358e616b3c","summary":"Date:
+        2016-06-27T14:20:38Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.08 GB","date":[{"name":"ingestiondate","content":"2016-06-28T00:09:26.321Z"},{"name":"beginposition","content":"2016-06-27T14:20:38Z"},{"name":"endposition","content":"2016-06-27T14:20:38Z"}],"int":[{"name":"orbitnumber","content":"5298"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"3.235735714285714"},"str":[{"name":"uuid","content":"095292ae-9d38-4c49-b261-8f358e616b3c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T232301_R010_V20160627T142038_20160627T142038.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.616722069061711,-61.19974375617475
+        -4.521138290585007,-61.19771185555156 -4.521138360525212,-61.19773390587045
+        -4.5652581385101065,-61.19761273399186 -4.609571394393226,-61.19751317791347
+        -4.609571322775516,-61.19749103093647 -5.513961491831883,-61.19500718671128
+        -5.510472970358236,-60.292718824860636 -5.510539807042403,-60.29271854959391
+        -5.510302364769759,-60.24859255586318 -5.510131987398975,-60.204525314213285
+        -5.5100652401698405,-60.204525598059945 -5.507391437327689,-59.70762921084262
+        -5.510538165612144,-59.70764217236141 -5.513893497961508,-58.80535357891916
+        -5.513960396525286,-58.80535376268811 -5.514057522441122,-58.76124545442016
+        -5.514221687588917,-58.7170995025818 -5.514154731632817,-58.71709932764371
+        -5.515947033626909,-57.90315169909761 -5.516014389089381,-57.903151791669515
+        -5.516044812342758,-57.85874693129026 -5.516142631941844,-57.814323596961835
+        -5.516075248310466,-57.81432351345917 -5.516693539799448,-56.91188395837315
+        -4.567517939644129,-56.91201123965434 -3.662943732152377,-56.9121104660506
+        -2.714170526975779,-56.91219153266883 -2.7138520768084997,-57.85574991870128
+        -2.7128765456728288,-58.755101671966266 -2.7118493409356286,-59.31585468578026
+        -2.708535417726956,-59.315866557865895 -2.711149745616365,-60.30215450635603
+        -3.6144376607741897,-60.29978406651288 -3.616722069061711,-61.19974375617475</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T232301_R010_V20160627T142038_20160627T142038"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.19974375617475 -3.616722069061711,-61.19771185555156
+        -4.521138290585007,-61.19773390587045 -4.521138360525212,-61.19761273399186
+        -4.5652581385101065,-61.19751317791347 -4.609571394393226,-61.19749103093647
+        -4.609571322775516,-61.19500718671128 -5.513961491831883,-60.292718824860636
+        -5.510472970358236,-60.29271854959391 -5.510539807042403,-60.24859255586318
+        -5.510302364769759,-60.204525314213285 -5.510131987398975,-60.204525598059945
+        -5.5100652401698405,-59.70762921084262 -5.507391437327689,-59.70764217236141
+        -5.510538165612144,-58.80535357891916 -5.513893497961508,-58.80535376268811
+        -5.513960396525286,-58.76124545442016 -5.514057522441122,-58.7170995025818
+        -5.514221687588917,-58.71709932764371 -5.514154731632817,-57.90315169909761
+        -5.515947033626909,-57.903151791669515 -5.516014389089381,-57.85874693129026
+        -5.516044812342758,-57.814323596961835 -5.516142631941844,-57.81432351345917
+        -5.516075248310466,-56.91188395837315 -5.516693539799448,-56.91201123965434
+        -4.567517939644129,-56.9121104660506 -3.662943732152377,-56.91219153266883
+        -2.714170526975779,-57.85574991870128 -2.7138520768084997,-58.755101671966266
+        -2.7128765456728288,-59.31585468578026 -2.7118493409356286,-59.315866557865895
+        -2.708535417726956,-60.30215450635603 -2.711149745616365,-60.29978406651288
+        -3.6144376607741897,-61.19974375617475 -3.616722069061711))"},{"name":"s2datatakeid","content":"GS2A_20160627T142042_005298_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.08
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210205_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''73dc0a12-293d-4f10-8673-d049b9fe63c0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''73dc0a12-293d-4f10-8673-d049b9fe63c0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''73dc0a12-293d-4f10-8673-d049b9fe63c0'')/Products(''Quicklook'')/$value"}],"id":"73dc0a12-293d-4f10-8673-d049b9fe63c0","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        450.97 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:30:42.502Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"3.2492"},"str":[{"name":"uuid","content":"73dc0a12-293d-4f10-8673-d049b9fe63c0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210205_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.712564363533809,-64.92552249361438
+        -2.745781310451184,-64.93280424980706 -2.894440574599122,-64.96538538012297
+        -3.043179264062513,-64.99799276203979 -3.19194705374276,-65.03071064149661
+        -3.340735109940246,-65.06332271512811 -3.489486780824862,-65.09585393732199
+        -3.638144400299183,-65.12845217237721 -3.704798041103085,-65.14303719805457
+        -3.703402824973188,-65.70080921622827 -2.711148939858159,-65.69820496206522
+        -2.712564363533809,-64.92552249361438 -2.712564363533809,-64.92552249361438</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210205_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.92552249361438 -2.712564363533809,-64.93280424980706
+        -2.745781310451184,-64.96538538012297 -2.894440574599122,-64.99799276203979
+        -3.043179264062513,-65.03071064149661 -3.19194705374276,-65.06332271512811
+        -3.340735109940246,-65.09585393732199 -3.489486780824862,-65.12845217237721
+        -3.638144400299183,-65.14303719805457 -3.704798041103085,-65.70080921622827
+        -3.703402824973188,-65.69820496206522 -2.711148939858159,-64.92552249361438
+        -2.712564363533809,-64.92552249361438 -2.712564363533809))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"450.97
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002558_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8efb1b2e-7de6-425c-b01c-c91eddfe1acb'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8efb1b2e-7de6-425c-b01c-c91eddfe1acb'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8efb1b2e-7de6-425c-b01c-c91eddfe1acb'')/Products(''Quicklook'')/$value"}],"id":"8efb1b2e-7de6-425c-b01c-c91eddfe1acb","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        651.72 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:54:09.026Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"3.4236"},"str":[{"name":"uuid","content":"8efb1b2e-7de6-425c-b01c-c91eddfe1acb"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002558_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.711148939858159,-59.69820496206522
+        -2.712957132034671,-58.711109424229335 -3.705874334456282,-58.71276241632309
+        -3.703402824973188,-59.70080921622827 -2.711148939858159,-59.69820496206522
+        -2.711148939858159,-59.69820496206522</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002558_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.69820496206522 -2.711148939858159,-58.711109424229335
+        -2.712957132034671,-58.71276241632309 -3.705874334456282,-59.70080921622827
+        -3.703402824973188,-59.69820496206522 -2.711148939858159,-59.69820496206522
+        -2.711148939858159))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"651.72
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002257_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''84df764e-5f2c-4f8f-96e2-0e22c1d6eda0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''84df764e-5f2c-4f8f-96e2-0e22c1d6eda0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''84df764e-5f2c-4f8f-96e2-0e22c1d6eda0'')/Products(''Quicklook'')/$value"}],"id":"84df764e-5f2c-4f8f-96e2-0e22c1d6eda0","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        587.55 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:59:52.047Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"3.5406"},"str":[{"name":"uuid","content":"84df764e-5f2c-4f8f-96e2-0e22c1d6eda0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002257_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.703403494175396,-60.29943120816969
+        -3.689673324469156,-60.29636487162095 -3.54126976725244,-60.26335944559812
+        -3.392791854875465,-60.230436130679145 -3.244296884085361,-60.19745789870841
+        -3.095712340043154,-60.16456579344091 -3.068750582881187,-60.15857496732752
+        -2.946892851696688,-60.13148696528118 -2.904422588500513,-60.12207267086711
+        -2.798418603696909,-60.09854601291832 -2.710558443925352,-60.07907853561371
+        -2.708535417726956,-59.315866557865895 -3.699830563697336,-59.31231525624494
+        -3.703403494175396,-60.29943120816969 -3.703403494175396,-60.29943120816969</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002257_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.29943120816969 -3.703403494175396,-60.29636487162095
+        -3.689673324469156,-60.26335944559812 -3.54126976725244,-60.230436130679145
+        -3.392791854875465,-60.19745789870841 -3.244296884085361,-60.16456579344091
+        -3.095712340043154,-60.15857496732752 -3.068750582881187,-60.13148696528118
+        -2.946892851696688,-60.12207267086711 -2.904422588500513,-60.09854601291832
+        -2.798418603696909,-60.07907853561371 -2.710558443925352,-59.315866557865895
+        -2.708535417726956,-59.31231525624494 -3.699830563697336,-60.29943120816969
+        -3.703403494175396,-60.29943120816969 -3.703403494175396))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"587.55
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T232530_R010_V20160627T142038_20160627T142038","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''619403a9-3595-455e-b9ba-2721681e7527'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''619403a9-3595-455e-b9ba-2721681e7527'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''619403a9-3595-455e-b9ba-2721681e7527'')/Products(''Quicklook'')/$value"}],"id":"619403a9-3595-455e-b9ba-2721681e7527","summary":"Date:
+        2016-06-27T14:20:38Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.17 GB","date":[{"name":"ingestiondate","content":"2016-06-28T00:09:23.851Z"},{"name":"beginposition","content":"2016-06-27T14:20:38Z"},{"name":"endposition","content":"2016-06-27T14:20:38Z"}],"int":[{"name":"orbitnumber","content":"5298"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"3.643899999999999"},"str":[{"name":"uuid","content":"619403a9-3595-455e-b9ba-2721681e7527"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T232530_R010_V20160627T142038_20160627T142038.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-60.30515631259404
+        -0.9033617375403121,-60.304790530777176 -0.903361766508728,-60.30482331831355
+        -0.9478046119954973,-60.30477253533339 -0.992287945780174,-60.30475452350715
+        -0.9922879139314531,-60.30472170612534 -1.807260703892119,-60.303790470814704
+        -1.807260761605379,-60.303823126388046 -1.851413056416722,-60.3037400197687
+        -1.895643950033409,-60.30368947897708 -1.8956438893910947,-60.30365676531919
+        -2.799531686765212,-60.30195540280954 -2.797879750232732,-59.69840098382115
+        -2.799530854700205,-59.698404092062326 -2.8012317183660334,-58.799189044685384
+        -2.801265630042686,-58.79918908725958 -2.8013148643462156,-58.755231308382875
+        -2.801398081739323,-58.71123581739256 -2.801364140934071,-58.7112357768642
+        -2.8022726801247053,-57.90006628771813 -2.802306823350039,-57.9000663091644
+        -2.8023222452332335,-57.855813156781615 -2.802371831094856,-57.811541496895146
+        -2.802337673572892,-57.81154147754995 -2.802651092372252,-56.912185042742124
+        -1.897732319008923,-56.91224050123892 -1.897474262556893,-56.01294627189678
+        -0.9487194831258218,-56.01334325958346 0,-56.01348393064086 0,-56.91228937849629
+        0,-57.000179734950805 0,-57.81057740574848 0,-57.89899708558173 0,-58.70920384697636
+        0,-58.7970528123519 0,-59.319960543069975 0,-59.69520275703949 0,-60.30515631259404</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160627T232530_R010_V20160627T142038_20160627T142038"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.30515631259404 0,-60.304790530777176
+        -0.9033617375403121,-60.30482331831355 -0.903361766508728,-60.30477253533339
+        -0.9478046119954973,-60.30475452350715 -0.992287945780174,-60.30472170612534
+        -0.9922879139314531,-60.303790470814704 -1.807260703892119,-60.303823126388046
+        -1.807260761605379,-60.3037400197687 -1.851413056416722,-60.30368947897708
+        -1.895643950033409,-60.30365676531919 -1.8956438893910947,-60.30195540280954
+        -2.799531686765212,-59.69840098382115 -2.797879750232732,-59.698404092062326
+        -2.799530854700205,-58.799189044685384 -2.8012317183660334,-58.79918908725958
+        -2.801265630042686,-58.755231308382875 -2.8013148643462156,-58.71123581739256
+        -2.801398081739323,-58.7112357768642 -2.801364140934071,-57.90006628771813
+        -2.8022726801247053,-57.9000663091644 -2.802306823350039,-57.855813156781615
+        -2.8023222452332335,-57.811541496895146 -2.802371831094856,-57.81154147754995
+        -2.802337673572892,-56.912185042742124 -2.802651092372252,-56.91224050123892
+        -1.897732319008923,-56.01294627189678 -1.897474262556893,-56.01334325958346
+        -0.9487194831258218,-56.01348393064086 0,-56.91228937849629 0,-57.000179734950805
+        0,-57.81057740574848 0,-57.89899708558173 0,-58.70920384697636 0,-58.7970528123519
+        0,-59.319960543069975 0,-59.69520275703949 0,-60.30515631259404 0))"},{"name":"s2datatakeid","content":"GS2A_20160627T142042_005298_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.17
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002355_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8b86152c-a08d-48c0-acb3-3044e59b34b7'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8b86152c-a08d-48c0-acb3-3044e59b34b7'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8b86152c-a08d-48c0-acb3-3044e59b34b7'')/Products(''Quicklook'')/$value"}],"id":"8b86152c-a08d-48c0-acb3-3044e59b34b7","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        547.18 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:08:04.615Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"3.9053"},"str":[{"name":"uuid","content":"8b86152c-a08d-48c0-acb3-3044e59b34b7"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002355_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.90436043578707,-56.97646115003355
+        -0.99473801702551,-56.99639076640593 -1.143198458992709,-57.02911369239136
+        -1.291776307284784,-57.06171512085576 -1.440363340100116,-57.09463011247999
+        -1.589116400735654,-57.12726516379404 -1.7379484965137,-57.15965473987136
+        -1.886712333619381,-57.192381299703634 -1.897688625707193,-57.19478604488944
+        -1.89752229642809,-57.89948706224901 -0.904256642483688,-57.89910831789247
+        -0.90436043578707,-56.97646115003355 -0.90436043578707,-56.97646115003355</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002355_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-56.97646115003355 -0.90436043578707,-56.99639076640593
+        -0.99473801702551,-57.02911369239136 -1.143198458992709,-57.06171512085576
+        -1.291776307284784,-57.09463011247999 -1.440363340100116,-57.12726516379404
+        -1.589116400735654,-57.15965473987136 -1.7379484965137,-57.192381299703634
+        -1.886712333619381,-57.19478604488944 -1.897688625707193,-57.89948706224901
+        -1.89752229642809,-57.89910831789247 -0.904256642483688,-56.97646115003355
+        -0.90436043578707,-56.97646115003355 -0.90436043578707))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"547.18
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164040_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6159fd21-8484-4636-b5ea-8be2bc1a0e35'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6159fd21-8484-4636-b5ea-8be2bc1a0e35'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6159fd21-8484-4636-b5ea-8be2bc1a0e35'')/Products(''Quicklook'')/$value"}],"id":"6159fd21-8484-4636-b5ea-8be2bc1a0e35","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        472.42 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:35:06.675Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"3.9663"},"str":[{"name":"uuid","content":"6159fd21-8484-4636-b5ea-8be2bc1a0e35"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164040_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.902641037447156,-59.48907521607748
+        -0.908658574549098,-59.490390737689474 -1.057298313648001,-59.52291809885697
+        -1.20599178478114,-59.55533225479151 -1.354668045164277,-59.5878438471964
+        -1.503367378006841,-59.620420928222046 -1.652114656232122,-59.65303822989145
+        -1.800899483990587,-59.685794378608485 -1.894537003369659,-59.706544154323005
+        -1.895643950033409,-60.30368947897708 -0.903361766508728,-60.30482331831355
+        -0.902641037447156,-59.48907521607748 -0.902641037447156,-59.48907521607748</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164040_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.48907521607748 -0.902641037447156,-59.490390737689474
+        -0.908658574549098,-59.52291809885697 -1.057298313648001,-59.55533225479151
+        -1.20599178478114,-59.5878438471964 -1.354668045164277,-59.620420928222046
+        -1.503367378006841,-59.65303822989145 -1.652114656232122,-59.685794378608485
+        -1.800899483990587,-59.706544154323005 -1.894537003369659,-60.30368947897708
+        -1.895643950033409,-60.30482331831355 -0.903361766508728,-59.48907521607748
+        -0.902641037447156,-59.48907521607748 -0.902641037447156))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"472.42
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003134_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9adaeaf8-c574-4edb-bc0c-74696e7e9ac6'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9adaeaf8-c574-4edb-bc0c-74696e7e9ac6'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9adaeaf8-c574-4edb-bc0c-74696e7e9ac6'')/Products(''Quicklook'')/$value"}],"id":"9adaeaf8-c574-4edb-bc0c-74696e7e9ac6","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        350.18 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:55:32.618Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"4.0791"},"str":[{"name":"uuid","content":"9adaeaf8-c574-4edb-bc0c-74696e7e9ac6"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003134_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.3309761148482,-58.164965598042514
+        -6.34463583796341,-58.16795126401774 -6.493017020979393,-58.20045584940047
+        -6.641458225182249,-58.233091616384456 -6.789947526712803,-58.26578683216962
+        -6.938627346512479,-58.29810720277851 -7.087278451887491,-58.33073113884422
+        -7.236099103057056,-58.36322021862552 -7.323360765643782,-58.38235148208099
+        -7.322106788572572,-58.8117341092901 -6.329351607734412,-58.80800386867027
+        -6.3309761148482,-58.164965598042514 -6.3309761148482,-58.164965598042514</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003134_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.164965598042514
+        -6.3309761148482,-58.16795126401774 -6.34463583796341,-58.20045584940047 -6.493017020979393,-58.233091616384456
+        -6.641458225182249,-58.26578683216962 -6.789947526712803,-58.29810720277851
+        -6.938627346512479,-58.33073113884422 -7.087278451887491,-58.36322021862552
+        -7.236099103057056,-58.38235148208099 -7.323360765643782,-58.8117341092901
+        -7.322106788572572,-58.80800386867027 -6.329351607734412,-58.164965598042514
+        -6.3309761148482,-58.164965598042514 -6.3309761148482))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"350.18
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164417_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''66b632c0-5a20-4f36-9e82-f8a9fe600c2d'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''66b632c0-5a20-4f36-9e82-f8a9fe600c2d'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''66b632c0-5a20-4f36-9e82-f8a9fe600c2d'')/Products(''Quicklook'')/$value"}],"id":"66b632c0-5a20-4f36-9e82-f8a9fe600c2d","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        87.55 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:39:06.389Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"4.1752"},"str":[{"name":"uuid","content":"66b632c0-5a20-4f36-9e82-f8a9fe600c2d"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164417_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.903487446838926,-59.48926025354856
+        -0.908658574549098,-59.490390737689474 -1.057298313648001,-59.52291809885697
+        -1.20599178478114,-59.55533225479151 -1.354668045164277,-59.5878438471964
+        -1.503367378006841,-59.620420928222046 -1.652114656232122,-59.65303822989145
+        -1.800899483990587,-59.685794378608485 -1.849740206127926,-59.69661732689679
+        -0.903361498199144,-59.695535795558214 -0.903487446838926,-59.48926025354856
+        -0.903487446838926,-59.48926025354856</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T164417_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.48926025354856 -0.903487446838926,-59.490390737689474
+        -0.908658574549098,-59.52291809885697 -1.057298313648001,-59.55533225479151
+        -1.20599178478114,-59.5878438471964 -1.354668045164277,-59.620420928222046
+        -1.503367378006841,-59.65303822989145 -1.652114656232122,-59.685794378608485
+        -1.800899483990587,-59.69661732689679 -1.849740206127926,-59.695535795558214
+        -0.903361498199144,-59.48926025354856 -0.903487446838926,-59.48926025354856
+        -0.903487446838926))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"87.55
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160620T211347_R053_V20160620T142754_20160620T142754","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''634095ac-0757-4a3e-b9f6-6db7d6a38983'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''634095ac-0757-4a3e-b9f6-6db7d6a38983'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''634095ac-0757-4a3e-b9f6-6db7d6a38983'')/Products(''Quicklook'')/$value"}],"id":"634095ac-0757-4a3e-b9f6-6db7d6a38983","summary":"Date:
+        2016-06-20T14:27:54Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.40 GB","date":[{"name":"ingestiondate","content":"2016-06-20T21:40:05.073Z"},{"name":"beginposition","content":"2016-06-20T14:27:54Z"},{"name":"endposition","content":"2016-06-20T14:27:54Z"}],"int":[{"name":"orbitnumber","content":"5198"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"4.416923076923077"},"str":[{"name":"uuid","content":"634095ac-0757-4a3e-b9f6-6db7d6a38983"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160620T211347_R053_V20160620T142754_20160620T142754.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.522819979734341,-63.90178676662203
+        -5.516014389089381,-63.90315179166951 -5.516633044843839,-63.00018056571296
+        -5.516700066819259,-63.00018056573138 -5.51666329264377,-62.95603179187785
+        -5.516693539799448,-62.91188395837315 -5.51662651925904,-62.91188396736038
+        -5.515947927683427,-62.09720938629529 -5.516014937246069,-62.097209294235604
+        -5.5159111504805916,-62.05305697799958 -5.515874390220655,-62.00892491028778
+        -5.515807411549814,-62.0089250113026 -5.5138941737767615,-61.1950073715956
+        -5.513961491831883,-61.19500718671128 -5.513789767821807,-61.15059164364745
+        -5.513685455771881,-61.10621586418906 -5.51361819829923,-61.1062160579905
+        -5.510472970358236,-60.292718824860636 -5.510539807042403,-60.29271854959391
+        -5.510302364769759,-60.24859255586318 -5.510131987398975,-60.204525314213285
+        -5.5100652401698405,-60.204525598059945 -5.505214111502747,-59.302997530767676
+        -4.55802276012127,-59.30832298262014 -3.6553345476849817,-59.31247466262803
+        -2.708535417726956,-59.315866557865895 -2.711033187970939,-60.25818167438885
+        -2.7127451087194467,-61.15704255065438 -2.713786464257691,-62.05636168750624
+        -2.714173730986409,-63.000179935454945 -3.662948076063292,-63.00018010157539
+        -4.523326747747264,-63.00018029497392 -4.522819979734341,-63.90178676662203</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160620T211347_R053_V20160620T142754_20160620T142754"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.90178676662203 -4.522819979734341,-63.90315179166951
+        -5.516014389089381,-63.00018056571296 -5.516633044843839,-63.00018056573138
+        -5.516700066819259,-62.95603179187785 -5.51666329264377,-62.91188395837315
+        -5.516693539799448,-62.91188396736038 -5.51662651925904,-62.09720938629529
+        -5.515947927683427,-62.097209294235604 -5.516014937246069,-62.05305697799958
+        -5.5159111504805916,-62.00892491028778 -5.515874390220655,-62.0089250113026
+        -5.515807411549814,-61.1950073715956 -5.5138941737767615,-61.19500718671128
+        -5.513961491831883,-61.15059164364745 -5.513789767821807,-61.10621586418906
+        -5.513685455771881,-61.1062160579905 -5.51361819829923,-60.292718824860636
+        -5.510472970358236,-60.29271854959391 -5.510539807042403,-60.24859255586318
+        -5.510302364769759,-60.204525314213285 -5.510131987398975,-60.204525598059945
+        -5.5100652401698405,-59.302997530767676 -5.505214111502747,-59.30832298262014
+        -4.55802276012127,-59.31247466262803 -3.6553345476849817,-59.315866557865895
+        -2.708535417726956,-60.25818167438885 -2.711033187970939,-61.15704255065438
+        -2.7127451087194467,-62.05636168750624 -2.713786464257691,-63.000179935454945
+        -2.714173730986409,-63.00018010157539 -3.662948076063292,-63.00018029497392
+        -4.523326747747264,-63.90178676662203 -4.522819979734341))"},{"name":"s2datatakeid","content":"GS2A_20160620T142752_005198_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.40
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162701_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7a67cc53-a32d-42a5-bb5d-fc163f44301d'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7a67cc53-a32d-42a5-bb5d-fc163f44301d'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''7a67cc53-a32d-42a5-bb5d-fc163f44301d'')/Products(''Quicklook'')/$value"}],"id":"7a67cc53-a32d-42a5-bb5d-fc163f44301d","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        586.87 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:18:53.649Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"4.5781"},"str":[{"name":"uuid","content":"7a67cc53-a32d-42a5-bb5d-fc163f44301d"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162701_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.332499393722028,-63.00018083096244
+        -6.331550719524735,-62.00746942176938 -7.324654218871246,-62.0054206977693
+        -7.325753155189578,-63.00018120429812 -6.332499393722028,-63.00018083096244
+        -6.332499393722028,-63.00018083096244</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162701_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.00018083096244 -6.332499393722028,-62.00746942176938
+        -6.331550719524735,-62.0054206977693 -7.324654218871246,-63.00018120429812
+        -7.325753155189578,-63.00018083096244 -6.332499393722028,-63.00018083096244
+        -6.332499393722028))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"586.87
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160820T005221_R053_V20160819T142752_20160819T142755","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c0302599-47b8-4dd4-bd21-c7fc474a4b2e'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c0302599-47b8-4dd4-bd21-c7fc474a4b2e'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c0302599-47b8-4dd4-bd21-c7fc474a4b2e'')/Products(''Quicklook'')/$value"}],"id":"c0302599-47b8-4dd4-bd21-c7fc474a4b2e","summary":"Date:
+        2016-08-19T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.35 GB","date":[{"name":"ingestiondate","content":"2016-08-20T01:49:56.03Z"},{"name":"beginposition","content":"2016-08-19T14:27:52Z"},{"name":"endposition","content":"2016-08-19T14:27:55Z"}],"int":[{"name":"orbitnumber","content":"6056"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"4.733215384615384"},"str":[{"name":"uuid","content":"c0302599-47b8-4dd4-bd21-c7fc474a4b2e"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160820T005221_R053_V20160819T142752_20160819T142755.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.611785103351425,-63.03099693933921
+        -4.75341684539191,-63.06261930950591 -4.901933176501299,-63.09576316620988
+        -5.050457728650281,-63.12890587666944 -5.199019359712746,-63.16206651683809
+        -5.347584950188722,-63.19528918518512 -5.496254557064499,-63.228447066286094
+        -5.516473550237508,-63.23297406868139 -5.516633044843839,-63.00018056571296
+        -5.516700066819259,-63.00018056573138 -5.51666329264377,-62.95603179187781
+        -5.516693539799448,-62.91188395837315 -5.51662651925904,-62.91188396736038
+        -5.515947927683427,-62.09720938629529 -5.516014937246069,-62.097209294235604
+        -5.5159111504805916,-62.05305697799958 -5.515874390220655,-62.00892491028778
+        -5.515807411549814,-62.0089250113026 -5.5138941737767615,-61.1950073715956
+        -5.513961491831883,-61.19500718671128 -5.513789767821807,-61.15059164364744
+        -5.513685455771881,-61.10621586418906 -5.51361819829923,-61.1062160579905
+        -5.511330808246041,-60.51459423780219 -5.476971949795893,-60.50709128953242
+        -5.328523236055582,-60.47460726959911 -5.18016442482726,-60.44198169340587
+        -5.031771960588346,-60.40946596943592 -4.883344446212616,-60.37688239715226
+        -4.734797877621189,-60.344349160831385 -4.586088977197805,-60.311865859528886
+        -4.518281646043683,-60.29708647703196 -4.51686114304703,-60.29677686217516
+        -4.516861143047031,-60.29677686217516 -4.437271792893448,-60.2794294540324
+        -4.28844620695189,-60.24699728704413 -4.139750816955357,-60.214531871108726
+        -3.991081477852637,-60.18206946540452 -3.842467335498599,-60.14959316263669
+        -3.693890872252473,-60.11706619902027 -3.613773940616464,-60.0995300195736
+        -3.545388263129647,-60.08456160418996 -3.397002915034123,-60.05195181257256
+        -3.248623913304362,-60.019368350288495 -3.100175846090416,-59.98685469863778
+        -2.951609344401376,-59.9543356465532 -2.80293371186129,-59.92191032296365
+        -2.710088204071448,-59.90167465957994 -2.711033187970939,-60.25818167438888
+        -2.7127451087194467,-61.15704255065438 -2.713786464257691,-62.05636168750623
+        -2.714013070905095,-62.60863089388647 -2.822607456181975,-62.632796400101206
+        -2.971124313218735,-62.66575268545243 -3.119675380446653,-62.69872733805031
+        -3.268213364555315,-62.73179219809378 -3.416857838603853,-62.76470517944859
+        -3.565510152974454,-62.79771548620793 -3.707441405505453,-62.82915232908049
+        -3.714218089455685,-62.830653320192326 -3.862865875804657,-62.86368705400962
+        -4.011402290332152,-62.89677017161084 -4.079991366521906,-62.91206471841211
+        -4.0799913665219,-62.91206471841211 -4.159865949486904,-62.92987579876564
+        -4.308224473997755,-62.96307061415145 -4.456563699878798,-62.9962613753077
+        -4.474074134293395,-63.00018028390277 -4.4740741342933985,-63.00018028390277
+        -4.523320552842943,-63.01120183872894 -4.6049549669242,-63.02947196266887
+        -4.611785103351425,-63.03099693933921</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160820T005221_R053_V20160819T142752_20160819T142755"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.03099693933921 -4.611785103351425,-63.06261930950591
+        -4.75341684539191,-63.09576316620988 -4.901933176501299,-63.12890587666944
+        -5.050457728650281,-63.16206651683809 -5.199019359712746,-63.19528918518512
+        -5.347584950188722,-63.228447066286094 -5.496254557064499,-63.23297406868139
+        -5.516473550237508,-63.00018056571296 -5.516633044843839,-63.00018056573138
+        -5.516700066819259,-62.95603179187781 -5.51666329264377,-62.91188395837315
+        -5.516693539799448,-62.91188396736038 -5.51662651925904,-62.09720938629529
+        -5.515947927683427,-62.097209294235604 -5.516014937246069,-62.05305697799958
+        -5.5159111504805916,-62.00892491028778 -5.515874390220655,-62.0089250113026
+        -5.515807411549814,-61.1950073715956 -5.5138941737767615,-61.19500718671128
+        -5.513961491831883,-61.15059164364744 -5.513789767821807,-61.10621586418906
+        -5.513685455771881,-61.1062160579905 -5.51361819829923,-60.51459423780219
+        -5.511330808246041,-60.50709128953242 -5.476971949795893,-60.47460726959911
+        -5.328523236055582,-60.44198169340587 -5.18016442482726,-60.40946596943592
+        -5.031771960588346,-60.37688239715226 -4.883344446212616,-60.344349160831385
+        -4.734797877621189,-60.311865859528886 -4.586088977197805,-60.29708647703196
+        -4.518281646043683,-60.29677686217516 -4.51686114304703,-60.29677686217516
+        -4.516861143047031,-60.2794294540324 -4.437271792893448,-60.24699728704413
+        -4.28844620695189,-60.214531871108726 -4.139750816955357,-60.18206946540452
+        -3.991081477852637,-60.14959316263669 -3.842467335498599,-60.11706619902027
+        -3.693890872252473,-60.0995300195736 -3.613773940616464,-60.08456160418996
+        -3.545388263129647,-60.05195181257256 -3.397002915034123,-60.019368350288495
+        -3.248623913304362,-59.98685469863778 -3.100175846090416,-59.9543356465532
+        -2.951609344401376,-59.92191032296365 -2.80293371186129,-59.90167465957994
+        -2.710088204071448,-60.25818167438888 -2.711033187970939,-61.15704255065438
+        -2.7127451087194467,-62.05636168750623 -2.713786464257691,-62.60863089388647
+        -2.714013070905095,-62.632796400101206 -2.822607456181975,-62.66575268545243
+        -2.971124313218735,-62.69872733805031 -3.119675380446653,-62.73179219809378
+        -3.268213364555315,-62.76470517944859 -3.416857838603853,-62.79771548620793
+        -3.565510152974454,-62.82915232908049 -3.707441405505453,-62.830653320192326
+        -3.714218089455685,-62.86368705400962 -3.862865875804657,-62.89677017161084
+        -4.011402290332152,-62.91206471841211 -4.079991366521906,-62.91206471841211
+        -4.0799913665219,-62.92987579876564 -4.159865949486904,-62.96307061415145
+        -4.308224473997755,-62.9962613753077 -4.456563699878798,-63.00018028390277
+        -4.474074134293395,-63.00018028390277 -4.4740741342933985,-63.01120183872894
+        -4.523320552842943,-63.02947196266887 -4.6049549669242,-63.03099693933921
+        -4.611785103351425))"},{"name":"s2datatakeid","content":"GS2A_20160819T142752_006056_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.35
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003401_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''23b6969c-1608-403e-bceb-de1b3208e716'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''23b6969c-1608-403e-bceb-de1b3208e716'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''23b6969c-1608-403e-bceb-de1b3208e716'')/Products(''Quicklook'')/$value"}],"id":"23b6969c-1608-403e-bceb-de1b3208e716","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        461.41 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:04:35.003Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"4.7444"},"str":[{"name":"uuid","content":"23b6969c-1608-403e-bceb-de1b3208e716"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003401_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.088395907663773,-59.49904927096546
+        0.024399213729268,-59.474154478813645 0.172842622071785,-59.441499516985935
+        0.32133626115349,-59.40869392676323 0.469973915136995,-59.37603259419638 0.618641640463251,-59.34332275476831
+        0.76734975471361,-59.310610351310885 0.904157458038835,-59.2802376178625 0.904506202344557,-58.70941548873812
+        -0.088443094250338,-58.70920587028089 -0.088395907663773,-59.49904927096546
+        -0.088395907663773,-59.49904927096546</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003401_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.49904927096546 -0.088395907663773,-59.474154478813645
+        0.024399213729268,-59.441499516985935 0.172842622071785,-59.40869392676323
+        0.32133626115349,-59.37603259419638 0.469973915136995,-59.34332275476831 0.618641640463251,-59.310610351310885
+        0.76734975471361,-59.2802376178625 0.904157458038835,-58.70941548873812 0.904506202344557,-58.70920587028089
+        -0.088443094250338,-59.49904927096546 -0.088395907663773,-59.49904927096546
+        -0.088395907663773))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"461.41
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160102T014441_R039_V20160101T150922_20160101T150922","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5d422d08-bd93-440a-ae64-62e1087fd292'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5d422d08-bd93-440a-ae64-62e1087fd292'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5d422d08-bd93-440a-ae64-62e1087fd292'')/Products(''Quicklook'')/$value"}],"id":"5d422d08-bd93-440a-ae64-62e1087fd292","summary":"Date:
+        2016-01-01T15:09:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.45 GB","date":[{"name":"ingestiondate","content":"2016-01-02T01:08:35.632Z"},{"name":"beginposition","content":"2016-01-01T15:09:22Z"},{"name":"endposition","content":"2016-01-01T15:09:22Z"}],"int":[{"name":"orbitnumber","content":"2753"},{"name":"relativeorbitnumber","content":"39"}],"double":{"name":"cloudcoverpercentage","content":"4.769230769230769"},"str":[{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160102T014441_R039_V20160101T150922_20160101T150922.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.8605453326806517,-69.89910353713103
+        -0.088471762244608,-69.8989981502445 -0.088481655461822,-69.00017973516373
+        -0.088482727241185,-69.0001797351637 -0.0884821391683909,-68.95623403354793
+        -0.088482622864584,-68.9122892746056 -0.0884815511082114,-68.91228927459399
+        -0.0884706994281444,-68.10136127543512 -0.088471771010446,-68.10136127555407
+        -0.0884701113057866,-68.05741187000014 -0.08846952345505,-68.01348276237039
+        -0.0884684523676527,-68.01348276223986 -0.0884378568029472,-67.20330435261852
+        -0.088438933321785,-67.2033043528574 -0.0884361871891444,-67.15909255040486
+        -0.08843451908062,-67.11492060834647 -0.0884334435323415,-67.11492060809606
+        -0.08837769347984,-66.21736370515437 0.8596303086734559,-66.21703796423765
+        1.7187297869936355,-66.21608803051849 1.717220694829835,-65.31831584605472
+        2.708535417726956,-65.31586655786589 2.71091678651033,-66.2142677651005 2.710949551849636,-66.21426770386935
+        2.7110331879709384,-66.25818167438875 2.711149745616365,-66.30215450635603
+        2.7111169363095944,-66.3021545657364 2.712660887740188,-67.11282149469653
+        2.712693903442946,-67.11282145289017 2.7127451087194463,-67.15704255065498
+        2.712829405650466,-67.20130348583473 2.7127963601713736,-67.20130352571755
+        2.7137355404388757,-68.01238365781276 2.713768419219707,-68.0123836360222
+        2.71378646425769,-68.0563616875051 2.713837411591844,-68.10036002514651 2.713804517627621,-68.10036004500532
+        2.714137627658002,-68.9121915346075 2.714170526975778,-68.91219153266881 2.7141556791285275,-68.95618526301429
+        2.714173730986408,-69.00017993545494 2.714140830963322,-69.00017993545096
+        2.713837142510183,-69.89999980098749 1.7650496613143274,-69.89942676808782
+        0.8605453326806517,-69.89910353713103</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160102T014441_R039_V20160101T150922_20160101T150922"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-69.89910353713103 0.8605453326806517,-69.8989981502445
+        -0.088471762244608,-69.00017973516373 -0.088481655461822,-69.0001797351637
+        -0.088482727241185,-68.95623403354793 -0.0884821391683909,-68.9122892746056
+        -0.088482622864584,-68.91228927459399 -0.0884815511082114,-68.10136127543512
+        -0.0884706994281444,-68.10136127555407 -0.088471771010446,-68.05741187000014
+        -0.0884701113057866,-68.01348276237039 -0.08846952345505,-68.01348276223986
+        -0.0884684523676527,-67.20330435261852 -0.0884378568029472,-67.2033043528574
+        -0.088438933321785,-67.15909255040486 -0.0884361871891444,-67.11492060834647
+        -0.08843451908062,-67.11492060809606 -0.0884334435323415,-66.21736370515437
+        -0.08837769347984,-66.21703796423765 0.8596303086734559,-66.21608803051849
+        1.7187297869936355,-65.31831584605472 1.717220694829835,-65.31586655786589
+        2.708535417726956,-66.2142677651005 2.71091678651033,-66.21426770386935 2.710949551849636,-66.25818167438875
+        2.7110331879709384,-66.30215450635603 2.711149745616365,-66.3021545657364
+        2.7111169363095944,-67.11282149469653 2.712660887740188,-67.11282145289017
+        2.712693903442946,-67.15704255065498 2.7127451087194463,-67.20130348583473
+        2.712829405650466,-67.20130352571755 2.7127963601713736,-68.01238365781276
+        2.7137355404388757,-68.0123836360222 2.713768419219707,-68.0563616875051 2.71378646425769,-68.10036002514651
+        2.713837411591844,-68.10036004500532 2.713804517627621,-68.9121915346075 2.714137627658002,-68.91219153266881
+        2.714170526975778,-68.95618526301429 2.7141556791285275,-69.00017993545494
+        2.714173730986408,-69.00017993545096 2.714140830963322,-69.89999980098749
+        2.713837142510183,-69.89942676808782 1.7650496613143274,-69.89910353713103
+        0.8605453326806517))"},{"name":"s2datatakeid","content":"GS2A_20160101T145712_002753_N02.01"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.01"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.45
+        GB"},{"name":"uuid","content":"5d422d08-bd93-440a-ae64-62e1087fd292"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001421_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''72667baf-e345-461a-adae-4955c2a089dc'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''72667baf-e345-461a-adae-4955c2a089dc'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''72667baf-e345-461a-adae-4955c2a089dc'')/Products(''Quicklook'')/$value"}],"id":"72667baf-e345-461a-adae-4955c2a089dc","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        641.68 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:45:34.661Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"5.0133"},"str":[{"name":"uuid","content":"72667baf-e345-461a-adae-4955c2a089dc"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001421_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.904463466083483,-58.79727531806687
+        0.904820387748182,-57.810677821481484 -0.088473813037585,-57.81057836572721
+        -0.088438915806152,-58.797054939516336 0.904463466083483,-58.79727531806687
+        0.904463466083483,-58.79727531806687</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001421_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.79727531806687 0.904463466083483,-57.810677821481484
+        0.904820387748182,-57.81057836572721 -0.088473813037585,-58.797054939516336
+        -0.088438915806152,-58.79727531806687 0.904463466083483,-58.79727531806687
+        0.904463466083483))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"641.68
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163024_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c547c60e-7fc9-4008-aab7-8b3e9d45af18'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c547c60e-7fc9-4008-aab7-8b3e9d45af18'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c547c60e-7fc9-4008-aab7-8b3e9d45af18'')/Products(''Quicklook'')/$value"}],"id":"c547c60e-7fc9-4008-aab7-8b3e9d45af18","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        624.63 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:21:13.13Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"5.0158"},"str":[{"name":"uuid","content":"c547c60e-7fc9-4008-aab7-8b3e9d45af18"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163024_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.904463645229748,-61.20308401831023
+        0.903837296874274,-60.21702277446622 -0.08837769347984,-60.217363705154376
+        -0.088438933321785,-61.2033043528574 0.904463645229748,-61.20308401831023
+        0.904463645229748,-61.20308401831023</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163024_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.20308401831023 0.904463645229748,-60.21702277446622
+        0.903837296874274,-60.217363705154376 -0.08837769347984,-61.2033043528574
+        -0.088438933321785,-61.20308401831023 0.904463645229748,-61.20308401831023
+        0.904463645229748))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"624.63
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20151228T112701_R110_V20151227T142229_20151227T142229","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6ed0b7de-3435-43df-98bf-ad63c8d077ef'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6ed0b7de-3435-43df-98bf-ad63c8d077ef'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''6ed0b7de-3435-43df-98bf-ad63c8d077ef'')/Products(''Quicklook'')/$value"}],"id":"6ed0b7de-3435-43df-98bf-ad63c8d077ef","summary":"Date:
         2015-12-27T14:22:29Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
         5.47 GB","date":[{"name":"ingestiondate","content":"2015-12-28T10:57:09.913Z"},{"name":"beginposition","content":"2015-12-27T14:22:29Z"},{"name":"endposition","content":"2015-12-27T14:22:29Z"}],"int":[{"name":"orbitnumber","content":"2681"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"5.166666666666667"},"str":[{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20151228T112701_R110_V20151227T142229_20151227T142229.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
         srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.277741311151398,-58.81156740766095
@@ -63,7 +2967,280 @@ interactions:
         -5.427449229390539,-56.956038252707735 -5.428189238842002,-57.85862076311558
         -5.427580735171929,-58.80508864893815 -5.425529942673673,-58.808170510311776
         -6.373701120217797,-58.81156740766095 -7.277741311151398))"},{"name":"s2datatakeid","content":"GS2A_20151227T140932_002681_N02.01"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.01"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.47
-        GB"},{"name":"uuid","content":"6ed0b7de-3435-43df-98bf-ad63c8d077ef"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20151219T221022_R139_V20151219T145832_20151219T145832","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0848f6b8-5730-4759-850e-fc9945d42296'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0848f6b8-5730-4759-850e-fc9945d42296'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0848f6b8-5730-4759-850e-fc9945d42296'')/Products(''Quicklook'')/$value"}],"id":"0848f6b8-5730-4759-850e-fc9945d42296","summary":"Date:
+        GB"},{"name":"uuid","content":"6ed0b7de-3435-43df-98bf-ad63c8d077ef"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162728_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''33932faa-d5c1-47ec-abc0-e08d0596454c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''33932faa-d5c1-47ec-abc0-e08d0596454c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''33932faa-d5c1-47ec-abc0-e08d0596454c'')/Products(''Quicklook'')/$value"}],"id":"33932faa-d5c1-47ec-abc0-e08d0596454c","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        629.80 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:19:04.914Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"5.349"},"str":[{"name":"uuid","content":"33932faa-d5c1-47ec-abc0-e08d0596454c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162728_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.903921076504472,-61.20308428515767
+        -0.903295103942012,-60.21702318736773 -1.895504025238056,-60.21585252570553
+        -1.896817942614176,-61.20232771671445 -0.903921076504472,-61.20308428515767
+        -0.903921076504472,-61.20308428515767</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162728_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.20308428515767 -0.903921076504472,-60.21702318736773
+        -0.903295103942012,-60.21585252570553 -1.895504025238056,-61.20232771671445
+        -1.896817942614176,-61.20308428515767 -0.903921076504472,-61.20308428515767
+        -0.903921076504472))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"629.80
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193823_R010_V20161015T142322_20161015T142317","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a131a6f3-66be-49f5-b177-2c3cb94c0941'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a131a6f3-66be-49f5-b177-2c3cb94c0941'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a131a6f3-66be-49f5-b177-2c3cb94c0941'')/Products(''Quicklook'')/$value"}],"id":"a131a6f3-66be-49f5-b177-2c3cb94c0941","summary":"Date:
+        2016-10-15T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        236.50 MB","date":[{"name":"ingestiondate","content":"2016-10-16T19:54:14.317Z"},{"name":"beginposition","content":"2016-10-15T14:23:22Z"},{"name":"endposition","content":"2016-10-15T14:23:17Z"}],"int":[{"name":"orbitnumber","content":"6871"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"5.3747"},"str":[{"name":"uuid","content":"a131a6f3-66be-49f5-b177-2c3cb94c0941"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193823_R010_V20161015T142322_20161015T142317.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.091472415015076,-58.713607604627796
+        -4.0710655876662,-58.79943765026566 -4.071293746952152,-58.79948756956329
+        -4.071263290415811,-58.79961576002665 -4.072934000114667,-58.79998965365683
+        -4.023268001634567,-59.0193151601655 -4.022300406245837,-59.01910516927283
+        -4.022256307446581,-59.01930744596894 -4.021814055575593,-59.0192081552901
+        -4.021401045218522,-59.02110366972844 -4.020707113802223,-59.02095168468179
+        -3.977803412838779,-59.21797652152788 -3.97795702903033,-59.218010225657856
+        -3.977928556471848,-59.21814094461331 -3.980232425329074,-59.21865723511738
+        -3.933564428118137,-59.43939167911487 -3.931825785113038,-59.43901354242624
+        -3.931796551079765,-59.43916048225512 -3.931068400735043,-59.438996597813194
+        -3.930656891709004,-59.441071935450736 -3.93014543405919,-59.44095961792933
+        -3.890604029762547,-59.64109025614157 -3.890710387834033,-59.6411136131795
+        -3.890685282334616,-59.64124050276158 -3.89298407460232,-59.64175681061376
+        -3.88129419291909,-59.70144179477869 -3.614480435341899,-59.700542771043224
+        -3.616892447971682,-58.712593296005636 -4.091472415015076,-58.713607604627796
+        -4.091472415015076,-58.713607604627796</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193823_R010_V20161015T142322_20161015T142317"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.713607604627796
+        -4.091472415015076,-58.79943765026566 -4.0710655876662,-58.79948756956329
+        -4.071293746952152,-58.79961576002665 -4.071263290415811,-58.79998965365683
+        -4.072934000114667,-59.0193151601655 -4.023268001634567,-59.01910516927283
+        -4.022300406245837,-59.01930744596894 -4.022256307446581,-59.0192081552901
+        -4.021814055575593,-59.02110366972844 -4.021401045218522,-59.02095168468179
+        -4.020707113802223,-59.21797652152788 -3.977803412838779,-59.218010225657856
+        -3.97795702903033,-59.21814094461331 -3.977928556471848,-59.21865723511738
+        -3.980232425329074,-59.43939167911487 -3.933564428118137,-59.43901354242624
+        -3.931825785113038,-59.43916048225512 -3.931796551079765,-59.438996597813194
+        -3.931068400735043,-59.441071935450736 -3.930656891709004,-59.44095961792933
+        -3.93014543405919,-59.64109025614157 -3.890604029762547,-59.6411136131795
+        -3.890710387834033,-59.64124050276158 -3.890685282334616,-59.64175681061376
+        -3.89298407460232,-59.70144179477869 -3.88129419291909,-59.700542771043224
+        -3.614480435341899,-58.712593296005636 -3.616892447971682,-58.713607604627796
+        -4.091472415015076,-58.713607604627796 -4.091472415015076))"},{"name":"s2datatakeid","content":"GS2A_20161015T142322_006871_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"236.50
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210421_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''896013b3-fb7e-4226-b8e3-b40248b44e49'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''896013b3-fb7e-4226-b8e3-b40248b44e49'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''896013b3-fb7e-4226-b8e3-b40248b44e49'')/Products(''Quicklook'')/$value"}],"id":"896013b3-fb7e-4226-b8e3-b40248b44e49","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        322.68 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:32:26.01Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"5.5426"},"str":[{"name":"uuid","content":"896013b3-fb7e-4226-b8e3-b40248b44e49"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210421_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.615889071085348,-65.12357193512123
+        -3.638144400299183,-65.12845217237721 -3.786692227235183,-65.16095713150692
+        -3.935222529760456,-65.19339602435124 -4.083666442187001,-65.22587208059373
+        -4.232066029025286,-65.25828662611146 -4.38048671069555,-65.2907543828382
+        -4.528995316028908,-65.32332722259548 -4.607842018076661,-65.34060687084069
+        -4.606712116481468,-65.70388607627802 -3.614480435341899,-65.70054277104322
+        -3.615889071085348,-65.12357193512123 -3.615889071085348,-65.12357193512123</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210421_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.12357193512123 -3.615889071085348,-65.12845217237721
+        -3.638144400299183,-65.16095713150692 -3.786692227235183,-65.19339602435124
+        -3.935222529760456,-65.22587208059373 -4.083666442187001,-65.25828662611146
+        -4.232066029025286,-65.2907543828382 -4.38048671069555,-65.32332722259548
+        -4.528995316028908,-65.34060687084069 -4.607842018076661,-65.70388607627802
+        -4.606712116481468,-65.70054277104322 -3.614480435341899,-65.12357193512123
+        -3.615889071085348,-65.12357193512123 -3.615889071085348))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"322.68
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160717T000123_R139_V20160716T145212_20160716T145212","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''12e27e75-7a5e-4d45-ba07-153f035f616a'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''12e27e75-7a5e-4d45-ba07-153f035f616a'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''12e27e75-7a5e-4d45-ba07-153f035f616a'')/Products(''Quicklook'')/$value"}],"id":"12e27e75-7a5e-4d45-ba07-153f035f616a","summary":"Date:
+        2016-07-16T14:52:12Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.98 GB","date":[{"name":"ingestiondate","content":"2016-07-17T00:19:42.923Z"},{"name":"beginposition","content":"2016-07-16T14:52:12Z"},{"name":"endposition","content":"2016-07-16T14:52:12Z"}],"int":[{"name":"orbitnumber","content":"5570"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"5.5630461538461535"},"str":[{"name":"uuid","content":"12e27e75-7a5e-4d45-ba07-153f035f616a"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160717T000123_R139_V20160716T145212_20160716T145212.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.523381648369522,-69.00018029277894
+        -5.516700066819259,-69.00018056573137 -5.515947927683427,-68.09720938629528
+        -5.516014937246069,-68.0972092942356 -5.5159111504805916,-68.05305697799957
+        -5.515874390220655,-68.00892491028777 -5.515807411549814,-68.0089250113026
+        -5.5138941737767615,-67.1950073715956 -5.513961491831883,-67.19500718671128
+        -5.513789767821807,-67.15059164364747 -5.513685455771881,-67.10621586418905
+        -5.51361819829923,-67.1062160579905 -5.510472970358236,-66.29271882486063
+        -5.510539807042403,-66.2927185495939 -5.510302364769759,-66.24859255586318
+        -5.510131987398975,-66.20452531421327 -5.5100652401698405,-66.20452559805993
+        -5.50739143732769,-65.70762921084261 -5.510538165612144,-65.7076421723614
+        -5.514221687588917,-64.7170995025818 -4.609788652965886,-64.71473645978604
+        -4.609788718499236,-64.71471538989506 -4.565473358388603,-64.71462067571626
+        -4.52135149851371,-64.71450539703987 -4.521351434515379,-64.7145263749642
+        -3.705874281780436,-64.71278347479007 -3.705874334456282,-64.71276241632309
+        -3.6613052618115467,-64.71268821847 -3.616892447971682,-64.71259329600564
+        -3.616892396739029,-64.7126142806687 -2.712957132034671,-64.71110942422933
+        -2.7118493409356286,-65.31585468578025 -2.708535417726956,-65.31586655786589
+        -2.711033187970939,-66.25818167438887 -2.7127451087194467,-67.15704255065438
+        -2.713837411591844,-68.10036002514651 -3.6180666685010414,-68.09956848458614
+        -3.618066685535434,-68.09957952238194 -3.662493919852758,-68.09952959403803
+        -3.707077536924511,-68.09949056661111 -3.7070775194102277,-68.09947948996727
+        -4.522765530735929,-68.09856280108971 -4.523381648369522,-69.00018029277894</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160717T000123_R139_V20160716T145212_20160716T145212"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-69.00018029277894 -4.523381648369522,-69.00018056573137
+        -5.516700066819259,-68.09720938629528 -5.515947927683427,-68.0972092942356
+        -5.516014937246069,-68.05305697799957 -5.5159111504805916,-68.00892491028777
+        -5.515874390220655,-68.0089250113026 -5.515807411549814,-67.1950073715956
+        -5.5138941737767615,-67.19500718671128 -5.513961491831883,-67.15059164364747
+        -5.513789767821807,-67.10621586418905 -5.513685455771881,-67.1062160579905
+        -5.51361819829923,-66.29271882486063 -5.510472970358236,-66.2927185495939
+        -5.510539807042403,-66.24859255586318 -5.510302364769759,-66.20452531421327
+        -5.510131987398975,-66.20452559805993 -5.5100652401698405,-65.70762921084261
+        -5.50739143732769,-65.7076421723614 -5.510538165612144,-64.7170995025818 -5.514221687588917,-64.71473645978604
+        -4.609788652965886,-64.71471538989506 -4.609788718499236,-64.71462067571626
+        -4.565473358388603,-64.71450539703987 -4.52135149851371,-64.7145263749642
+        -4.521351434515379,-64.71278347479007 -3.705874281780436,-64.71276241632309
+        -3.705874334456282,-64.71268821847 -3.6613052618115467,-64.71259329600564
+        -3.616892447971682,-64.7126142806687 -3.616892396739029,-64.71110942422933
+        -2.712957132034671,-65.31585468578025 -2.7118493409356286,-65.31586655786589
+        -2.708535417726956,-66.25818167438887 -2.711033187970939,-67.15704255065438
+        -2.7127451087194467,-68.10036002514651 -2.713837411591844,-68.09956848458614
+        -3.6180666685010414,-68.09957952238194 -3.618066685535434,-68.09952959403803
+        -3.662493919852758,-68.09949056661111 -3.707077536924511,-68.09947948996727
+        -3.7070775194102277,-68.09856280108971 -4.522765530735929,-69.00018029277894
+        -4.523381648369522))"},{"name":"s2datatakeid","content":"GS2A_20160716T144732_005570_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.98
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161002T211950_R110_V20161002T141302_20161002T141258","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ccea60f6-7da3-4e8d-aa84-ef916f85a433'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ccea60f6-7da3-4e8d-aa84-ef916f85a433'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ccea60f6-7da3-4e8d-aa84-ef916f85a433'')/Products(''Quicklook'')/$value"}],"id":"ccea60f6-7da3-4e8d-aa84-ef916f85a433","summary":"Date:
+        2016-10-02T14:13:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        356.94 MB","date":[{"name":"ingestiondate","content":"2016-10-02T21:39:31.615Z"},{"name":"beginposition","content":"2016-10-02T14:13:02Z"},{"name":"endposition","content":"2016-10-02T14:12:58Z"}],"int":[{"name":"orbitnumber","content":"6685"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"5.6403"},"str":[{"name":"uuid","content":"ccea60f6-7da3-4e8d-aa84-ef916f85a433"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161002T211950_R110_V20161002T141302_20161002T141258.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.802417554128697,-57.582323919362494
+        -2.669074166640955,-57.552741155844174 -2.520600139630849,-57.51979328690548
+        -2.372216171165134,-57.48684840313345 -2.223827119296859,-57.453797642428576
+        -2.075336671052912,-57.420894808589 -1.926848043596051,-57.38793205739548
+        -1.809172413156079,-57.36200092921632 -1.80927362038077,-56.912245922484004
+        -2.802651092372252,-56.912185042742124 -2.802417554128697,-57.582323919362494
+        -2.802417554128697,-57.582323919362494</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161002T211950_R110_V20161002T141302_20161002T141258"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.582323919362494
+        -2.802417554128697,-57.552741155844174 -2.669074166640955,-57.51979328690548
+        -2.520600139630849,-57.48684840313345 -2.372216171165134,-57.453797642428576
+        -2.223827119296859,-57.420894808589 -2.075336671052912,-57.38793205739548
+        -1.926848043596051,-57.36200092921632 -1.809172413156079,-56.912245922484004
+        -1.80927362038077,-56.912185042742124 -2.802651092372252,-57.582323919362494
+        -2.802417554128697,-57.582323919362494 -2.802417554128697))"},{"name":"s2datatakeid","content":"GS2A_20161002T141302_006685_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"356.94
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163705_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5ce44948-9797-4e34-9ad9-d6a443452078'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5ce44948-9797-4e34-9ad9-d6a443452078'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5ce44948-9797-4e34-9ad9-d6a443452078'')/Products(''Quicklook'')/$value"}],"id":"5ce44948-9797-4e34-9ad9-d6a443452078","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        618.30 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:28:33.33Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"5.8211"},"str":[{"name":"uuid","content":"5ce44948-9797-4e34-9ad9-d6a443452078"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163705_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.494267275120172,-62.10129558033036
+        -0.49206513731478,-62.10081083410424 -0.483559119663311,-62.09893450675754
+        -0.463507526857866,-62.09452325275858 -0.33515730355075,-62.06626170094086
+        -0.186577212254185,-62.03348893381526 -0.038019317570919,-62.00071777636644
+        0,-61.992352972307344 0,-61.11492283955807 -0.992852760559312,-61.11464157113414
+        -0.993271027199255,-62.10122818112512 -0.494267275120172,-62.10129558033036
+        -0.494267275120172,-62.10129558033036</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163705_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.10129558033036 -0.494267275120172,-62.10081083410424
+        -0.49206513731478,-62.09893450675754 -0.483559119663311,-62.09452325275858
+        -0.463507526857866,-62.06626170094086 -0.33515730355075,-62.03348893381526
+        -0.186577212254185,-62.00071777636644 -0.038019317570919,-61.992352972307344
+        0,-61.11492283955807 0,-61.11464157113414 -0.992852760559312,-62.10122818112512
+        -0.993271027199255,-62.10129558033036 -0.494267275120172,-62.10129558033036
+        -0.494267275120172))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"618.30
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160922T072621_R096_V20160921T143742_20160921T143741","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f96dacf-b808-410a-9ffe-3b843b0b5db0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f96dacf-b808-410a-9ffe-3b843b0b5db0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f96dacf-b808-410a-9ffe-3b843b0b5db0'')/Products(''Quicklook'')/$value"}],"id":"1f96dacf-b808-410a-9ffe-3b843b0b5db0","summary":"Date:
+        2016-09-21T14:37:42Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.98 GB","date":[{"name":"ingestiondate","content":"2016-09-22T07:44:38.296Z"},{"name":"beginposition","content":"2016-09-21T14:37:42Z"},{"name":"endposition","content":"2016-09-21T14:37:41Z"}],"int":[{"name":"orbitnumber","content":"6528"},{"name":"relativeorbitnumber","content":"96"}],"double":{"name":"cloudcoverpercentage","content":"5.862564285714285"},"str":[{"name":"uuid","content":"1f96dacf-b808-410a-9ffe-3b843b0b5db0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160922T072621_R096_V20160921T143742_20160921T143741.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.419397042918071,-65.4946828187076
+        -4.514888729201384,-65.51601495383333 -4.567904307004729,-65.52785824107107
+        -4.716331836662966,-65.56096924352441 -4.864762244511137,-65.5941292568853
+        -5.01314013517604,-65.62732685498283 -5.161572430242984,-65.66053124629066
+        -5.310024942310952,-65.69376287234897 -5.369389879321262,-65.70706077606671
+        -5.369389879321281,-65.70706077606671 -5.458545928888695,-65.7270319681998
+        -5.507555059926438,-65.73803664287288 -5.50739143732769,-65.70762921084261
+        -5.510538165612144,-65.7076421723614 -5.513893497961508,-64.80535357891915
+        -5.513960396525286,-64.8053537626881 -5.514057522441122,-64.76124545442016
+        -5.514221687588917,-64.7170995025818 -5.514154731632817,-64.71709932764371
+        -5.515947033626909,-63.903151699097606 -5.516014389089381,-63.90315179166951
+        -5.516044812342758,-63.858746931290256 -5.516142631941844,-63.81432359696183
+        -5.516075248310466,-63.814323513459165 -5.516617866836133,-63.02233392665298
+        -5.440426632846916,-63.00563775403575 -5.291894209756859,-62.973130414461146
+        -5.143190956745284,-62.940663007217694 -5.01186442425952,-62.91195165427325
+        -5.011864424259512,-62.91195165427325 -4.994440799009397,-62.9081424022915
+        -4.845660648788484,-62.87564777230609 -4.696983668252916,-62.84315523679087
+        -4.611736355028872,-62.824510126892655 -4.548332039654319,-62.81064247073471
+        -4.523248374709383,-62.805149576872466 -4.399764280714936,-62.778108671028924
+        -4.251222761040038,-62.74553780842557 -4.102749974947415,-62.7129702664386
+        -3.954345934350642,-62.68039887459058 -3.805957637348863,-62.647811897046815
+        -3.70732766371842,-62.626150725690614 -3.657499893868676,-62.61520752230848
+        -3.508957211993131,-62.58270793665637 -3.360275960393424,-62.55014915932852
+        -3.211440324851741,-62.5176698113122 -3.062577075170361,-62.48514082302497
+        -2.913798214415122,-62.4526016132058 -2.765090097140043,-62.420064251455926
+        -2.713931104842322,-62.408869179229825 -2.7141556791285284,-62.956185263014774
+        -2.7138520768084997,-63.855749918701285 -2.7128765456728288,-64.75510167196632
+        -2.712217975392005,-65.11461643704322 -2.785690762807076,-65.13093263431678
+        -2.934152455776705,-65.16395005982072 -3.08255076453906,-65.19695255031056
+        -3.230918283549447,-65.2299948813566 -3.379344889687476,-65.26307199481842
+        -3.527811958550025,-65.29612819440457 -3.611001245356122,-65.31468168971877
+        -3.676319738021342,-65.32924950721213 -3.704316671357573,-65.33547661205557
+        -3.824876214300276,-65.36229158156547 -3.973452209231009,-65.3954348657151
+        -4.122121994490888,-65.42847239571935 -4.270779366559355,-65.46156400089251
+        -4.419397042918071,-65.4946828187076</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160922T072621_R096_V20160921T143742_20160921T143741"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.4946828187076 -4.419397042918071,-65.51601495383333
+        -4.514888729201384,-65.52785824107107 -4.567904307004729,-65.56096924352441
+        -4.716331836662966,-65.5941292568853 -4.864762244511137,-65.62732685498283
+        -5.01314013517604,-65.66053124629066 -5.161572430242984,-65.69376287234897
+        -5.310024942310952,-65.70706077606671 -5.369389879321262,-65.70706077606671
+        -5.369389879321281,-65.7270319681998 -5.458545928888695,-65.73803664287288
+        -5.507555059926438,-65.70762921084261 -5.50739143732769,-65.7076421723614
+        -5.510538165612144,-64.80535357891915 -5.513893497961508,-64.8053537626881
+        -5.513960396525286,-64.76124545442016 -5.514057522441122,-64.7170995025818
+        -5.514221687588917,-64.71709932764371 -5.514154731632817,-63.903151699097606
+        -5.515947033626909,-63.90315179166951 -5.516014389089381,-63.858746931290256
+        -5.516044812342758,-63.81432359696183 -5.516142631941844,-63.814323513459165
+        -5.516075248310466,-63.02233392665298 -5.516617866836133,-63.00563775403575
+        -5.440426632846916,-62.973130414461146 -5.291894209756859,-62.940663007217694
+        -5.143190956745284,-62.91195165427325 -5.01186442425952,-62.91195165427325
+        -5.011864424259512,-62.9081424022915 -4.994440799009397,-62.87564777230609
+        -4.845660648788484,-62.84315523679087 -4.696983668252916,-62.824510126892655
+        -4.611736355028872,-62.81064247073471 -4.548332039654319,-62.805149576872466
+        -4.523248374709383,-62.778108671028924 -4.399764280714936,-62.74553780842557
+        -4.251222761040038,-62.7129702664386 -4.102749974947415,-62.68039887459058
+        -3.954345934350642,-62.647811897046815 -3.805957637348863,-62.626150725690614
+        -3.70732766371842,-62.61520752230848 -3.657499893868676,-62.58270793665637
+        -3.508957211993131,-62.55014915932852 -3.360275960393424,-62.5176698113122
+        -3.211440324851741,-62.48514082302497 -3.062577075170361,-62.4526016132058
+        -2.913798214415122,-62.420064251455926 -2.765090097140043,-62.408869179229825
+        -2.713931104842322,-62.956185263014774 -2.7141556791285284,-63.855749918701285
+        -2.7138520768084997,-64.75510167196632 -2.7128765456728288,-65.11461643704322
+        -2.712217975392005,-65.13093263431678 -2.785690762807076,-65.16395005982072
+        -2.934152455776705,-65.19695255031056 -3.08255076453906,-65.2299948813566
+        -3.230918283549447,-65.26307199481842 -3.379344889687476,-65.29612819440457
+        -3.527811958550025,-65.31468168971877 -3.611001245356122,-65.32924950721213
+        -3.676319738021342,-65.33547661205557 -3.704316671357573,-65.36229158156547
+        -3.824876214300276,-65.3954348657151 -3.973452209231009,-65.42847239571935
+        -4.122121994490888,-65.46156400089251 -4.270779366559355,-65.4946828187076
+        -4.419397042918071))"},{"name":"s2datatakeid","content":"GS2A_20160921T143742_006528_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.98
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225331_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1522289d-b271-4d86-a7cc-19dff7452c94'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1522289d-b271-4d86-a7cc-19dff7452c94'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1522289d-b271-4d86-a7cc-19dff7452c94'')/Products(''Quicklook'')/$value"}],"id":"1522289d-b271-4d86-a7cc-19dff7452c94","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        88.10 MB","date":[{"name":"ingestiondate","content":"2016-09-28T23:02:46.18Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"5.8644"},"str":[{"name":"uuid","content":"1522289d-b271-4d86-a7cc-19dff7452c94"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225331_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.993276516786622,-62.2178589766747
+        -0.962246444953023,-62.211006273910414 -0.813762279058937,-62.17811748397836
+        -0.665299603772363,-62.14531783266749 -0.516819767527847,-62.11256815795422
+        -0.368279118567406,-62.07984467844377 -0.219709234559883,-62.04712522750268
+        -0.07109140869026,-62.01438693062904 -0.066941884694596,-62.01347400485576
+        -0.993245791526875,-62.01333665746029 -0.993276516786622,-62.2178589766747
+        -0.993276516786622,-62.2178589766747</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T225331_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.2178589766747 -0.993276516786622,-62.211006273910414
+        -0.962246444953023,-62.17811748397836 -0.813762279058937,-62.14531783266749
+        -0.665299603772363,-62.11256815795422 -0.516819767527847,-62.07984467844377
+        -0.368279118567406,-62.04712522750268 -0.219709234559883,-62.01438693062904
+        -0.07109140869026,-62.01347400485576 -0.066941884694596,-62.01333665746029
+        -0.993245791526875,-62.2178589766747 -0.993276516786622,-62.2178589766747
+        -0.993276516786622))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"88.10
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000733_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e88a76b0-6055-432f-8cdf-432adaddbd78'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e88a76b0-6055-432f-8cdf-432adaddbd78'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e88a76b0-6055-432f-8cdf-432adaddbd78'')/Products(''Quicklook'')/$value"}],"id":"e88a76b0-6055-432f-8cdf-432adaddbd78","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        648.85 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:47:20.066Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"5.8919"},"str":[{"name":"uuid","content":"e88a76b0-6055-432f-8cdf-432adaddbd78"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000733_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.807260224698412,-59.69653612035876
+        -1.808465090603132,-58.71005016650019 -2.801398081739323,-58.71123581739256
+        -2.799530854700205,-59.698404092062326 -1.807260224698412,-59.69653612035876
+        -1.807260224698412,-59.69653612035876</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T000733_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.69653612035876 -1.807260224698412,-58.71005016650019
+        -1.808465090603132,-58.71123581739256 -2.801398081739323,-59.698404092062326
+        -2.799530854700205,-59.69653612035876 -1.807260224698412,-59.69653612035876
+        -1.807260224698412))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"648.85
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193800_R010_V20161015T142322_20161015T142317","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4070dcec-e71e-4725-8c9b-88514a2b8164'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4070dcec-e71e-4725-8c9b-88514a2b8164'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''4070dcec-e71e-4725-8c9b-88514a2b8164'')/Products(''Quicklook'')/$value"}],"id":"4070dcec-e71e-4725-8c9b-88514a2b8164","summary":"Date:
+        2016-10-15T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        564.44 MB","date":[{"name":"ingestiondate","content":"2016-10-16T19:54:17.926Z"},{"name":"beginposition","content":"2016-10-15T14:23:22Z"},{"name":"endposition","content":"2016-10-15T14:23:17Z"}],"int":[{"name":"orbitnumber","content":"6871"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"5.9744"},"str":[{"name":"uuid","content":"4070dcec-e71e-4725-8c9b-88514a2b8164"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193800_R010_V20161015T142322_20161015T142317.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.703392835495449,-60.29648646769209
+        -3.569504283831413,-60.26670126329472 -3.420914653034927,-60.23367735657053
+        -3.272282078403655,-60.2005940025612 -3.123580865298651,-60.16765157858968
+        -2.974992840208899,-60.134540096061926 -2.826373129367793,-60.101500281208935
+        -2.710549719712296,-60.075787216941684 -2.708535417726956,-59.315866557865895
+        -3.699830563697336,-59.31231525624494 -3.703392835495449,-60.29648646769209
+        -3.703392835495449,-60.29648646769209</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193800_R010_V20161015T142322_20161015T142317"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.29648646769209 -3.703392835495449,-60.26670126329472
+        -3.569504283831413,-60.23367735657053 -3.420914653034927,-60.2005940025612
+        -3.272282078403655,-60.16765157858968 -3.123580865298651,-60.134540096061926
+        -2.974992840208899,-60.101500281208935 -2.826373129367793,-60.075787216941684
+        -2.710549719712296,-59.315866557865895 -2.708535417726956,-59.31231525624494
+        -3.699830563697336,-60.29648646769209 -3.703392835495449,-60.29648646769209
+        -3.703392835495449))"},{"name":"s2datatakeid","content":"GS2A_20161015T142322_006871_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"564.44
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002103_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''535f3c8f-7aa9-48c2-8730-730f5ef4e9b3'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''535f3c8f-7aa9-48c2-8730-730f5ef4e9b3'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''535f3c8f-7aa9-48c2-8730-730f5ef4e9b3'')/Products(''Quicklook'')/$value"}],"id":"535f3c8f-7aa9-48c2-8730-730f5ef4e9b3","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        624.21 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:50:08.795Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"6.1036"},"str":[{"name":"uuid","content":"535f3c8f-7aa9-48c2-8730-730f5ef4e9b3"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002103_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.614480435341899,-59.700542771043224
+        -3.616892447971682,-58.712593296005636 -4.609788718499236,-58.71471538989507
+        -4.606712116481468,-59.70388607627803 -3.614480435341899,-59.700542771043224
+        -3.614480435341899,-59.700542771043224</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002103_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.700542771043224
+        -3.614480435341899,-58.712593296005636 -3.616892447971682,-58.71471538989507
+        -4.609788718499236,-59.70388607627803 -4.606712116481468,-59.700542771043224
+        -3.614480435341899,-59.700542771043224 -3.614480435341899))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"624.21
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20151219T221022_R139_V20151219T145832_20151219T145832","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0848f6b8-5730-4759-850e-fc9945d42296'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0848f6b8-5730-4759-850e-fc9945d42296'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0848f6b8-5730-4759-850e-fc9945d42296'')/Products(''Quicklook'')/$value"}],"id":"0848f6b8-5730-4759-850e-fc9945d42296","summary":"Date:
         2015-12-19T14:58:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
         5.79 GB","date":[{"name":"ingestiondate","content":"2015-12-19T21:28:42.109Z"},{"name":"beginposition","content":"2015-12-19T14:58:32Z"},{"name":"endposition","content":"2015-12-19T14:58:32Z"}],"int":[{"name":"orbitnumber","content":"2567"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"6.230769230769231"},"str":[{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20151219T221022_R139_V20151219T145832_20151219T145832.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
         srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.904463645229748,-67.20308401831022
@@ -117,7 +3294,344 @@ interactions:
         1.808922546237677,-67.20244815849307 1.7643945316073189,-67.20250180864736
         1.719941930287078,-67.20247990259755 1.7199419038295671,-67.20306224449203
         0.9044636313989689,-67.20308401831022 0.904463645229748))"},{"name":"s2datatakeid","content":"GS2A_20151219T144722_002567_N02.01"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.01"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.79
-        GB"},{"name":"uuid","content":"0848f6b8-5730-4759-850e-fc9945d42296"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20151219T221009_R139_V20151219T145832_20151219T145832","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''37ecee60-23d8-4ec2-a65f-2de24f51d30e'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''37ecee60-23d8-4ec2-a65f-2de24f51d30e'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''37ecee60-23d8-4ec2-a65f-2de24f51d30e'')/Products(''Quicklook'')/$value"}],"id":"37ecee60-23d8-4ec2-a65f-2de24f51d30e","summary":"Date:
+        GB"},{"name":"uuid","content":"0848f6b8-5730-4759-850e-fc9945d42296"}]}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['445770']
+    status: {code: 200, message: OK}
+- request:
+    body: q=beginPosition%3A%5B2015-12-19T00%3A00%3A00Z+TO+2016-10-19T00%3A00%3A00Z%5D+cloudcoverpercentage%3A%5B0+TO+10%5D+platformname%3ASentinel-2+footprint%3A%22Intersects%28POLYGON%28%28-66.2695+-8.0592%2C-66.2695+0.7031%2C-57.3047+0.7031%2C-57.3047+-8.0592%2C-66.2695+-8.0592%29%29%29%22
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['283']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.1]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=100&start=100&orderby=cloudcoverpercentage%20asc,beginposition%20desc
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","subtitle":"Displaying 100
+        to 131 of 132 total results. Request done in 0.656 seconds.","updated":"2018-06-06T13:15:28.784Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","opensearch:totalResults":"132","opensearch:startIndex":"100","opensearch:itemsPerPage":"100","opensearch:Query":{"role":"request","searchTerms":"beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=100&rows=100"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=0&rows=100"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[2015-12-19T00:00:00Z
+        TO 2016-10-19T00:00:00Z] cloudcoverpercentage:[0 TO 10] platformname:Sentinel-2
+        footprint:\"Intersects(POLYGON((-66.2695 -8.0592,-66.2695 0.7031,-57.3047
+        0.7031,-57.3047 -8.0592,-66.2695 -8.0592)))\"&start=131&rows=100"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}],"entry":[{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205912_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f9eef954-f7a5-46ab-bb97-2a241c395a02'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f9eef954-f7a5-46ab-bb97-2a241c395a02'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f9eef954-f7a5-46ab-bb97-2a241c395a02'')/Products(''Quicklook'')/$value"}],"id":"f9eef954-f7a5-46ab-bb97-2a241c395a02","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        617.05 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:25:44.59Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"6.2413"},"str":[{"name":"uuid","content":"f9eef954-f7a5-46ab-bb97-2a241c395a02"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205912_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.712829405650467,-67.20130348583471
+        -2.710949551849636,-66.21426770386934 -3.70313029364641,-66.21157923265464
+        -3.705699752817911,-67.19956599017397 -2.712829405650467,-67.20130348583471
+        -2.712829405650467,-67.20130348583471</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T205912_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-67.20130348583471 -2.712829405650467,-66.21426770386934
+        -2.710949551849636,-66.21157923265464 -3.70313029364641,-67.19956599017397
+        -3.705699752817911,-67.20130348583471 -2.712829405650467,-67.20130348583471
+        -2.712829405650467))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"617.05
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001148_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1a7a8086-b3ed-43c9-aad0-3ca796694175'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1a7a8086-b3ed-43c9-aad0-3ca796694175'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1a7a8086-b3ed-43c9-aad0-3ca796694175'')/Products(''Quicklook'')/$value"}],"id":"1a7a8086-b3ed-43c9-aad0-3ca796694175","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        636.00 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:49:29.871Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"6.2426"},"str":[{"name":"uuid","content":"1a7a8086-b3ed-43c9-aad0-3ca796694175"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001148_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.611889313575712,-56.91228131155878
+        -0.697963581657938,-56.93115749711932 -0.846400305219232,-56.963680069246905
+        -0.993382515484712,-56.996091857922984 -0.993270928775962,-57.89913129788935
+        0,-57.89899708558173 0,-56.91228937849629 -0.611889313575712,-56.91228131155878
+        -0.611889313575712,-56.91228131155878</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001148_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-56.91228131155878 -0.611889313575712,-56.93115749711932
+        -0.697963581657938,-56.963680069246905 -0.846400305219232,-56.996091857922984
+        -0.993382515484712,-57.89913129788935 -0.993270928775962,-57.89899708558173
+        0,-56.91228937849629 0,-56.91228131155878 -0.611889313575712,-56.91228131155878
+        -0.611889313575712))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"636.00
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160701T210613_R053_V20160630T143319_20160630T143319","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ae416732-3e3c-4a0a-a1c8-9ec0778c94ad'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ae416732-3e3c-4a0a-a1c8-9ec0778c94ad'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''ae416732-3e3c-4a0a-a1c8-9ec0778c94ad'')/Products(''Quicklook'')/$value"}],"id":"ae416732-3e3c-4a0a-a1c8-9ec0778c94ad","summary":"Date:
+        2016-06-30T14:33:19Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        1.01 GB","date":[{"name":"ingestiondate","content":"2016-07-01T21:14:22.229Z"},{"name":"beginposition","content":"2016-06-30T14:33:19Z"},{"name":"endposition","content":"2016-06-30T14:33:19Z"}],"int":[{"name":"orbitnumber","content":"5341"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"6.287675"},"str":[{"name":"uuid","content":"ae416732-3e3c-4a0a-a1c8-9ec0778c94ad"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160701T210613_R053_V20160630T143319_20160630T143319.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.809275755330586,-63.00017982400019
+        -2.80265440098957,-63.000179948753996 -2.8022731333090847,-62.10029356487891
+        -2.802307101216853,-62.100293543551295 -2.802254490521156,-62.05629195689357
+        -2.802235856336857,-62.012310655608864 -2.8022019041077386,-62.01231067901112
+        -2.801232060899604,-61.20117067407488 -2.801266185267337,-61.20117063124223
+        -2.801179136160849,-61.15690643373672 -2.801126259103253,-61.112682072108385
+        -2.8010921654831153,-61.112682117006855 -2.7994978062830684,-60.301955466581816
+        -2.799531686765212,-60.30195540280954 -2.7994113236892346,-60.257979338983326
+        -2.799324956972109,-60.21406213432756 -2.799291121891581,-60.21406220008751
+        -2.7968320051609,-59.31559501298386 -1.805518735702188,-59.31814228744849
+        -1.8071830948535272,-60.259877379667 -1.8083238116030889,-61.158183299979804
+        -1.8090177052801104,-62.05694607560237 -1.809275755330586,-63.00017982400019</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160701T210613_R053_V20160630T143319_20160630T143319"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.00017982400019 -1.809275755330586,-63.000179948753996
+        -2.80265440098957,-62.10029356487891 -2.8022731333090847,-62.100293543551295
+        -2.802307101216853,-62.05629195689357 -2.802254490521156,-62.012310655608864
+        -2.802235856336857,-62.01231067901112 -2.8022019041077386,-61.20117067407488
+        -2.801232060899604,-61.20117063124223 -2.801266185267337,-61.15690643373672
+        -2.801179136160849,-61.112682072108385 -2.801126259103253,-61.112682117006855
+        -2.8010921654831153,-60.301955466581816 -2.7994978062830684,-60.30195540280954
+        -2.799531686765212,-60.257979338983326 -2.7994113236892346,-60.21406213432756
+        -2.799324956972109,-60.21406220008751 -2.799291121891581,-59.31559501298386
+        -2.7968320051609,-59.31814228744849 -1.805518735702188,-60.259877379667 -1.8071830948535272,-61.158183299979804
+        -1.8083238116030889,-62.05694607560237 -1.8090177052801104,-63.00017982400019
+        -1.809275755330586))"},{"name":"s2datatakeid","content":"GS2A_20160630T143322_005341_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"1.01
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160801T214417_R053_V20160730T142756_20160730T142756","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2995d9a4-44a4-4bb0-a3d9-5fede2613d3f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2995d9a4-44a4-4bb0-a3d9-5fede2613d3f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2995d9a4-44a4-4bb0-a3d9-5fede2613d3f'')/Products(''Quicklook'')/$value"}],"id":"2995d9a4-44a4-4bb0-a3d9-5fede2613d3f","summary":"Date:
+        2016-07-30T14:27:56Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.13 GB","date":[{"name":"ingestiondate","content":"2016-08-02T00:11:51.575Z"},{"name":"beginposition","content":"2016-07-30T14:27:56Z"},{"name":"endposition","content":"2016-07-30T14:27:56Z"}],"int":[{"name":"orbitnumber","content":"5770"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"6.296941666666668"},"str":[{"name":"uuid","content":"2995d9a4-44a4-4bb0-a3d9-5fede2613d3f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160801T214417_R053_V20160730T142756_20160730T142756.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>1.809216727530456,-61.61185974848256
+        1.674727346348959,-61.641560228328125 1.526251868684637,-61.674275412571085
+        1.37757002718829,-61.70650594507199 1.229086246672755,-61.739582855465066
+        1.080446542568943,-61.77217646278815 0.931778521945484,-61.80478965008389
+        0.816233459302303,-61.830133185000115 0.783104828227493,-61.83739958478531
+        0.634315024644408,-61.869900452917854 0.485560532829676,-61.90247947419612
+        0.336879556987645,-61.935069872794806 0.188316653689195,-61.967786258411365
+        0.039865543746979,-62.0005791177546 -0.088469036309483,-62.028945691847284
+        -0.0884378568029472,-61.20330435261851 -0.088438933321785,-61.2033043528574
+        -0.0884361871891444,-61.15909255040489 -0.08843451908062,-61.11492060834645
+        -0.0884334435323415,-61.11492060809604 -0.0883831463539118,-60.305153124974716
+        -0.08838421517998,-60.30515312533039 -0.0883804180877932,-60.261228967454656
+        -0.08837769347984,-60.217363705154376 -0.0883766260868944,-60.217363704787616
+        -0.0883314873482076,-59.69520596226658 -0.088384188930846,-59.69520594472657
+        -0.088406152802686,-59.3275586854238 -0.088299703500415,-59.32753547135797
+        -0.088299703500415,-59.32753547135796 -0.087492129583607,-59.32735935865762
+        -0.053493479344233,-59.31994038438019 -0.053493479344231,-59.31994038438019
+        0.06131976321013,-59.2948865517362 0.210045521424224,-59.26231149314348 0.358734172621333,-59.22971695753967
+        0.507334685880629,-59.19689593595309 0.655900947525433,-59.16411034598502
+        0.804365723564745,-59.13140601247656 0.863870723803852,-59.11830160419293
+        0.95278606884472,-59.09872034246007 1.101207935280413,-59.065987864508905
+        1.249820912833326,-59.03351860734304 1.398360007494958,-59.00049618319104
+        1.547134630550781,-58.96783917756968 1.696000942103578,-58.93524000180869
+        1.719767291642326,-58.92998446138427 1.844782238064731,-58.90233944574957
+        1.993506251424866,-58.869586022573806 2.142149445722465,-58.83671206402271
+        2.290758209818235,-58.80387940422339 2.439333139916089,-58.77095055544866
+        2.587812845757051,-58.73798052947275 2.708812469260454,-58.711104665516324
+        2.712957132034671,-58.711109424229335 2.711148939858159,-59.69820496206522
+        2.7095488645433083,-59.69820206576192 2.71091678651033,-60.21426776510049
+        2.710949551849636,-60.214267703869346 2.711033187970939,-60.258181674388844
+        2.711149745616365,-60.30215450635603 2.7111169363095944,-60.302154565736394
+        2.7126608877401894,-61.11282149469654 2.712693903442947,-61.112821452890174
+        2.7127451087194467,-61.157042550654374 2.712829405650467,-61.201303485834714
+        2.7127963601713745,-61.201303525717535 2.713042132701515,-61.413553743390885
+        2.566334146277016,-61.4456039573296 2.417513049630044,-61.47807339932549 2.268794425795294,-61.51065213338136
+        2.120114672840553,-61.54320446643723 1.971534686004324,-61.57574023860139
+        1.823169529104466,-61.60877842787347 1.809216727530456,-61.61185974848256</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160801T214417_R053_V20160730T142756_20160730T142756"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.61185974848256 1.809216727530456,-61.641560228328125
+        1.674727346348959,-61.674275412571085 1.526251868684637,-61.70650594507199
+        1.37757002718829,-61.739582855465066 1.229086246672755,-61.77217646278815
+        1.080446542568943,-61.80478965008389 0.931778521945484,-61.830133185000115
+        0.816233459302303,-61.83739958478531 0.783104828227493,-61.869900452917854
+        0.634315024644408,-61.90247947419612 0.485560532829676,-61.935069872794806
+        0.336879556987645,-61.967786258411365 0.188316653689195,-62.0005791177546
+        0.039865543746979,-62.028945691847284 -0.088469036309483,-61.20330435261851
+        -0.0884378568029472,-61.2033043528574 -0.088438933321785,-61.15909255040489
+        -0.0884361871891444,-61.11492060834645 -0.08843451908062,-61.11492060809604
+        -0.0884334435323415,-60.305153124974716 -0.0883831463539118,-60.30515312533039
+        -0.08838421517998,-60.261228967454656 -0.0883804180877932,-60.217363705154376
+        -0.08837769347984,-60.217363704787616 -0.0883766260868944,-59.69520596226658
+        -0.0883314873482076,-59.69520594472657 -0.088384188930846,-59.3275586854238
+        -0.088406152802686,-59.32753547135797 -0.088299703500415,-59.32753547135796
+        -0.088299703500415,-59.32735935865762 -0.087492129583607,-59.31994038438019
+        -0.053493479344233,-59.31994038438019 -0.053493479344231,-59.2948865517362
+        0.06131976321013,-59.26231149314348 0.210045521424224,-59.22971695753967 0.358734172621333,-59.19689593595309
+        0.507334685880629,-59.16411034598502 0.655900947525433,-59.13140601247656
+        0.804365723564745,-59.11830160419293 0.863870723803852,-59.09872034246007
+        0.95278606884472,-59.065987864508905 1.101207935280413,-59.03351860734304
+        1.249820912833326,-59.00049618319104 1.398360007494958,-58.96783917756968
+        1.547134630550781,-58.93524000180869 1.696000942103578,-58.92998446138427
+        1.719767291642326,-58.90233944574957 1.844782238064731,-58.869586022573806
+        1.993506251424866,-58.83671206402271 2.142149445722465,-58.80387940422339
+        2.290758209818235,-58.77095055544866 2.439333139916089,-58.73798052947275
+        2.587812845757051,-58.711104665516324 2.708812469260454,-58.711109424229335
+        2.712957132034671,-59.69820496206522 2.711148939858159,-59.69820206576192
+        2.7095488645433083,-60.21426776510049 2.71091678651033,-60.214267703869346
+        2.710949551849636,-60.258181674388844 2.711033187970939,-60.30215450635603
+        2.711149745616365,-60.302154565736394 2.7111169363095944,-61.11282149469654
+        2.7126608877401894,-61.112821452890174 2.712693903442947,-61.157042550654374
+        2.7127451087194467,-61.201303485834714 2.712829405650467,-61.201303525717535
+        2.7127963601713745,-61.413553743390885 2.713042132701515,-61.4456039573296
+        2.566334146277016,-61.47807339932549 2.417513049630044,-61.51065213338136
+        2.268794425795294,-61.54320446643723 2.120114672840553,-61.57574023860139
+        1.971534686004324,-61.60877842787347 1.823169529104466,-61.61185974848256
+        1.809216727530456))"},{"name":"s2datatakeid","content":"GS2A_20160730T142802_005770_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.13
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160707T235404_R010_V20160707T142325_20160707T142325","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''aa2f0690-f61b-43d1-957f-640e425a7f13'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''aa2f0690-f61b-43d1-957f-640e425a7f13'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''aa2f0690-f61b-43d1-957f-640e425a7f13'')/Products(''Quicklook'')/$value"}],"id":"aa2f0690-f61b-43d1-957f-640e425a7f13","summary":"Date:
+        2016-07-07T14:23:25Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        2.83 GB","date":[{"name":"ingestiondate","content":"2016-07-08T00:06:55.55Z"},{"name":"beginposition","content":"2016-07-07T14:23:25Z"},{"name":"endposition","content":"2016-07-07T14:23:25Z"}],"int":[{"name":"orbitnumber","content":"5441"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"6.325166666666667"},"str":[{"name":"uuid","content":"aa2f0690-f61b-43d1-957f-640e425a7f13"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160707T235404_R010_V20160707T142325_20160707T142325.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.616722069061711,-61.19974375617475
+        -4.609571394393226,-61.19751317791347 -4.606657663157584,-60.29647433483778
+        -4.606713487460716,-60.29647414676393 -4.606515167396074,-60.25240911203205
+        -4.606372862374041,-60.208402873279454 -4.606317112822742,-60.208403067215386
+        -4.6040464321306755,-59.70387709430677 -4.606712116481468,-59.70388607627803
+        -4.609514603686967,-58.80284714545978 -4.609570479556857,-58.802847271018024
+        -4.609651602313045,-58.75880016628978 -4.609788718499236,-58.71471538989507
+        -4.609732794670302,-58.714715270370384 -4.611229783913699,-57.90189720205743
+        -4.61128604135956,-57.90189726530612 -4.611311451838565,-57.857554087886 -4.611393153929231,-57.81319242276077
+        -4.611336872944486,-57.813192365708524 -4.611853289877044,-56.91200637633081
+        -3.6629437321530456,-56.9121104660506 -2.714170526975779,-56.91219153266883
+        -2.7138520768084997,-57.85574991870128 -2.7128765456728288,-58.755101671966266
+        -2.7118493409356286,-59.31585468578026 -2.708535417726956,-59.315866557865895
+        -2.711149745616365,-60.30215450635603 -3.6144376607741893,-60.29978406651288
+        -3.616722069061711,-61.19974375617475</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160707T235404_R010_V20160707T142325_20160707T142325"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.19974375617475 -3.616722069061711,-61.19751317791347
+        -4.609571394393226,-60.29647433483778 -4.606657663157584,-60.29647414676393
+        -4.606713487460716,-60.25240911203205 -4.606515167396074,-60.208402873279454
+        -4.606372862374041,-60.208403067215386 -4.606317112822742,-59.70387709430677
+        -4.6040464321306755,-59.70388607627803 -4.606712116481468,-58.80284714545978
+        -4.609514603686967,-58.802847271018024 -4.609570479556857,-58.75880016628978
+        -4.609651602313045,-58.71471538989507 -4.609788718499236,-58.714715270370384
+        -4.609732794670302,-57.90189720205743 -4.611229783913699,-57.90189726530612
+        -4.61128604135956,-57.857554087886 -4.611311451838565,-57.81319242276077 -4.611393153929231,-57.813192365708524
+        -4.611336872944486,-56.91200637633081 -4.611853289877044,-56.9121104660506
+        -3.6629437321530456,-56.91219153266883 -2.714170526975779,-57.85574991870128
+        -2.7138520768084997,-58.755101671966266 -2.7128765456728288,-59.31585468578026
+        -2.7118493409356286,-59.315866557865895 -2.708535417726956,-60.30215450635603
+        -2.711149745616365,-60.29978406651288 -3.6144376607741893,-61.19974375617475
+        -3.616722069061711))"},{"name":"s2datatakeid","content":"GS2A_20160707T142322_005441_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"2.83
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T003824_R096_V20160812T143752_20160812T143749","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''df7dd412-8673-40fb-8bff-b60c1b8f731f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''df7dd412-8673-40fb-8bff-b60c1b8f731f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''df7dd412-8673-40fb-8bff-b60c1b8f731f'')/Products(''Quicklook'')/$value"}],"id":"df7dd412-8673-40fb-8bff-b60c1b8f731f","summary":"Date:
+        2016-08-12T14:37:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.57 GB","date":[{"name":"ingestiondate","content":"2016-08-13T00:35:36.611Z"},{"name":"beginposition","content":"2016-08-12T14:37:52Z"},{"name":"endposition","content":"2016-08-12T14:37:49Z"}],"int":[{"name":"orbitnumber","content":"5956"},{"name":"relativeorbitnumber","content":"96"}],"double":{"name":"cloudcoverpercentage","content":"6.354564285714285"},"str":[{"name":"uuid","content":"df7dd412-8673-40fb-8bff-b60c1b8f731f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T003824_R096_V20160812T143752_20160812T143749.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.393941030556579,-65.50110919660497
+        -4.514942175618708,-65.52812205288485 -4.542524304092956,-65.53427961504664
+        -4.691168067771232,-65.5673366480012 -4.839824347830986,-65.60042947465455
+        -4.988483082654521,-65.6335383886075 -5.137136575805998,-65.66665624502404
+        -5.285663921853993,-65.69985773959127 -5.434056135772236,-65.73317237352822
+        -5.507617938916156,-65.74972200064518 -5.507391437327689,-65.70762921084261
+        -5.510538165612144,-65.7076421723614 -5.513893497961508,-64.80535357891915
+        -5.513960396525286,-64.8053537626881 -5.514057522441122,-64.76124545442016
+        -5.514221687588917,-64.7170995025818 -5.514154731632817,-64.71709932764371
+        -5.515947033626909,-63.903151699097606 -5.516014389089381,-63.90315179166951
+        -5.516044812342758,-63.858746931290234 -5.516142631941844,-63.81432359696183
+        -5.516075248310466,-63.814323513459165 -5.516609625705226,-63.03436243204556
+        -5.41464044184139,-63.01203362424454 -5.360486925989168,-63.000180522805806
+        -5.360486925989176,-63.000180522805806 -5.265949988908369,-62.97948831312576
+        -5.117254339928802,-62.946979606218015 -4.968649309607414,-62.91446510234912
+        -4.95720994627079,-62.911958983256405 -4.957209946270786,-62.911958983256405
+        -4.820142624356157,-62.88193047359821 -4.671757122747616,-62.84932745214707
+        -4.611744461161145,-62.836145451563624 -4.523376197668469,-62.8167350393252
+        -4.374963457561644,-62.78415345689637 -4.226420978836966,-62.751651608058296
+        -4.0777166368509,-62.71924365644082 -3.928924234874795,-62.68682619035389
+        -3.780110288759486,-62.65440858778236 -3.631417584175566,-62.6219476527136
+        -3.618306909123694,-62.619089297473444 -3.482718687321822,-62.589528706370615
+        -3.334074661831115,-62.557075150217344 -3.18542807349117,-62.52460157442333
+        -3.036912647992026,-62.49207729418411 -2.88847314623518,-62.45946847581133
+        -2.740071049068597,-62.4268193437158 -2.713936111060697,-62.42106996980929
+        -2.7141556791285284,-62.956185263014774 -2.7138520768084997,-63.855749918701285
+        -2.7128765456728288,-64.7551016719663 -2.712195041716851,-65.1271359737962
+        -2.76010895942105,-65.13772879419547 -2.90872816184874,-65.17058308262754
+        -3.057391494349951,-65.20345826164868 -3.206109159452298,-65.2362555176288
+        -3.354746464186489,-65.26919749454538 -3.503259103386111,-65.30224022573243
+        -3.651657035622143,-65.33540763051379 -3.704287445672967,-65.34716029943225
+        -3.800035249823613,-65.3685413268794 -3.948393852390879,-65.40175972733249
+        -4.096822580952169,-65.43492050298636 -4.245351496242935,-65.4680215990946
+        -4.393941030556579,-65.50110919660497</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T003824_R096_V20160812T143752_20160812T143749"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.50110919660497 -4.393941030556579,-65.52812205288485
+        -4.514942175618708,-65.53427961504664 -4.542524304092956,-65.5673366480012
+        -4.691168067771232,-65.60042947465455 -4.839824347830986,-65.6335383886075
+        -4.988483082654521,-65.66665624502404 -5.137136575805998,-65.69985773959127
+        -5.285663921853993,-65.73317237352822 -5.434056135772236,-65.74972200064518
+        -5.507617938916156,-65.70762921084261 -5.507391437327689,-65.7076421723614
+        -5.510538165612144,-64.80535357891915 -5.513893497961508,-64.8053537626881
+        -5.513960396525286,-64.76124545442016 -5.514057522441122,-64.7170995025818
+        -5.514221687588917,-64.71709932764371 -5.514154731632817,-63.903151699097606
+        -5.515947033626909,-63.90315179166951 -5.516014389089381,-63.858746931290234
+        -5.516044812342758,-63.81432359696183 -5.516142631941844,-63.814323513459165
+        -5.516075248310466,-63.03436243204556 -5.516609625705226,-63.01203362424454
+        -5.41464044184139,-63.000180522805806 -5.360486925989168,-63.000180522805806
+        -5.360486925989176,-62.97948831312576 -5.265949988908369,-62.946979606218015
+        -5.117254339928802,-62.91446510234912 -4.968649309607414,-62.911958983256405
+        -4.95720994627079,-62.911958983256405 -4.957209946270786,-62.88193047359821
+        -4.820142624356157,-62.84932745214707 -4.671757122747616,-62.836145451563624
+        -4.611744461161145,-62.8167350393252 -4.523376197668469,-62.78415345689637
+        -4.374963457561644,-62.751651608058296 -4.226420978836966,-62.71924365644082
+        -4.0777166368509,-62.68682619035389 -3.928924234874795,-62.65440858778236
+        -3.780110288759486,-62.6219476527136 -3.631417584175566,-62.619089297473444
+        -3.618306909123694,-62.589528706370615 -3.482718687321822,-62.557075150217344
+        -3.334074661831115,-62.52460157442333 -3.18542807349117,-62.49207729418411
+        -3.036912647992026,-62.45946847581133 -2.88847314623518,-62.4268193437158
+        -2.740071049068597,-62.42106996980929 -2.713936111060697,-62.956185263014774
+        -2.7141556791285284,-63.855749918701285 -2.7138520768084997,-64.7551016719663
+        -2.7128765456728288,-65.1271359737962 -2.712195041716851,-65.13772879419547
+        -2.76010895942105,-65.17058308262754 -2.90872816184874,-65.20345826164868
+        -3.057391494349951,-65.2362555176288 -3.206109159452298,-65.26919749454538
+        -3.354746464186489,-65.30224022573243 -3.503259103386111,-65.33540763051379
+        -3.651657035622143,-65.34716029943225 -3.704287445672967,-65.3685413268794
+        -3.800035249823613,-65.40175972733249 -3.948393852390879,-65.43492050298636
+        -4.096822580952169,-65.4680215990946 -4.245351496242935,-65.50110919660497
+        -4.393941030556579))"},{"name":"s2datatakeid","content":"GS2A_20160812T143752_005956_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.57
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160618T092409_R010_V20160617T142324_20160617T142324","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a3c47590-8a28-4c23-91a8-59dd84792bc0'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a3c47590-8a28-4c23-91a8-59dd84792bc0'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''a3c47590-8a28-4c23-91a8-59dd84792bc0'')/Products(''Quicklook'')/$value"}],"id":"a3c47590-8a28-4c23-91a8-59dd84792bc0","summary":"Date:
+        2016-06-17T14:23:24Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        2.71 GB","date":[{"name":"ingestiondate","content":"2016-06-18T09:44:34.725Z"},{"name":"beginposition","content":"2016-06-17T14:23:24Z"},{"name":"endposition","content":"2016-06-17T14:23:24Z"}],"int":[{"name":"orbitnumber","content":"5155"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"6.446322222222223"},"str":[{"name":"uuid","content":"a3c47590-8a28-4c23-91a8-59dd84792bc0"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160618T092409_R010_V20160617T142324_20160617T142324.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.616722069061711,-61.19974375617475
+        -4.609571394393226,-61.19751317791347 -4.606657663157584,-60.29647433483778
+        -4.606713487460716,-60.29647414676393 -4.606515167396074,-60.25240911203205
+        -4.606372862374041,-60.208402873279454 -4.606317112822742,-60.208403067215386
+        -4.6040464321306755,-59.70387709430677 -4.606712116481468,-59.70388607627803
+        -4.609514603686967,-58.80284714545978 -4.609570479556857,-58.802847271018024
+        -4.609651602313045,-58.75880016628978 -4.609788718499236,-58.71471538989507
+        -4.609732794670302,-58.714715270370384 -4.611229783913699,-57.90189720205743
+        -4.61128604135956,-57.90189726530612 -4.611311451838565,-57.857554087886 -4.611393153929231,-57.81319242276077
+        -4.611336872944486,-57.813192365708524 -4.611853289877044,-56.91200637633081
+        -3.6629437321530456,-56.9121104660506 -2.714170526975779,-56.91219153266883
+        -2.7138520768084997,-57.85574991870128 -2.7128765456728288,-58.755101671966266
+        -2.7118493409356286,-59.31585468578026 -2.708535417726956,-59.315866557865895
+        -2.711149745616365,-60.30215450635603 -3.6144376607741893,-60.29978406651288
+        -3.616722069061711,-61.19974375617475</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160618T092409_R010_V20160617T142324_20160617T142324"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.19974375617475 -3.616722069061711,-61.19751317791347
+        -4.609571394393226,-60.29647433483778 -4.606657663157584,-60.29647414676393
+        -4.606713487460716,-60.25240911203205 -4.606515167396074,-60.208402873279454
+        -4.606372862374041,-60.208403067215386 -4.606317112822742,-59.70387709430677
+        -4.6040464321306755,-59.70388607627803 -4.606712116481468,-58.80284714545978
+        -4.609514603686967,-58.802847271018024 -4.609570479556857,-58.75880016628978
+        -4.609651602313045,-58.71471538989507 -4.609788718499236,-58.714715270370384
+        -4.609732794670302,-57.90189720205743 -4.611229783913699,-57.90189726530612
+        -4.61128604135956,-57.857554087886 -4.611311451838565,-57.81319242276077 -4.611393153929231,-57.813192365708524
+        -4.611336872944486,-56.91200637633081 -4.611853289877044,-56.9121104660506
+        -3.6629437321530456,-56.91219153266883 -2.714170526975779,-57.85574991870128
+        -2.7138520768084997,-58.755101671966266 -2.7128765456728288,-59.31585468578026
+        -2.7118493409356286,-59.315866557865895 -2.708535417726956,-60.30215450635603
+        -2.711149745616365,-60.29978406651288 -3.6144376607741893,-61.19974375617475
+        -3.616722069061711))"},{"name":"s2datatakeid","content":"GS2A_20160617T142322_005155_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"2.71
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163804_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''95d56be8-6f10-40c5-9171-1482f4617a3f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''95d56be8-6f10-40c5-9171-1482f4617a3f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''95d56be8-6f10-40c5-9171-1482f4617a3f'')/Products(''Quicklook'')/$value"}],"id":"95d56be8-6f10-40c5-9171-1482f4617a3f","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        486.16 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:34:09.546Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"6.6126"},"str":[{"name":"uuid","content":"95d56be8-6f10-40c5-9171-1482f4617a3f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163804_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-8.229553262013363,-63.82875302748752
+        -8.206494115705139,-63.82352047485793 -8.057956489371724,-63.789870026079
+        -7.976932405090137,-63.77155033940166 -7.909211863834918,-63.75619331104565
+        -7.760673401311588,-63.72251752439719 -7.612217608662349,-63.688914258633325
+        -7.544254342367686,-63.67357012946399 -7.463906060411885,-63.65536007335661
+        -7.315560382874527,-63.62173403031397 -7.236654630642684,-63.603858366074384
+        -7.23727611900566,-62.91158966794781 -8.23048908614055,-62.911382652974034
+        -8.229553262013363,-63.82875302748752 -8.229553262013363,-63.82875302748752</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T163804_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.82875302748752 -8.229553262013363,-63.82352047485793
+        -8.206494115705139,-63.789870026079 -8.057956489371724,-63.77155033940166
+        -7.976932405090137,-63.75619331104565 -7.909211863834918,-63.72251752439719
+        -7.760673401311588,-63.688914258633325 -7.612217608662349,-63.67357012946399
+        -7.544254342367686,-63.65536007335661 -7.463906060411885,-63.62173403031397
+        -7.315560382874527,-63.603858366074384 -7.236654630642684,-62.91158966794781
+        -7.23727611900566,-62.911382652974034 -8.23048908614055,-63.82875302748752
+        -8.229553262013363,-63.82875302748752 -8.229553262013363))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"486.16
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162910_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''cf7644cc-aebf-4528-b54c-84c0ed299515'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''cf7644cc-aebf-4528-b54c-84c0ed299515'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''cf7644cc-aebf-4528-b54c-84c0ed299515'')/Products(''Quicklook'')/$value"}],"id":"cf7644cc-aebf-4528-b54c-84c0ed299515","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        623.66 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:18:13.148Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"6.6436"},"str":[{"name":"uuid","content":"cf7644cc-aebf-4528-b54c-84c0ed299515"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162910_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.904256732085073,-62.101251151937454
+        -0.903875955648899,-61.114689730255705 -1.896723233843827,-61.11389599692503
+        -1.897522484501646,-62.100872558955864 -0.904256732085073,-62.101251151937454
+        -0.904256732085073,-62.101251151937454</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162910_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.101251151937454
+        -0.904256732085073,-61.114689730255705 -0.903875955648899,-61.11389599692503
+        -1.896723233843827,-62.100872558955864 -1.897522484501646,-62.101251151937454
+        -0.904256732085073,-62.101251151937454 -0.904256732085073))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"623.66
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20151219T221009_R139_V20151219T145832_20151219T145832","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''37ecee60-23d8-4ec2-a65f-2de24f51d30e'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''37ecee60-23d8-4ec2-a65f-2de24f51d30e'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''37ecee60-23d8-4ec2-a65f-2de24f51d30e'')/Products(''Quicklook'')/$value"}],"id":"37ecee60-23d8-4ec2-a65f-2de24f51d30e","summary":"Date:
         2015-12-19T14:58:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
         6.13 GB","date":[{"name":"ingestiondate","content":"2015-12-19T21:28:48.174Z"},{"name":"beginposition","content":"2015-12-19T14:58:32Z"},{"name":"endposition","content":"2015-12-19T14:58:32Z"}],"int":[{"name":"orbitnumber","content":"2567"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"6.666666666666667"},"str":[{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20151219T221009_R139_V20151219T145832_20151219T145832.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
         srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-68.10136233979134
@@ -166,12 +3680,693 @@ interactions:
         -0.9042776014159831,-63.81057740574847 0,-64.70920384697635 0,-64.7970528123519
         0,-65.31996054306995 0,-65.69520275703948 0,-66.21736699592725 0,-66.30515631259404
         0,-67.11492283955806 0,-67.2033064795971 0,-68.10136233979134 0))"},{"name":"s2datatakeid","content":"GS2A_20151219T144722_002567_N02.01"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.01"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.13
-        GB"},{"name":"uuid","content":"37ecee60-23d8-4ec2-a65f-2de24f51d30e"}]}]}}'}
+        GB"},{"name":"uuid","content":"37ecee60-23d8-4ec2-a65f-2de24f51d30e"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193841_R010_V20161015T142322_20161015T142317","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c870cd04-8268-411c-95c2-46a6a1f9b0f3'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c870cd04-8268-411c-95c2-46a6a1f9b0f3'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c870cd04-8268-411c-95c2-46a6a1f9b0f3'')/Products(''Quicklook'')/$value"}],"id":"c870cd04-8268-411c-95c2-46a6a1f9b0f3","summary":"Date:
+        2016-10-15T14:23:22Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        500.60 MB","date":[{"name":"ingestiondate","content":"2016-10-16T19:54:27.127Z"},{"name":"beginposition","content":"2016-10-15T14:23:22Z"},{"name":"endposition","content":"2016-10-15T14:23:17Z"}],"int":[{"name":"orbitnumber","content":"6871"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"6.7083"},"str":[{"name":"uuid","content":"c870cd04-8268-411c-95c2-46a6a1f9b0f3"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193841_R010_V20161015T142322_20161015T142317.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.770082722952254,-58.79915641882751
+        -2.78402743298413,-58.73526571108647 -2.786516064869562,-58.73581399446269
+        -2.831119759072428,-58.538716631264464 -2.830568722026465,-58.53859537460961
+        -2.831074309772226,-58.53636362672752 -2.829297822634915,-58.53597245642912
+        -2.881416408496363,-58.31595427507608 -2.881867119846244,-58.31605338832732
+        -2.881878568340793,-58.316006310701994 -2.881973300997966,-58.31602712680286
+        -2.882010694886413,-58.31587318839375 -2.88371226079907,-58.31624729479174
+        -2.883731834266064,-58.31616591731521 -2.883736970056227,-58.31616704745528
+        -2.931591836218065,-58.11742034338268 -2.931360368962254,-58.11736945744147
+        -2.931853443083683,-58.115323450811886 -2.930399804204174,-58.11500394293855
+        -2.987383461842803,-57.89212031974283 -2.987578037418232,-57.8921629994453
+        -2.987612876268068,-57.89202895637551 -2.98782266908944,-57.89207493807546
+        -2.987896588017439,-57.89178998692866 -2.988220890616196,-57.891861104263405
+        -2.988296374340228,-57.891569566005415 -2.98880132188639,-57.89168029591731
+        -2.98883994306428,-57.89153032680085 -2.989118447185749,-57.89159136167413
+        -2.989166224659048,-57.89140549406126 -2.989933816006664,-57.891573972603766
+        -3.010343651000473,-57.81171560037376 -3.707163215146263,-57.812265809915736
+        -3.705699017907994,-58.8007940487913 -2.770082722952254,-58.79915641882751
+        -2.770082722952254,-58.79915641882751</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161016T193841_R010_V20161015T142322_20161015T142317"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.79915641882751 -2.770082722952254,-58.73526571108647
+        -2.78402743298413,-58.73581399446269 -2.786516064869562,-58.538716631264464
+        -2.831119759072428,-58.53859537460961 -2.830568722026465,-58.53636362672752
+        -2.831074309772226,-58.53597245642912 -2.829297822634915,-58.31595427507608
+        -2.881416408496363,-58.31605338832732 -2.881867119846244,-58.316006310701994
+        -2.881878568340793,-58.31602712680286 -2.881973300997966,-58.31587318839375
+        -2.882010694886413,-58.31624729479174 -2.88371226079907,-58.31616591731521
+        -2.883731834266064,-58.31616704745528 -2.883736970056227,-58.11742034338268
+        -2.931591836218065,-58.11736945744147 -2.931360368962254,-58.115323450811886
+        -2.931853443083683,-58.11500394293855 -2.930399804204174,-57.89212031974283
+        -2.987383461842803,-57.8921629994453 -2.987578037418232,-57.89202895637551
+        -2.987612876268068,-57.89207493807546 -2.98782266908944,-57.89178998692866
+        -2.987896588017439,-57.891861104263405 -2.988220890616196,-57.891569566005415
+        -2.988296374340228,-57.89168029591731 -2.98880132188639,-57.89153032680085
+        -2.98883994306428,-57.89159136167413 -2.989118447185749,-57.89140549406126
+        -2.989166224659048,-57.891573972603766 -2.989933816006664,-57.81171560037376
+        -3.010343651000473,-57.812265809915736 -3.707163215146263,-58.8007940487913
+        -3.705699017907994,-58.79915641882751 -2.770082722952254,-58.79915641882751
+        -2.770082722952254))"},{"name":"s2datatakeid","content":"GS2A_20161015T142322_006871_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"500.60
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220152_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f12b52dd-9de0-4588-84c2-04fb81f7502f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f12b52dd-9de0-4588-84c2-04fb81f7502f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''f12b52dd-9de0-4588-84c2-04fb81f7502f'')/Products(''Quicklook'')/$value"}],"id":"f12b52dd-9de0-4588-84c2-04fb81f7502f","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        626.06 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:12:25.738Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"6.9514"},"str":[{"name":"uuid","content":"f12b52dd-9de0-4588-84c2-04fb81f7502f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220152_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.808379981779864,-61.20241689465753
+        -1.807127364970991,-60.215990513413956 -2.799324956972109,-60.21406213432756
+        -2.801266185267337,-61.20117063124223 -1.808379981779864,-61.20241689465753
+        -1.808379981779864,-61.20241689465753</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T220152_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.20241689465753 -1.808379981779864,-60.215990513413956
+        -1.807127364970991,-60.21406213432756 -2.799324956972109,-61.20117063124223
+        -2.801266185267337,-61.20241689465753 -1.808379981779864,-61.20241689465753
+        -1.808379981779864))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"626.06
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161008T210133_R053_V20161008T143312_20161008T143313","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e6194e18-b0ae-46c1-8483-d1346ad11cea'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e6194e18-b0ae-46c1-8483-d1346ad11cea'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e6194e18-b0ae-46c1-8483-d1346ad11cea'')/Products(''Quicklook'')/$value"}],"id":"e6194e18-b0ae-46c1-8483-d1346ad11cea","summary":"Date:
+        2016-10-08T14:33:12Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        205.42 MB","date":[{"name":"ingestiondate","content":"2016-10-08T21:52:06.304Z"},{"name":"beginposition","content":"2016-10-08T14:33:12Z"},{"name":"endposition","content":"2016-10-08T14:33:13Z"}],"int":[{"name":"orbitnumber","content":"6771"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"7.1767"},"str":[{"name":"uuid","content":"e6194e18-b0ae-46c1-8483-d1346ad11cea"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161008T210133_R053_V20161008T143312_20161008T143313.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.710056627200581,-59.889761889451215
+        -2.743131849879266,-59.896973079985 -2.891895371619766,-59.92948810761593
+        -3.040688569831037,-59.96197011087101 -3.189446634677118,-59.99442875804476
+        -3.338058581976309,-60.02701983537813 -3.486599611882616,-60.05957948067604
+        -3.635049442069249,-60.09211057770096 -3.702706816391463,-60.10695565957032
+        -3.703403926315087,-60.29955059811704 -2.711149745616365,-60.30215450635603
+        -2.710056627200581,-59.889761889451215 -2.710056627200581,-59.889761889451215</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161008T210133_R053_V20161008T143312_20161008T143313"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.889761889451215
+        -2.710056627200581,-59.896973079985 -2.743131849879266,-59.92948810761593
+        -2.891895371619766,-59.96197011087101 -3.040688569831037,-59.99442875804476
+        -3.189446634677118,-60.02701983537813 -3.338058581976309,-60.05957948067604
+        -3.486599611882616,-60.09211057770096 -3.635049442069249,-60.10695565957032
+        -3.702706816391463,-60.29955059811704 -3.703403926315087,-60.30215450635603
+        -2.711149745616365,-59.889761889451215 -2.710056627200581,-59.889761889451215
+        -2.710056627200581))"},{"name":"s2datatakeid","content":"GS2A_20161008T143312_006771_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"205.42
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162818_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''455a5bde-a5a8-411a-944d-6bfe15f8081d'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''455a5bde-a5a8-411a-944d-6bfe15f8081d'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''455a5bde-a5a8-411a-944d-6bfe15f8081d'')/Products(''Quicklook'')/$value"}],"id":"455a5bde-a5a8-411a-944d-6bfe15f8081d","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        614.80 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:19:00.311Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"7.1968"},"str":[{"name":"uuid","content":"455a5bde-a5a8-411a-944d-6bfe15f8081d"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162818_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.809051653364241,-62.10091718433367
+        -1.808289691632107,-61.113989555549914 -2.801126259103253,-61.112682072108385
+        -2.802307101216853,-62.100293543551295 -1.809051653364241,-62.10091718433367
+        -1.809051653364241,-62.10091718433367</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162818_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.10091718433367 -1.809051653364241,-61.113989555549914
+        -1.808289691632107,-61.112682072108385 -2.801126259103253,-62.100293543551295
+        -2.802307101216853,-62.10091718433367 -1.809051653364241,-62.10091718433367
+        -1.809051653364241))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"614.80
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160921T231407_R096_V20160921T143742_20160921T143741","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''86603671-fc91-424e-84a6-5d083b92fd41'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''86603671-fc91-424e-84a6-5d083b92fd41'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''86603671-fc91-424e-84a6-5d083b92fd41'')/Products(''Quicklook'')/$value"}],"id":"86603671-fc91-424e-84a6-5d083b92fd41","summary":"Date:
+        2016-09-21T14:37:42Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.36 GB","date":[{"name":"ingestiondate","content":"2016-09-22T00:05:01.611Z"},{"name":"beginposition","content":"2016-09-21T14:37:42Z"},{"name":"endposition","content":"2016-09-21T14:37:41Z"}],"int":[{"name":"orbitnumber","content":"6528"},{"name":"relativeorbitnumber","content":"96"}],"double":{"name":"cloudcoverpercentage","content":"7.323458333333332"},"str":[{"name":"uuid","content":"86603671-fc91-424e-84a6-5d083b92fd41"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160921T231407_R096_V20160921T143742_20160921T143741.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0.816175483179788,-64.33545671468978
+        0.78017998446173,-64.34338509467307 0.631688207904404,-64.37606074139981 0.483246309288946,-64.40876856270583
+        0.334800349800358,-64.44149865534665 0.18635270274442,-64.47425366146983 0.037835159713696,-64.50698848756632
+        -0.088448190800307,-64.53486897000188 -0.0884706851318954,-63.89899815036412
+        -0.088471762244608,-63.89899815024451 -0.0884722487571825,-63.854797517463126
+        -0.088473813037585,-63.81057836572721 -0.0884727354735923,-63.810578365835106
+        -0.088481655461822,-63.00017973516372 -0.088482727241185,-63.0001797351637
+        -0.0884821391683909,-62.95623403354793 -0.088482622864584,-62.912289274605605
+        -0.0884815511082114,-62.912289274593995 -0.0884706994281444,-62.101361275435124
+        -0.088471771010446,-62.101361275554076 -0.0884701113057866,-62.05741187000464
+        -0.08846952345505,-62.013482762370394 -0.0884684523676525,-62.013482762239875
+        -0.088461626204315,-61.832724204276474 0.057802021727914,-61.8005927586828
+        0.206433590630948,-61.767943920820166 0.355179652345996,-61.73530575298974
+        0.504008357760651,-61.70265545004443 0.652878880403341,-61.66995167153512
+        0.801642356721745,-61.63719922684713 0.816165120398466,-61.63400245967834
+        0.8814875493856131,-61.619623612716445 0.904611534514424,-61.61453353495185
+        0.950320351772974,-61.604472058390726 1.098933711165127,-61.571698552659605
+        1.247437900098566,-61.538940466479566 1.395863799273102,-61.50620618330782
+        1.544321202761404,-61.4734931469166 1.692872237953451,-61.44080727151279 1.720091575771449,-61.43481175560293
+        1.784956907144874,-61.42052407789203 1.809064860717812,-61.41521389657289
+        1.841449237845192,-61.40808069408294 1.990106672072546,-61.375285367277 2.138875904496751,-61.34250142280844
+        2.287677109303459,-61.30965925034619 2.436512236585456,-61.27678441643151
+        2.585259250611488,-61.24376837539632 2.712812730272023,-61.21544081528314
+        2.7137355404388757,-62.01238365781276 2.713768419219708,-62.01238363602219
+        2.713786464257691,-62.05636168750621 2.713837411591844,-62.100360025146514
+        2.7138045176276218,-62.100360045005324 2.714137627658003,-62.912191534607516
+        2.714170526975779,-62.91219153266882 2.7141556791285284,-62.95618526301482
+        2.714173730986409,-63.000179935454945 2.714140830963323,-63.00017993545097
+        2.713867017359404,-63.81148151018264 2.713900094942792,-63.81148152819555
+        2.7138520768084997,-63.85574991870165 2.713837142510183,-63.899999800987494
+        2.7138040787718225,-63.89999978101821 2.713785688937714,-63.91695355004005
+        2.71159364108562,-63.91743111617711 2.562980471546755,-63.95000178353229 2.414390095956956,-63.98249962923799
+        2.266263819526927,-64.01620957074554 2.117893504042741,-64.04906585865007
+        1.969142173698393,-64.08106692629917 1.820579402382278,-64.11371351477088
+        1.809415417891804,-64.11616186445985 1.7436852493873485,-64.1305770078839
+        1.720397077934445,-64.13568428722328 1.671906065978274,-64.14631874789833
+        1.522807270355006,-64.17778451789177 1.374735623147485,-64.21245506319529
+        1.225999447825257,-64.2452355035298 1.07731339046891,-64.27796858982333 0.928688830203306,-64.31067448912927
+        0.904637587317022,-64.3159720235284 0.8833351475027138,-64.32066410568962
+        0.816175483179788,-64.33545671468978</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160921T231407_R096_V20160921T143742_20160921T143741"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-64.33545671468978 0.816175483179788,-64.34338509467307
+        0.78017998446173,-64.37606074139981 0.631688207904404,-64.40876856270583 0.483246309288946,-64.44149865534665
+        0.334800349800358,-64.47425366146983 0.18635270274442,-64.50698848756632 0.037835159713696,-64.53486897000188
+        -0.088448190800307,-63.89899815036412 -0.0884706851318954,-63.89899815024451
+        -0.088471762244608,-63.854797517463126 -0.0884722487571825,-63.81057836572721
+        -0.088473813037585,-63.810578365835106 -0.0884727354735923,-63.00017973516372
+        -0.088481655461822,-63.0001797351637 -0.088482727241185,-62.95623403354793
+        -0.0884821391683909,-62.912289274605605 -0.088482622864584,-62.912289274593995
+        -0.0884815511082114,-62.101361275435124 -0.0884706994281444,-62.101361275554076
+        -0.088471771010446,-62.05741187000464 -0.0884701113057866,-62.013482762370394
+        -0.08846952345505,-62.013482762239875 -0.0884684523676525,-61.832724204276474
+        -0.088461626204315,-61.8005927586828 0.057802021727914,-61.767943920820166
+        0.206433590630948,-61.73530575298974 0.355179652345996,-61.70265545004443
+        0.504008357760651,-61.66995167153512 0.652878880403341,-61.63719922684713
+        0.801642356721745,-61.63400245967834 0.816165120398466,-61.619623612716445
+        0.8814875493856131,-61.61453353495185 0.904611534514424,-61.604472058390726
+        0.950320351772974,-61.571698552659605 1.098933711165127,-61.538940466479566
+        1.247437900098566,-61.50620618330782 1.395863799273102,-61.4734931469166 1.544321202761404,-61.44080727151279
+        1.692872237953451,-61.43481175560293 1.720091575771449,-61.42052407789203
+        1.784956907144874,-61.41521389657289 1.809064860717812,-61.40808069408294
+        1.841449237845192,-61.375285367277 1.990106672072546,-61.34250142280844 2.138875904496751,-61.30965925034619
+        2.287677109303459,-61.27678441643151 2.436512236585456,-61.24376837539632
+        2.585259250611488,-61.21544081528314 2.712812730272023,-62.01238365781276
+        2.7137355404388757,-62.01238363602219 2.713768419219708,-62.05636168750621
+        2.713786464257691,-62.100360025146514 2.713837411591844,-62.100360045005324
+        2.7138045176276218,-62.912191534607516 2.714137627658003,-62.91219153266882
+        2.714170526975779,-62.95618526301482 2.7141556791285284,-63.000179935454945
+        2.714173730986409,-63.00017993545097 2.714140830963323,-63.81148151018264
+        2.713867017359404,-63.81148152819555 2.713900094942792,-63.85574991870165
+        2.7138520768084997,-63.899999800987494 2.713837142510183,-63.89999978101821
+        2.7138040787718225,-63.91695355004005 2.713785688937714,-63.91743111617711
+        2.71159364108562,-63.95000178353229 2.562980471546755,-63.98249962923799 2.414390095956956,-64.01620957074554
+        2.266263819526927,-64.04906585865007 2.117893504042741,-64.08106692629917
+        1.969142173698393,-64.11371351477088 1.820579402382278,-64.11616186445985
+        1.809415417891804,-64.1305770078839 1.7436852493873485,-64.13568428722328
+        1.720397077934445,-64.14631874789833 1.671906065978274,-64.17778451789177
+        1.522807270355006,-64.21245506319529 1.374735623147485,-64.2452355035298 1.225999447825257,-64.27796858982333
+        1.07731339046891,-64.31067448912927 0.928688830203306,-64.3159720235284 0.904637587317022,-64.32066410568962
+        0.8833351475027138,-64.33545671468978 0.816175483179788))"},{"name":"s2datatakeid","content":"GS2A_20160921T143742_006528_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.36
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001747_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb9e41a0-0b70-4d1b-9bc2-0d19094bab06'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb9e41a0-0b70-4d1b-9bc2-0d19094bab06'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb9e41a0-0b70-4d1b-9bc2-0d19094bab06'')/Products(''Quicklook'')/$value"}],"id":"eb9e41a0-0b70-4d1b-9bc2-0d19094bab06","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        614.45 MB","date":[{"name":"ingestiondate","content":"2016-10-06T00:44:20.799Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"7.4771"},"str":[{"name":"uuid","content":"eb9e41a0-0b70-4d1b-9bc2-0d19094bab06"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001747_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.616721351843382,-58.80061624728885
+        -3.618150301207514,-57.812185568725496 -4.611393153929231,-57.81319242276077
+        -4.609570479556857,-58.802847271018024 -3.616721351843382,-58.80061624728885
+        -3.616721351843382,-58.80061624728885</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T001747_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-58.80061624728885 -3.616721351843382,-57.812185568725496
+        -3.618150301207514,-57.81319242276077 -4.611393153929231,-58.802847271018024
+        -4.609570479556857,-58.80061624728885 -3.616721351843382,-58.80061624728885
+        -3.616721351843382))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"614.45
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T232635_R110_V20160813T141052_20160813T141049","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c979a69c-d9fb-4b7f-b7ae-1f23c9afdfa2'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c979a69c-d9fb-4b7f-b7ae-1f23c9afdfa2'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c979a69c-d9fb-4b7f-b7ae-1f23c9afdfa2'')/Products(''Quicklook'')/$value"}],"id":"c979a69c-d9fb-4b7f-b7ae-1f23c9afdfa2","summary":"Date:
+        2016-08-13T14:10:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.59 GB","date":[{"name":"ingestiondate","content":"2016-08-13T22:33:13.474Z"},{"name":"beginposition","content":"2016-08-13T14:10:52Z"},{"name":"endposition","content":"2016-08-13T14:10:49Z"}],"int":[{"name":"orbitnumber","content":"5970"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"7.715308333333334"},"str":[{"name":"uuid","content":"c979a69c-d9fb-4b7f-b7ae-1f23c9afdfa2"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T232635_R110_V20160813T141052_20160813T141049.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.85533602943453,-57.38445467242115
+        -2.003836612503953,-57.4173899529627 -2.152213121270442,-57.45045576259334
+        -2.300555144668367,-57.48345154952641 -2.448854541764934,-57.51659091173712
+        -2.597252079848268,-57.54960136629737 -2.745778779802651,-57.58254771616425
+        -2.802413106805851,-57.59508552915518 -2.8026204268243964,-57.00017994874974
+        -2.80265440098957,-57.000179948754 -2.8026357597624734,-56.95618202471934
+        -2.802651092372252,-56.912185042742124 -2.802617118935394,-56.912185044824206
+        -2.8022731333090847,-56.10029356487891 -2.802307101216853,-56.100293543551295
+        -2.802254490521156,-56.05629195689357 -2.802235856336857,-56.01231065560888
+        -2.8022019041077386,-56.01231067901114 -2.801232060899604,-55.20117067407488
+        -2.801266185267337,-55.20117063124223 -2.8011791361608487,-55.1569064337366
+        -2.801126259103253,-55.1126820721084 -2.801092165483116,-55.11268211700687
+        -2.800649822322755,-54.88775200795293 -2.726366764665169,-54.871476681473936
+        -2.57770371324837,-54.8389847846227 -2.428961758780379,-54.80630621514347
+        -2.280141085600721,-54.77374386893893 -2.131393263626372,-54.74123845284182
+        -1.982702829667828,-54.70870239232931 -1.834036743878813,-54.67621413002838
+        -1.807704461186773,-54.670449473033756 -1.68542445820299,-54.64367996418614
+        -1.536776737203988,-54.61127564289518 -1.38814223976932,-54.57924994349981
+        -1.239812843027332,-54.54622737067093 -1.091361663905751,-54.51358560422333
+        -0.992406396164465,-54.49183333325926 -0.942821588487937,-54.48093363891352
+        -0.794124019401779,-54.44840177634228 -0.645264661189201,-54.41609317733705
+        -0.496407202449395,-54.38348578290408 -0.347589237411009,-54.35095685024132
+        -0.198924590165784,-54.3181916169873 -0.050310494536624,-54.285465656767855
+        0,-54.274442853298424 0,-55.11492283955806 0,-55.2033064795971 0,-56.01348393064086
+        0,-56.101362339791336 0,-56.91228937849629 0,-56.974812948389165 -0.07232071965961,-56.99073289253927
+        -0.22091019024079,-57.023482732634015 -0.369364950597466,-57.05643307320793
+        -0.517867259137493,-57.0891866271196 -0.666284559359523,-57.12212066729991
+        -0.814788913350435,-57.15499529282653 -0.904338126878361,-57.1747711639547
+        -0.963358948296889,-57.1878052053747 -1.111943642287606,-57.22059341908307
+        -1.260541989873661,-57.25344946378394 -1.40924650526984,-57.28607795685728
+        -1.557973802974862,-57.31889132171177 -1.70666095989329,-57.35172532457992
+        -1.85533602943453,-57.38445467242115</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160813T232635_R110_V20160813T141052_20160813T141049"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.38445467242115 -1.85533602943453,-57.4173899529627
+        -2.003836612503953,-57.45045576259334 -2.152213121270442,-57.48345154952641
+        -2.300555144668367,-57.51659091173712 -2.448854541764934,-57.54960136629737
+        -2.597252079848268,-57.58254771616425 -2.745778779802651,-57.59508552915518
+        -2.802413106805851,-57.00017994874974 -2.8026204268243964,-57.000179948754
+        -2.80265440098957,-56.95618202471934 -2.8026357597624734,-56.912185042742124
+        -2.802651092372252,-56.912185044824206 -2.802617118935394,-56.10029356487891
+        -2.8022731333090847,-56.100293543551295 -2.802307101216853,-56.05629195689357
+        -2.802254490521156,-56.01231065560888 -2.802235856336857,-56.01231067901114
+        -2.8022019041077386,-55.20117067407488 -2.801232060899604,-55.20117063124223
+        -2.801266185267337,-55.1569064337366 -2.8011791361608487,-55.1126820721084
+        -2.801126259103253,-55.11268211700687 -2.801092165483116,-54.88775200795293
+        -2.800649822322755,-54.871476681473936 -2.726366764665169,-54.8389847846227
+        -2.57770371324837,-54.80630621514347 -2.428961758780379,-54.77374386893893
+        -2.280141085600721,-54.74123845284182 -2.131393263626372,-54.70870239232931
+        -1.982702829667828,-54.67621413002838 -1.834036743878813,-54.670449473033756
+        -1.807704461186773,-54.64367996418614 -1.68542445820299,-54.61127564289518
+        -1.536776737203988,-54.57924994349981 -1.38814223976932,-54.54622737067093
+        -1.239812843027332,-54.51358560422333 -1.091361663905751,-54.49183333325926
+        -0.992406396164465,-54.48093363891352 -0.942821588487937,-54.44840177634228
+        -0.794124019401779,-54.41609317733705 -0.645264661189201,-54.38348578290408
+        -0.496407202449395,-54.35095685024132 -0.347589237411009,-54.3181916169873
+        -0.198924590165784,-54.285465656767855 -0.050310494536624,-54.274442853298424
+        0,-55.11492283955806 0,-55.2033064795971 0,-56.01348393064086 0,-56.101362339791336
+        0,-56.91228937849629 0,-56.974812948389165 0,-56.99073289253927 -0.07232071965961,-57.023482732634015
+        -0.22091019024079,-57.05643307320793 -0.369364950597466,-57.0891866271196
+        -0.517867259137493,-57.12212066729991 -0.666284559359523,-57.15499529282653
+        -0.814788913350435,-57.1747711639547 -0.904338126878361,-57.1878052053747
+        -0.963358948296889,-57.22059341908307 -1.111943642287606,-57.25344946378394
+        -1.260541989873661,-57.28607795685728 -1.40924650526984,-57.31889132171177
+        -1.557973802974862,-57.35172532457992 -1.70666095989329,-57.38445467242115
+        -1.85533602943453))"},{"name":"s2datatakeid","content":"GS2A_20160813T141052_005970_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.59
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T004135_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2f107ef6-ea5a-4f97-864b-a11d8c38497b'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2f107ef6-ea5a-4f97-864b-a11d8c38497b'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''2f107ef6-ea5a-4f97-864b-a11d8c38497b'')/Products(''Quicklook'')/$value"}],"id":"2f107ef6-ea5a-4f97-864b-a11d8c38497b","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        71.43 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:09:29.09Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"7.7924"},"str":[{"name":"uuid","content":"2f107ef6-ea5a-4f97-864b-a11d8c38497b"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T004135_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.088314528725084,-59.499031309977966
+        0.024399213729268,-59.474154478813645 0.172842622071785,-59.441499516985935
+        0.32133626115349,-59.40869392676323 0.469973915136995,-59.37603259419638 0.618641640463251,-59.34332275476831
+        0.7265470379067,-59.31958602113949 -0.088299048298173,-59.31995619614116 -0.088314528725084,-59.499031309977966
+        -0.088314528725084,-59.499031309977966</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T004135_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.499031309977966
+        -0.088314528725084,-59.474154478813645 0.024399213729268,-59.441499516985935
+        0.172842622071785,-59.40869392676323 0.32133626115349,-59.37603259419638 0.469973915136995,-59.34332275476831
+        0.618641640463251,-59.31958602113949 0.7265470379067,-59.31995619614116 -0.088299048298173,-59.499031309977966
+        -0.088314528725084,-59.499031309977966 -0.088314528725084))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"71.43
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160820T004746_R053_V20160819T142752_20160819T142755","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8cfd5bc9-ef60-4135-8835-597aff52f1d8'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8cfd5bc9-ef60-4135-8835-597aff52f1d8'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8cfd5bc9-ef60-4135-8835-597aff52f1d8'')/Products(''Quicklook'')/$value"}],"id":"8cfd5bc9-ef60-4135-8835-597aff52f1d8","summary":"Date:
+        2016-08-19T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.30 GB","date":[{"name":"ingestiondate","content":"2016-08-20T01:41:39.572Z"},{"name":"beginposition","content":"2016-08-19T14:27:52Z"},{"name":"endposition","content":"2016-08-19T14:27:55Z"}],"int":[{"name":"orbitnumber","content":"6056"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"7.975325000000001"},"str":[{"name":"uuid","content":"8cfd5bc9-ef60-4135-8835-597aff52f1d8"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160820T004746_R053_V20160819T142752_20160819T142755.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.278143330486329,-63.62959034612093
+        -7.426725682070179,-63.66300352393632 -7.575206658863541,-63.69650597227179
+        -7.723576327529097,-63.73013687393224 -7.871841447826255,-63.76381341811951
+        -8.020043853931861,-63.79757498391452 -8.168243356843961,-63.8313463816942
+        -8.229536383758523,-63.84529845575013 -8.230398500927846,-63.00018159295572
+        -8.230498859705568,-63.00018159299859 -8.2304437940123,-62.955781654289254
+        -8.23048908614055,-62.911382652974034 -8.23038872950755,-62.911382673891325
+        -8.22937260678506,-62.09207424566609 -8.229472946800525,-62.09207403140284
+        -8.229317536684688,-62.04767075347121 -8.229262491883746,-62.003287660422316
+        -8.229162198038187,-62.00328789552824 -8.226297324933647,-61.18474557597368
+        -8.226398126465138,-61.18474514567033 -8.226140988458724,-61.140077621706126
+        -8.226032014373303,-61.10894189687769 -8.211886386928768,-61.105853972556574
+        -8.151891303102577,-61.092757326315855 -8.003179041634668,-61.06020489527269
+        -7.854478282203126,-61.02775044202249 -7.705809205726085,-60.99513259470773
+        -7.557137292783787,-60.96264449196031 -7.408512330587762,-60.930007850739536
+        -7.259956735173194,-60.89750081605335 -7.232176482074722,-60.891366335238885
+        -7.111574273042937,-60.86473475867026 -6.963187265288779,-60.832133122250326
+        -6.814793255261094,-60.79946816930766 -6.66632904041041,-60.766827082175446
+        -6.517705179328736,-60.73428841554707 -6.368940166848041,-60.70182658940168
+        -6.220136118202405,-60.669387775156935 -6.071402598514478,-60.636932483925925
+        -5.922755511568478,-60.60442204931692 -5.774135142259341,-60.571956507894726
+        -5.625519060581216,-60.539529540921485 -5.476971949795893,-60.50709128953242
+        -5.422867796542832,-60.495252046547655 -5.425362066336241,-61.150863213059225
+        -5.427449229390539,-62.05319609957077 -5.428189238842002,-62.95603825270778
+        -5.428015846663475,-63.2132277414119 -5.496254557064499,-63.228447066286094
+        -5.644886930646787,-63.261725632902575 -5.793450645541923,-63.295082795613965
+        -5.941867866544028,-63.32851654005788 -6.090270084914884,-63.361938827448895
+        -6.238571661827391,-63.39553875502224 -6.332095045597701,-63.41662522236505
+        -6.386943425055017,-63.42899173986695 -6.53538966932323,-63.46247541482574
+        -6.683893492179832,-63.49588577601731 -6.83245475098996,-63.52932903519619
+        -6.980986812478144,-63.56277155102696 -7.129548263684432,-63.59620680335488
+        -7.278143330486329,-63.62959034612093</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160820T004746_R053_V20160819T142752_20160819T142755"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.62959034612093 -7.278143330486329,-63.66300352393632
+        -7.426725682070179,-63.69650597227179 -7.575206658863541,-63.73013687393224
+        -7.723576327529097,-63.76381341811951 -7.871841447826255,-63.79757498391452
+        -8.020043853931861,-63.8313463816942 -8.168243356843961,-63.84529845575013
+        -8.229536383758523,-63.00018159295572 -8.230398500927846,-63.00018159299859
+        -8.230498859705568,-62.955781654289254 -8.2304437940123,-62.911382652974034
+        -8.23048908614055,-62.911382673891325 -8.23038872950755,-62.09207424566609
+        -8.22937260678506,-62.09207403140284 -8.229472946800525,-62.04767075347121
+        -8.229317536684688,-62.003287660422316 -8.229262491883746,-62.00328789552824
+        -8.229162198038187,-61.18474557597368 -8.226297324933647,-61.18474514567033
+        -8.226398126465138,-61.140077621706126 -8.226140988458724,-61.10894189687769
+        -8.226032014373303,-61.105853972556574 -8.211886386928768,-61.092757326315855
+        -8.151891303102577,-61.06020489527269 -8.003179041634668,-61.02775044202249
+        -7.854478282203126,-60.99513259470773 -7.705809205726085,-60.96264449196031
+        -7.557137292783787,-60.930007850739536 -7.408512330587762,-60.89750081605335
+        -7.259956735173194,-60.891366335238885 -7.232176482074722,-60.86473475867026
+        -7.111574273042937,-60.832133122250326 -6.963187265288779,-60.79946816930766
+        -6.814793255261094,-60.766827082175446 -6.66632904041041,-60.73428841554707
+        -6.517705179328736,-60.70182658940168 -6.368940166848041,-60.669387775156935
+        -6.220136118202405,-60.636932483925925 -6.071402598514478,-60.60442204931692
+        -5.922755511568478,-60.571956507894726 -5.774135142259341,-60.539529540921485
+        -5.625519060581216,-60.50709128953242 -5.476971949795893,-60.495252046547655
+        -5.422867796542832,-61.150863213059225 -5.425362066336241,-62.05319609957077
+        -5.427449229390539,-62.95603825270778 -5.428189238842002,-63.2132277414119
+        -5.428015846663475,-63.228447066286094 -5.496254557064499,-63.261725632902575
+        -5.644886930646787,-63.295082795613965 -5.793450645541923,-63.32851654005788
+        -5.941867866544028,-63.361938827448895 -6.090270084914884,-63.39553875502224
+        -6.238571661827391,-63.41662522236505 -6.332095045597701,-63.42899173986695
+        -6.386943425055017,-63.46247541482574 -6.53538966932323,-63.49588577601731
+        -6.683893492179832,-63.52932903519619 -6.83245475098996,-63.56277155102696
+        -6.980986812478144,-63.59620680335488 -7.129548263684432,-63.62959034612093
+        -7.278143330486329))"},{"name":"s2datatakeid","content":"GS2A_20160819T142752_006056_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.30
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160921T224527_R096_V20160921T143742_20160921T143741","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8fd9646d-7be4-4d74-8c06-7ea31bfc5dbc'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8fd9646d-7be4-4d74-8c06-7ea31bfc5dbc'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8fd9646d-7be4-4d74-8c06-7ea31bfc5dbc'')/Products(''Quicklook'')/$value"}],"id":"8fd9646d-7be4-4d74-8c06-7ea31bfc5dbc","summary":"Date:
+        2016-09-21T14:37:42Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.00 GB","date":[{"name":"ingestiondate","content":"2016-09-21T23:40:39.14Z"},{"name":"beginposition","content":"2016-09-21T14:37:42Z"},{"name":"endposition","content":"2016-09-21T14:37:41Z"}],"int":[{"name":"orbitnumber","content":"6528"},{"name":"relativeorbitnumber","content":"96"}],"double":{"name":"cloudcoverpercentage","content":"7.983961538461538"},"str":[{"name":"uuid","content":"8fd9646d-7be4-4d74-8c06-7ea31bfc5dbc"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160921T224527_R096_V20160921T143742_20160921T143741.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.412162341687465,-65.94109278044508
+        -6.498369922495509,-65.96055702127933 -6.646697579524212,-65.99398055084212
+        -6.794979752107197,-66.02756756388035 -6.943355865055756,-66.06100923105667
+        -7.091758668298326,-66.09452953330258 -7.240183131101282,-66.1280722833375
+        -7.388666181698373,-66.16161248897329 -7.537140101667119,-66.19520538089317
+        -7.685692452570203,-66.22879227037876 -7.83424129626237,-66.26233605141195
+        -7.982750696322448,-66.29596431099236 -8.131212951441983,-66.32962373980875
+        -8.221593669996807,-66.3501615015566 -8.221174458521304,-66.27734014430516
+        -8.221274538592427,-66.27733950365256 -8.220918997302837,-66.23296389570278
+        -8.220663876926901,-66.18864685496362 -8.220563930551878,-66.18864751558618
+        -8.216833080207858,-65.72299484166875 -8.221272080743814,-65.72302326127163
+        -8.226296312759192,-64.81561742540931 -8.22639648636114,-64.81561785311763
+        -8.226541922193537,-64.77125891780369 -8.226787741770087,-64.72686245728039
+        -8.22668748239152,-64.72686205012566 -8.229371267918504,-63.90828889229283
+        -8.22947212599136,-63.90828910774846 -8.229517681770956,-63.86363165409411
+        -8.229664156708726,-63.81895578445098 -8.22956325653525,-63.81895559010357
+        -8.229769285614262,-63.61698925061459 -8.114019564624313,-63.59163939352875
+        -7.965452551876856,-63.559076233523214 -7.816965624670972,-63.5264998010493
+        -7.668525516299609,-63.49390602006368 -7.520166909996265,-63.46132834540436
+        -7.37180827194954,-63.42871594693908 -7.325283839324728,-63.418500244180805
+        -7.223368466805813,-63.3961219561843 -7.074774689397622,-63.363562226440486
+        -6.926072001817773,-63.330995333991766 -6.777306733923288,-63.29848005298326
+        -6.628542784371366,-63.26593932682907 -6.479881247832417,-63.233333813151205
+        -6.421260219628097,-63.22051512276255 -6.332264493003007,-63.20105438144726
+        -6.331239734861969,-63.20083029705748 -6.182638961962619,-63.16831553339299
+        -6.034088600381392,-63.13577579206376 -5.88562479663921,-63.103226085572416
+        -5.737238908370292,-63.070690814408366 -5.588841874246305,-63.0381607407324
+        -5.440426632846916,-63.00563775403575 -5.428157610100384,-63.00295259425466
+        -5.427580735171929,-63.85862076311501 -5.4256255018713695,-64.76098681421246
+        -5.423640334598856,-65.30349460796113 -5.416924739912873,-65.30353928373772
+        -5.419120363757903,-65.71820053679382 -5.458545928888695,-65.7270319681998
+        -5.607048216698138,-65.76037717002136 -5.755618504511406,-65.79366537828807
+        -5.90423563319162,-65.82696000785249 -6.052875402336321,-65.8602699532733
+        -6.201476255275839,-65.89363355794967 -6.349979884924857,-65.92705301384046
+        -6.412162341687465,-65.94109278044508</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160921T224527_R096_V20160921T143742_20160921T143741"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.94109278044508 -6.412162341687465,-65.96055702127933
+        -6.498369922495509,-65.99398055084212 -6.646697579524212,-66.02756756388035
+        -6.794979752107197,-66.06100923105667 -6.943355865055756,-66.09452953330258
+        -7.091758668298326,-66.1280722833375 -7.240183131101282,-66.16161248897329
+        -7.388666181698373,-66.19520538089317 -7.537140101667119,-66.22879227037876
+        -7.685692452570203,-66.26233605141195 -7.83424129626237,-66.29596431099236
+        -7.982750696322448,-66.32962373980875 -8.131212951441983,-66.3501615015566
+        -8.221593669996807,-66.27734014430516 -8.221174458521304,-66.27733950365256
+        -8.221274538592427,-66.23296389570278 -8.220918997302837,-66.18864685496362
+        -8.220663876926901,-66.18864751558618 -8.220563930551878,-65.72299484166875
+        -8.216833080207858,-65.72302326127163 -8.221272080743814,-64.81561742540931
+        -8.226296312759192,-64.81561785311763 -8.22639648636114,-64.77125891780369
+        -8.226541922193537,-64.72686245728039 -8.226787741770087,-64.72686205012566
+        -8.22668748239152,-63.90828889229283 -8.229371267918504,-63.90828910774846
+        -8.22947212599136,-63.86363165409411 -8.229517681770956,-63.81895578445098
+        -8.229664156708726,-63.81895559010357 -8.22956325653525,-63.61698925061459
+        -8.229769285614262,-63.59163939352875 -8.114019564624313,-63.559076233523214
+        -7.965452551876856,-63.5264998010493 -7.816965624670972,-63.49390602006368
+        -7.668525516299609,-63.46132834540436 -7.520166909996265,-63.42871594693908
+        -7.37180827194954,-63.418500244180805 -7.325283839324728,-63.3961219561843
+        -7.223368466805813,-63.363562226440486 -7.074774689397622,-63.330995333991766
+        -6.926072001817773,-63.29848005298326 -6.777306733923288,-63.26593932682907
+        -6.628542784371366,-63.233333813151205 -6.479881247832417,-63.22051512276255
+        -6.421260219628097,-63.20105438144726 -6.332264493003007,-63.20083029705748
+        -6.331239734861969,-63.16831553339299 -6.182638961962619,-63.13577579206376
+        -6.034088600381392,-63.103226085572416 -5.88562479663921,-63.070690814408366
+        -5.737238908370292,-63.0381607407324 -5.588841874246305,-63.00563775403575
+        -5.440426632846916,-63.00295259425466 -5.428157610100384,-63.85862076311501
+        -5.427580735171929,-64.76098681421246 -5.4256255018713695,-65.30349460796113
+        -5.423640334598856,-65.30353928373772 -5.416924739912873,-65.71820053679382
+        -5.419120363757903,-65.7270319681998 -5.458545928888695,-65.76037717002136
+        -5.607048216698138,-65.79366537828807 -5.755618504511406,-65.82696000785249
+        -5.90423563319162,-65.8602699532733 -6.052875402336321,-65.89363355794967
+        -6.201476255275839,-65.92705301384046 -6.349979884924857,-65.94109278044508
+        -6.412162341687465))"},{"name":"s2datatakeid","content":"GS2A_20160921T143742_006528_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.00
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162841_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0510e5a3-2315-4f42-8207-b3afd9d0c071'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0510e5a3-2315-4f42-8207-b3afd9d0c071'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''0510e5a3-2315-4f42-8207-b3afd9d0c071'')/Products(''Quicklook'')/$value"}],"id":"0510e5a3-2315-4f42-8207-b3afd9d0c071","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        632.22 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:18:48.246Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"8.1607"},"str":[{"name":"uuid","content":"0510e5a3-2315-4f42-8207-b3afd9d0c071"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162841_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.808379981779864,-61.20241689465753
+        -1.807127364970991,-60.215990513413956 -2.799324956972109,-60.21406213432756
+        -2.801266185267337,-61.20117063124223 -1.808379981779864,-61.20241689465753
+        -1.808379981779864,-61.20241689465753</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162841_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-61.20241689465753 -1.808379981779864,-60.215990513413956
+        -1.807127364970991,-60.21406213432756 -2.799324956972109,-61.20117063124223
+        -2.801266185267337,-61.20241689465753 -1.808379981779864,-61.20241689465753
+        -1.808379981779864))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"632.22
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162627_R053_V20161018T143002_20161018T143021","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8b8a7d72-276b-4f1d-8814-ce14b0536fb8'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8b8a7d72-276b-4f1d-8814-ce14b0536fb8'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8b8a7d72-276b-4f1d-8814-ce14b0536fb8'')/Products(''Quicklook'')/$value"}],"id":"8b8a7d72-276b-4f1d-8814-ce14b0536fb8","summary":"Date:
+        2016-10-18T14:30:02Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        593.50 MB","date":[{"name":"ingestiondate","content":"2016-10-19T22:18:36.098Z"},{"name":"beginposition","content":"2016-10-18T14:30:02Z"},{"name":"endposition","content":"2016-10-18T14:30:21Z"}],"int":[{"name":"orbitnumber","content":"6914"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"8.3356"},"str":[{"name":"uuid","content":"8b8a7d72-276b-4f1d-8814-ce14b0536fb8"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162627_R053_V20161018T143002_20161018T143021.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-5.427551341986956,-62.09734193364203
+        -5.425259436921197,-61.10649394534544 -6.418001170031817,-61.10310921806829
+        -6.42071558745088,-62.09572748106634 -5.427551341986956,-62.09734193364203
+        -5.427551341986956,-62.09734193364203</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161019T162627_R053_V20161018T143002_20161018T143021"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.09734193364203 -5.427551341986956,-61.10649394534544
+        -5.425259436921197,-61.10310921806829 -6.418001170031817,-62.09572748106634
+        -6.42071558745088,-62.09734193364203 -5.427551341986956,-62.09734193364203
+        -5.427551341986956))"},{"name":"s2datatakeid","content":"GS2A_20161018T143002_006914_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"593.50
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003415_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8f2e604d-f909-4f12-9cc3-610320389b3c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8f2e604d-f909-4f12-9cc3-610320389b3c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''8f2e604d-f909-4f12-9cc3-610320389b3c'')/Products(''Quicklook'')/$value"}],"id":"8f2e604d-f909-4f12-9cc3-610320389b3c","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        290.84 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:03:59.105Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"8.5264"},"str":[{"name":"uuid","content":"8f2e604d-f909-4f12-9cc3-610320389b3c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003415_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-2.714014797284323,-57.37361398247777
+        -2.778142151508841,-57.38769577094944 -2.926559372916314,-57.42031625153309
+        -3.075094409161157,-57.45286198283637 -3.223748183897894,-57.485368756288814
+        -3.372485845322594,-57.517841857298535 -3.52131216595124,-57.55029614949062
+        -3.670154247785151,-57.58276455599576 -3.707220048011529,-57.59084470418677
+        -3.707077169132468,-57.9008696071629 -2.713837142510183,-57.8999998009875
+        -2.714014797284323,-57.37361398247777 -2.714014797284323,-57.37361398247777</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T003415_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.37361398247777 -2.714014797284323,-57.38769577094944
+        -2.778142151508841,-57.42031625153309 -2.926559372916314,-57.45286198283637
+        -3.075094409161157,-57.485368756288814 -3.223748183897894,-57.517841857298535
+        -3.372485845322594,-57.55029614949062 -3.52131216595124,-57.58276455599576
+        -3.670154247785151,-57.59084470418677 -3.707220048011529,-57.9008696071629
+        -3.707077169132468,-57.8999998009875 -2.713837142510183,-57.37361398247777
+        -2.714014797284323,-57.37361398247777 -2.714014797284323))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"290.84
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160710T210626_R053_V20160710T142756_20160710T142756","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''212596c4-6f5c-4e76-819e-ae6491ffb3ac'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''212596c4-6f5c-4e76-819e-ae6491ffb3ac'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''212596c4-6f5c-4e76-819e-ae6491ffb3ac'')/Products(''Quicklook'')/$value"}],"id":"212596c4-6f5c-4e76-819e-ae6491ffb3ac","summary":"Date:
+        2016-07-10T14:27:56Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.46 GB","date":[{"name":"ingestiondate","content":"2016-07-10T21:19:23.695Z"},{"name":"beginposition","content":"2016-07-10T14:27:56Z"},{"name":"endposition","content":"2016-07-10T14:27:56Z"}],"int":[{"name":"orbitnumber","content":"5484"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"8.790814285714287"},"str":[{"name":"uuid","content":"212596c4-6f5c-4e76-819e-ae6491ffb3ac"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160710T210626_R053_V20160710T142756_20160710T142756.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-4.566956183578661,-63.90184742647189
+        -5.516014389089381,-63.90315179166951 -5.516633044843839,-63.00018056571296
+        -5.516700066819259,-63.00018056573138 -5.51666329264377,-62.95603179187785
+        -5.516693539799448,-62.91188395837315 -5.51662651925904,-62.91188396736038
+        -5.515947927683427,-62.09720938629529 -5.516014937246069,-62.097209294235604
+        -5.5159111504805916,-62.05305697799958 -5.515874390220655,-62.00892491028778
+        -5.515807411549814,-62.0089250113026 -5.5138941737767615,-61.1950073715956
+        -5.513961491831883,-61.19500718671128 -5.513789767821807,-61.15059164364745
+        -5.513685455771881,-61.10621586418906 -5.51361819829923,-61.1062160579905
+        -5.510472970358236,-60.292718824860636 -5.510539807042403,-60.29271854959391
+        -5.510302364769759,-60.24859255586318 -5.510131987398975,-60.204525314213285
+        -5.5100652401698405,-60.204525598059945 -5.505214111502747,-59.302997530767676
+        -4.55802276012127,-59.30832298262014 -3.6553345476849817,-59.31247466262803
+        -2.708535417726956,-59.315866557865895 -2.711033187970939,-60.25818167438885
+        -2.7127451087194467,-61.15704255065438 -2.713786464257691,-62.05636168750624
+        -2.714173730986409,-63.000179935454945 -3.618471428039255,-63.000180093787996
+        -3.618066326597325,-63.900780615824445 -4.566956183578661,-63.90184742647189</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160710T210626_R053_V20160710T142756_20160710T142756"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-63.90184742647189 -4.566956183578661,-63.90315179166951
+        -5.516014389089381,-63.00018056571296 -5.516633044843839,-63.00018056573138
+        -5.516700066819259,-62.95603179187785 -5.51666329264377,-62.91188395837315
+        -5.516693539799448,-62.91188396736038 -5.51662651925904,-62.09720938629529
+        -5.515947927683427,-62.097209294235604 -5.516014937246069,-62.05305697799958
+        -5.5159111504805916,-62.00892491028778 -5.515874390220655,-62.0089250113026
+        -5.515807411549814,-61.1950073715956 -5.5138941737767615,-61.19500718671128
+        -5.513961491831883,-61.15059164364745 -5.513789767821807,-61.10621586418906
+        -5.513685455771881,-61.1062160579905 -5.51361819829923,-60.292718824860636
+        -5.510472970358236,-60.29271854959391 -5.510539807042403,-60.24859255586318
+        -5.510302364769759,-60.204525314213285 -5.510131987398975,-60.204525598059945
+        -5.5100652401698405,-59.302997530767676 -5.505214111502747,-59.30832298262014
+        -4.55802276012127,-59.31247466262803 -3.6553345476849817,-59.315866557865895
+        -2.708535417726956,-60.25818167438885 -2.711033187970939,-61.15704255065438
+        -2.7127451087194467,-62.05636168750624 -2.713786464257691,-63.000179935454945
+        -2.714173730986409,-63.000180093787996 -3.618471428039255,-63.900780615824445
+        -3.618066326597325,-63.90184742647189 -4.566956183578661))"},{"name":"s2datatakeid","content":"GS2A_20160710T142802_005484_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.46
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T210244_R110_V20160724T141050_20160724T141050","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e8c1ac09-7a74-4c8e-87de-b9130cd9eb9f'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e8c1ac09-7a74-4c8e-87de-b9130cd9eb9f'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''e8c1ac09-7a74-4c8e-87de-b9130cd9eb9f'')/Products(''Quicklook'')/$value"}],"id":"e8c1ac09-7a74-4c8e-87de-b9130cd9eb9f","summary":"Date:
+        2016-07-24T14:10:50Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.71 GB","date":[{"name":"ingestiondate","content":"2016-07-24T21:19:12.252Z"},{"name":"beginposition","content":"2016-07-24T14:10:50Z"},{"name":"endposition","content":"2016-07-24T14:10:50Z"}],"int":[{"name":"orbitnumber","content":"5684"},{"name":"relativeorbitnumber","content":"110"}],"double":{"name":"cloudcoverpercentage","content":"8.943249999999999"},"str":[{"name":"uuid","content":"e8c1ac09-7a74-4c8e-87de-b9130cd9eb9f"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T210244_R110_V20160724T141050_20160724T141050.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.8976422425506,-57.3913014017484
+        -2.008344860779034,-57.41589580977716 -2.156721034155078,-57.4489495314206
+        -2.305084278775512,-57.48198216222061 -2.453489394901023,-57.51511402933656
+        -2.601964388828422,-57.548080030654255 -2.750560991303983,-57.5809755165752
+        -2.802414032384851,-57.59242957670172 -2.802620426824397,-57.00017994874974
+        -2.80265440098957,-57.000179948754 -2.8026357597624734,-56.95618202471939
+        -2.802651092372252,-56.912185042742124 -2.802617118935394,-56.912185044824206
+        -2.8022731333090847,-56.10029356487891 -2.802307101216853,-56.100293543551295
+        -2.802254490521156,-56.05629195689357 -2.802235856336857,-56.01231065560888
+        -2.8022019041077386,-56.01231067901114 -2.801232060899604,-55.20117067407488
+        -2.801266185267337,-55.20117063124223 -2.801179136160849,-55.156906433736786
+        -2.801126259103253,-55.1126820721084 -2.8010921654831153,-55.11268211700687
+        -2.800644622058255,-54.88510768977246 -2.730956403242931,-54.86980689043512
+        -2.582382742051347,-54.837278831562415 -2.433746132249013,-54.804586331321424
+        -2.284988131221033,-54.77196625405755 -2.13618814240652,-54.739484633889774
+        -1.987438660044344,-54.706972266380696 -1.83866384975931,-54.67457096556807
+        -1.807701106781278,-54.6678079037607 -1.689939935024758,-54.642085825982825
+        -1.541269246720906,-54.60975494298969 -1.392569079030656,-54.577801471637386
+        -1.244338132666274,-54.54475988625661 -1.095984029695318,-54.512035375048605
+        -0.992404569333874,-54.48921349357184 -0.94759957454788,-54.47934151434927
+        -0.799034756453692,-54.44675413194797 -0.650206067709661,-54.41455521412428
+        -0.501445959921184,-54.381815409326 -0.352587533078996,-54.349324420239526
+        -0.203903345302002,-54.31647405699114 -0.055188436970546,-54.28386136000572
+        0,-54.27181153021508 0,-55.11492283955806 0,-55.2033064795971 0,-56.01348393064086
+        0,-56.101362339791336 0,-56.91228937849629 0,-56.972230820459814 -0.077052643668084,-56.98920837765593
+        -0.225502373433497,-57.0220046103732 -0.373873428938991,-57.0549041874705
+        -0.522295360406994,-57.087696245857856 -0.670709236519013,-57.12059097342838
+        -0.819263785788696,-57.15342149170001 -0.967841144180115,-57.18628061196094
+        -0.993358321266836,-57.19188876962892 -1.116547236314742,-57.21896319311188
+        -1.265181860181968,-57.25180736089125 -1.413959872317919,-57.28439635709376
+        -1.562628231265204,-57.31723757712512 -1.711258713628497,-57.350155024285016
+        -1.859870193452579,-57.382909719578045 -1.8976422425506,-57.3913014017484</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160724T210244_R110_V20160724T141050_20160724T141050"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-57.3913014017484 -1.8976422425506,-57.41589580977716
+        -2.008344860779034,-57.4489495314206 -2.156721034155078,-57.48198216222061
+        -2.305084278775512,-57.51511402933656 -2.453489394901023,-57.548080030654255
+        -2.601964388828422,-57.5809755165752 -2.750560991303983,-57.59242957670172
+        -2.802414032384851,-57.00017994874974 -2.802620426824397,-57.000179948754
+        -2.80265440098957,-56.95618202471939 -2.8026357597624734,-56.912185042742124
+        -2.802651092372252,-56.912185044824206 -2.802617118935394,-56.10029356487891
+        -2.8022731333090847,-56.100293543551295 -2.802307101216853,-56.05629195689357
+        -2.802254490521156,-56.01231065560888 -2.802235856336857,-56.01231067901114
+        -2.8022019041077386,-55.20117067407488 -2.801232060899604,-55.20117063124223
+        -2.801266185267337,-55.156906433736786 -2.801179136160849,-55.1126820721084
+        -2.801126259103253,-55.11268211700687 -2.8010921654831153,-54.88510768977246
+        -2.800644622058255,-54.86980689043512 -2.730956403242931,-54.837278831562415
+        -2.582382742051347,-54.804586331321424 -2.433746132249013,-54.77196625405755
+        -2.284988131221033,-54.739484633889774 -2.13618814240652,-54.706972266380696
+        -1.987438660044344,-54.67457096556807 -1.83866384975931,-54.6678079037607
+        -1.807701106781278,-54.642085825982825 -1.689939935024758,-54.60975494298969
+        -1.541269246720906,-54.577801471637386 -1.392569079030656,-54.54475988625661
+        -1.244338132666274,-54.512035375048605 -1.095984029695318,-54.48921349357184
+        -0.992404569333874,-54.47934151434927 -0.94759957454788,-54.44675413194797
+        -0.799034756453692,-54.41455521412428 -0.650206067709661,-54.381815409326
+        -0.501445959921184,-54.349324420239526 -0.352587533078996,-54.31647405699114
+        -0.203903345302002,-54.28386136000572 -0.055188436970546,-54.27181153021508
+        0,-55.11492283955806 0,-55.2033064795971 0,-56.01348393064086 0,-56.101362339791336
+        0,-56.91228937849629 0,-56.972230820459814 0,-56.98920837765593 -0.077052643668084,-57.0220046103732
+        -0.225502373433497,-57.0549041874705 -0.373873428938991,-57.087696245857856
+        -0.522295360406994,-57.12059097342838 -0.670709236519013,-57.15342149170001
+        -0.819263785788696,-57.18628061196094 -0.967841144180115,-57.19188876962892
+        -0.993358321266836,-57.21896319311188 -1.116547236314742,-57.25180736089125
+        -1.265181860181968,-57.28439635709376 -1.413959872317919,-57.31723757712512
+        -1.562628231265204,-57.350155024285016 -1.711258713628497,-57.382909719578045
+        -1.859870193452579,-57.3913014017484 -1.8976422425506))"},{"name":"s2datatakeid","content":"GS2A_20160724T141052_005684_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.71
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002623_R010_V20161005T142032_20161005T142037","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c1503696-e98c-46b0-a771-887a2630026c'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c1503696-e98c-46b0-a771-887a2630026c'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c1503696-e98c-46b0-a771-887a2630026c'')/Products(''Quicklook'')/$value"}],"id":"c1503696-e98c-46b0-a771-887a2630026c","summary":"Date:
+        2016-10-05T14:20:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        650.46 MB","date":[{"name":"ingestiondate","content":"2016-10-06T01:09:24.87Z"},{"name":"beginposition","content":"2016-10-05T14:20:32Z"},{"name":"endposition","content":"2016-10-05T14:20:37Z"}],"int":[{"name":"orbitnumber","content":"6728"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"8.9735"},"str":[{"name":"uuid","content":"c1503696-e98c-46b0-a771-887a2630026c"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002623_R010_V20161005T142032_20161005T142037.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-0.979091751910186,-59.695622340872454
+        -0.903371621015646,-59.678956899078834 -0.903963608086094,-58.70941523486894
+        -1.896907216496603,-58.710135007233 -1.895643386851301,-59.69666978552469
+        -0.979091751910186,-59.695622340872454 -0.979091751910186,-59.695622340872454</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161006T002623_R010_V20161005T142032_20161005T142037"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.695622340872454
+        -0.979091751910186,-59.678956899078834 -0.903371621015646,-58.70941523486894
+        -0.903963608086094,-58.710135007233 -1.896907216496603,-59.69666978552469
+        -1.895643386851301,-59.695622340872454 -0.979091751910186,-59.695622340872454
+        -0.979091751910186))"},{"name":"s2datatakeid","content":"GS2A_20161005T142032_006728_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"650.46
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210530_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c73ca1f3-a7ba-4e26-b78d-d03f9e6b9a4b'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c73ca1f3-a7ba-4e26-b78d-d03f9e6b9a4b'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''c73ca1f3-a7ba-4e26-b78d-d03f9e6b9a4b'')/Products(''Quicklook'')/$value"}],"id":"c73ca1f3-a7ba-4e26-b78d-d03f9e6b9a4b","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        70.62 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:29:25.043Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"9.0496"},"str":[{"name":"uuid","content":"c73ca1f3-a7ba-4e26-b78d-d03f9e6b9a4b"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210530_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-5.422852077967201,-65.51890988911529
+        -5.569761695109479,-65.5510254038701 -5.71824200920066,-65.58342914934973
+        -5.866669919343328,-65.61595507942987 -6.015071571862831,-65.6484850427217
+        -6.163474752386898,-65.6809838337331 -6.302960779772505,-65.71153771156702
+        -5.422162914642032,-65.70724488750403 -5.422852077967201,-65.51890988911529
+        -5.422852077967201,-65.51890988911529</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210530_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.51890988911529 -5.422852077967201,-65.5510254038701
+        -5.569761695109479,-65.58342914934973 -5.71824200920066,-65.61595507942987
+        -5.866669919343328,-65.6484850427217 -6.015071571862831,-65.6809838337331
+        -6.163474752386898,-65.71153771156702 -6.302960779772505,-65.70724488750403
+        -5.422162914642032,-65.51890988911529 -5.422852077967201,-65.51890988911529
+        -5.422852077967201))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"70.62
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215510_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eed702f3-181b-41fc-9bde-a3d6e5882517'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eed702f3-181b-41fc-9bde-a3d6e5882517'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eed702f3-181b-41fc-9bde-a3d6e5882517'')/Products(''Quicklook'')/$value"}],"id":"eed702f3-181b-41fc-9bde-a3d6e5882517","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        643.02 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:04:28.111Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"9.0864"},"str":[{"name":"uuid","content":"eed702f3-181b-41fc-9bde-a3d6e5882517"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215510_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-3.618066685535434,-62.09957952238195
+        -3.616541317710464,-61.11118510507441 -4.609340839911776,-61.10884495524299
+        -4.611286499197733,-62.098463319197016 -3.618066685535434,-62.09957952238195
+        -3.618066685535434,-62.09957952238195</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T215510_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-62.09957952238195 -3.618066685535434,-61.11118510507441
+        -3.616541317710464,-61.10884495524299 -4.609340839911776,-62.098463319197016
+        -4.611286499197733,-62.09957952238195 -3.618066685535434,-62.09957952238195
+        -3.618066685535434))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"643.02
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160517T183842_R139_V20160517T144736_20160517T144736","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1959c5f8-ba95-474f-afe8-d49b7a19c157'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1959c5f8-ba95-474f-afe8-d49b7a19c157'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1959c5f8-ba95-474f-afe8-d49b7a19c157'')/Products(''Quicklook'')/$value"}],"id":"1959c5f8-ba95-474f-afe8-d49b7a19c157","summary":"Date:
+        2016-05-17T14:47:36Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        5.77 GB","date":[{"name":"ingestiondate","content":"2016-05-18T03:55:21.74Z"},{"name":"beginposition","content":"2016-05-17T14:47:36Z"},{"name":"endposition","content":"2016-05-17T14:47:36Z"}],"int":[{"name":"orbitnumber","content":"4712"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"9.2613"},"str":[{"name":"uuid","content":"1959c5f8-ba95-474f-afe8-d49b7a19c157"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160517T183842_R139_V20160517T144736_20160517T144736.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-6.376870942991099,-69.00018084764044
+        -7.281365177888992,-69.00018118761395 -8.230498859705568,-69.00018159299859
+        -8.22937260678506,-68.09207424566608 -8.229472946800525,-68.09207403140283
+        -8.229317536684688,-68.04767075347118 -8.229262491883746,-68.0032876604223
+        -8.229162198038187,-68.00328789552823 -8.226297324933649,-67.18474557597366
+        -8.226398126465138,-67.18474514567032 -8.226140988458724,-67.14007762170615
+        -8.225984792224422,-67.09544973653786 -8.225884081237991,-67.0954501875956
+        -8.221174458521304,-66.27734014430516 -8.221274538592427,-66.27733950365256
+        -8.220918997302837,-66.2329638957028 -8.220663876926901,-66.18864685496362
+        -8.220563930551878,-66.18864751558618 -8.213299979039988,-65.28202352029784
+        -7.2661721315466945,-65.29030025371527 -6.416130193837673,-65.29683748483669
+        -6.418626011330089,-64.719916673474 -5.425787018912554,-64.71684733293108
+        -5.423640334598856,-65.30349460796113 -5.416924739912873,-65.30353928373772
+        -5.4219309173953585,-66.24899623557717 -5.425362066336241,-67.15086321305921
+        -5.427449229390539,-68.05319609957077 -5.428225419816825,-69.000180539198
+        -6.376870942991099,-69.00018084764044</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160517T183842_R139_V20160517T144736_20160517T144736"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-69.00018084764044 -6.376870942991099,-69.00018118761395
+        -7.281365177888992,-69.00018159299859 -8.230498859705568,-68.09207424566608
+        -8.22937260678506,-68.09207403140283 -8.229472946800525,-68.04767075347118
+        -8.229317536684688,-68.0032876604223 -8.229262491883746,-68.00328789552823
+        -8.229162198038187,-67.18474557597366 -8.226297324933649,-67.18474514567032
+        -8.226398126465138,-67.14007762170615 -8.226140988458724,-67.09544973653786
+        -8.225984792224422,-67.0954501875956 -8.225884081237991,-66.27734014430516
+        -8.221174458521304,-66.27733950365256 -8.221274538592427,-66.2329638957028
+        -8.220918997302837,-66.18864685496362 -8.220663876926901,-66.18864751558618
+        -8.220563930551878,-65.28202352029784 -8.213299979039988,-65.29030025371527
+        -7.2661721315466945,-65.29683748483669 -6.416130193837673,-64.719916673474
+        -6.418626011330089,-64.71684733293108 -5.425787018912554,-65.30349460796113
+        -5.423640334598856,-65.30353928373772 -5.416924739912873,-66.24899623557717
+        -5.4219309173953585,-67.15086321305921 -5.425362066336241,-68.05319609957077
+        -5.427449229390539,-69.000180539198 -5.428225419816825,-69.00018084764044
+        -6.376870942991099))"},{"name":"s2datatakeid","content":"GS2A_20160517T144742_004712_N02.02"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.02"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"5.77
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T223626_R053_V20160928T142752_20160928T142947","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5ea35368-b2a6-40f5-ba91-3eb9f8613e73'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5ea35368-b2a6-40f5-ba91-3eb9f8613e73'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''5ea35368-b2a6-40f5-ba91-3eb9f8613e73'')/Products(''Quicklook'')/$value"}],"id":"5ea35368-b2a6-40f5-ba91-3eb9f8613e73","summary":"Date:
+        2016-09-28T14:27:52Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        334.72 MB","date":[{"name":"ingestiondate","content":"2016-09-28T22:44:06.899Z"},{"name":"beginposition","content":"2016-09-28T14:27:52Z"},{"name":"endposition","content":"2016-09-28T14:29:47Z"}],"int":[{"name":"orbitnumber","content":"6628"},{"name":"relativeorbitnumber","content":"53"}],"double":{"name":"cloudcoverpercentage","content":"9.5391"},"str":[{"name":"uuid","content":"5ea35368-b2a6-40f5-ba91-3eb9f8613e73"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T223626_R053_V20160928T142752_20160928T142947.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-1.806181906567237,-59.69338057375918
+        -1.833341963874607,-59.69933389341461 -1.9819168064589,-59.732060209895145
+        -2.130658188191992,-59.76452446231266 -2.279452953268321,-59.79708670523409
+        -2.428325452483254,-59.82961664100856 -2.577126458406747,-59.8621192599083
+        -2.725828120087973,-59.89462886201905 -2.798460313532222,-59.910516605710995
+        -2.799531686765212,-60.30195540280954 -1.807260761605379,-60.303823126388046
+        -1.806181906567237,-59.69338057375918 -1.806181906567237,-59.69338057375918</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160928T223626_R053_V20160928T142752_20160928T142947"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-59.69338057375918 -1.806181906567237,-59.69933389341461
+        -1.833341963874607,-59.732060209895145 -1.9819168064589,-59.76452446231266
+        -2.130658188191992,-59.79708670523409 -2.279452953268321,-59.82961664100856
+        -2.428325452483254,-59.8621192599083 -2.577126458406747,-59.89462886201905
+        -2.725828120087973,-59.910516605710995 -2.798460313532222,-60.30195540280954
+        -2.799531686765212,-60.303823126388046 -1.807260761605379,-59.69338057375918
+        -1.806181906567237,-59.69338057375918 -1.806181906567237))"},{"name":"s2datatakeid","content":"GS2A_20160928T142752_006628_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"334.72
+        MB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20160608T035955_R010_V20160607T142041_20160607T142041","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb88069b-2d2a-420f-9961-d18cf9b80630'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb88069b-2d2a-420f-9961-d18cf9b80630'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''eb88069b-2d2a-420f-9961-d18cf9b80630'')/Products(''Quicklook'')/$value"}],"id":"eb88069b-2d2a-420f-9961-d18cf9b80630","summary":"Date:
+        2016-06-07T14:20:41Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        6.22 GB","date":[{"name":"ingestiondate","content":"2016-06-08T04:21:26.525Z"},{"name":"beginposition","content":"2016-06-07T14:20:41Z"},{"name":"endposition","content":"2016-06-07T14:20:41Z"}],"int":[{"name":"orbitnumber","content":"5012"},{"name":"relativeorbitnumber","content":"10"}],"double":{"name":"cloudcoverpercentage","content":"9.788635714285713"},"str":[{"name":"uuid","content":"eb88069b-2d2a-420f-9961-d18cf9b80630"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160608T035955_R010_V20160607T142041_20160607T142041.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>0,-60.30515631259404
+        -0.9033617375403121,-60.304790530777176 -0.903361766508728,-60.30482331831355
+        -0.9478046119954973,-60.30477253533339 -0.992287945780174,-60.30475452350715
+        -0.9922879139314531,-60.30472170612534 -1.807260703892119,-60.303790470814704
+        -1.807260761605379,-60.303823126388046 -1.851413056416722,-60.3037400197687
+        -1.895643950033409,-60.30368947897708 -1.8956438893910947,-60.30365676531919
+        -2.799531686765212,-60.30195540280954 -2.797879750232732,-59.69840098382115
+        -2.799530854700205,-59.698404092062326 -2.8012317183660334,-58.799189044685384
+        -2.801265630042686,-58.79918908725958 -2.8013148643462156,-58.755231308382875
+        -2.801398081739323,-58.71123581739256 -2.801364140934071,-58.7112357768642
+        -2.8022726801247053,-57.90006628771813 -2.802306823350039,-57.9000663091644
+        -2.8023222452332335,-57.855813156781615 -2.802371831094856,-57.811541496895146
+        -2.802337673572892,-57.81154147754995 -2.802651092372252,-56.912185042742124
+        -1.897732319008923,-56.91224050123892 -1.897474262556893,-56.01294627189678
+        -0.9487194831258218,-56.01334325958346 0,-56.01348393064086 0,-56.91228937849629
+        0,-57.000179734950805 0,-57.81057740574848 0,-57.89899708558173 0,-58.70920384697636
+        0,-58.7970528123519 0,-59.319960543069975 0,-59.69520275703949 0,-60.30515631259404</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20160608T035955_R010_V20160607T142041_20160607T142041"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-60.30515631259404 0,-60.304790530777176
+        -0.9033617375403121,-60.30482331831355 -0.903361766508728,-60.30477253533339
+        -0.9478046119954973,-60.30475452350715 -0.992287945780174,-60.30472170612534
+        -0.9922879139314531,-60.303790470814704 -1.807260703892119,-60.303823126388046
+        -1.807260761605379,-60.3037400197687 -1.851413056416722,-60.30368947897708
+        -1.895643950033409,-60.30365676531919 -1.8956438893910947,-60.30195540280954
+        -2.799531686765212,-59.69840098382115 -2.797879750232732,-59.698404092062326
+        -2.799530854700205,-58.799189044685384 -2.8012317183660334,-58.79918908725958
+        -2.801265630042686,-58.755231308382875 -2.8013148643462156,-58.71123581739256
+        -2.801398081739323,-58.7112357768642 -2.801364140934071,-57.90006628771813
+        -2.8022726801247053,-57.9000663091644 -2.802306823350039,-57.855813156781615
+        -2.8023222452332335,-57.811541496895146 -2.802371831094856,-57.81154147754995
+        -2.802337673572892,-56.912185042742124 -2.802651092372252,-56.91224050123892
+        -1.897732319008923,-56.01294627189678 -1.897474262556893,-56.01334325958346
+        -0.9487194831258218,-56.01348393064086 0,-56.91228937849629 0,-57.000179734950805
+        0,-57.81057740574848 0,-57.89899708558173 0,-58.70920384697636 0,-58.7970528123519
+        0,-59.319960543069975 0,-59.69520275703949 0,-60.30515631259404 0))"},{"name":"s2datatakeid","content":"GS2A_20160607T142042_005012_N02.02"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.02"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"6.22
+        GB"},{"name":"processed","content":"F"}]},{"title":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210524_R139_V20161004T144732_20161004T144903","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1cc52173-d1f4-4c4e-a9ad-161793da5968'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1cc52173-d1f4-4c4e-a9ad-161793da5968'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1cc52173-d1f4-4c4e-a9ad-161793da5968'')/Products(''Quicklook'')/$value"}],"id":"1cc52173-d1f4-4c4e-a9ad-161793da5968","summary":"Date:
+        2016-10-04T14:47:32Z, Instrument: MSI, Mode: , Satellite: Sentinel-2, Size:
+        174.30 MB","date":[{"name":"ingestiondate","content":"2016-10-04T21:33:22.075Z"},{"name":"beginposition","content":"2016-10-04T14:47:32Z"},{"name":"endposition","content":"2016-10-04T14:49:03Z"}],"int":[{"name":"orbitnumber","content":"6714"},{"name":"relativeorbitnumber","content":"139"}],"double":{"name":"cloudcoverpercentage","content":"9.9721"},"str":[{"name":"uuid","content":"1cc52173-d1f4-4c4e-a9ad-161793da5968"},{"name":"filename","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210524_R139_V20161004T144732_20161004T144903.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>-7.226575214692776,-65.91345425733603
+        -7.352666163602486,-65.94104059352149 -7.501114956149729,-65.9735768334516
+        -7.649517619302266,-66.00608136998613 -7.79791246856619,-66.03864884615592
+        -7.946323404256719,-66.07128952849521 -8.09479435898135,-66.10389834024062
+        -8.220105268205542,-66.13140122364122 -8.221274538592427,-66.27733950365256
+        -7.229185752148047,-66.28369026115281 -7.226575214692776,-65.91345425733603
+        -7.226575214692776,-65.91345425733603</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S2A_OPER_PRD_MSIL1C_PDMC_20161004T210524_R139_V20161004T144732_20161004T144903"},{"name":"instrumentshortname","content":"MSI"},{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"footprint","content":"POLYGON ((-65.91345425733603 -7.226575214692776,-65.94104059352149
+        -7.352666163602486,-65.9735768334516 -7.501114956149729,-66.00608136998613
+        -7.649517619302266,-66.03864884615592 -7.79791246856619,-66.07128952849521
+        -7.946323404256719,-66.10389834024062 -8.09479435898135,-66.13140122364122
+        -8.220105268205542,-66.27733950365256 -8.221274538592427,-66.28369026115281
+        -7.229185752148047,-65.91345425733603 -7.226575214692776,-65.91345425733603
+        -7.226575214692776))"},{"name":"s2datatakeid","content":"GS2A_20161004T144732_006714_N02.04"},{"name":"platformidentifier","content":"2015-000A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2A"},{"name":"processingbaseline","content":"02.04"},{"name":"processinglevel","content":"Level-1C"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformname","content":"Sentinel-2"},{"name":"size","content":"174.30
+        MB"},{"name":"processed","content":"F"}]}]}}'}
     headers:
       Content-Type: [application/json]
       Pragma: [no-cache]
       Server: [Apache-Coyote/1.1]
       Vary: [Accept-Encoding]
-      content-length: ['18631']
+      content-length: ['144277']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -698,14 +698,18 @@ def test_s2_cloudcover():
 @pytest.mark.scihub
 def test_order_by():
     api = SentinelAPI(**_api_auth)
-    products = api.query(
-        geojson_to_wkt(read_geojson(FIXTURES_DIR + '/map.geojson')),
-        ("20151219", "20151228"),
+    kwargs = dict(
+        area=geojson_to_wkt(read_geojson(FIXTURES_DIR + '/map.geojson')),
+        date=("20151219", "20161019"),
         platformname="Sentinel-2",
         cloudcoverpercentage=(0, 10),
         order_by="cloudcoverpercentage, -beginposition"
     )
-    assert len(products) == 3
+    # Check that order_by works correctly also in cases where pagination is required
+    expected_count = api.count(**kwargs)
+    assert expected_count > 100
+    products = api.query(**kwargs)
+    assert len(products) == expected_count
     vals = [x["cloudcoverpercentage"] for x in products.values()]
     assert sorted(vals) == vals
 


### PR DESCRIPTION
Fixes #200.

Also modified `count()` slightly to make its function signature fully compatible with `query()`, so exactly the same arguments can be used for both of them. Irrelevant arguments (`order_by`, `offset` and `limit`) are dropped, so they would not get erroneously included as query keywords.