### PR TITLE
Block all network traffic when using VCR cassettes for unit tests

### DIFF
--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -93,7 +93,10 @@ To run the tests
   py.test -v
 
 
-By default, prerecorded responses to Copernicus Open Access Hub queries are used to not be affected by its downtime. To allow the tests to run actual queries against the Copernicus Open Access Hub set the environment variables and add ``--vcr disable`` to ``py.test`` arguments.
+By default, prerecorded responses to Copernicus Open Access Hub queries are used to not be affected by its downtime.
+Furthermore, any network accesses are blocked as well (by raising a ``pytest_socket.SocketBlockedError: A test tried to use socket.socket`` exception) to guarantee that all tests are indeed correctly covered by recorded queries.
+
+To allow the tests to run actual queries against the Copernicus Open Access Hub set the environment variables and add ``--vcr disable`` to ``py.test`` arguments.
 
 .. code-block:: console
 

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,16 @@ setup(name='sentinelsat',
               'pytest',
               'requests-mock',
               'vcrpy',
-              'rstcheck'
+              'rstcheck',
+              'pytest-socket'
           ],
           # Pandas and its dependencies are not available for Python <= 3.4
           'test34': [
               'pytest',
               'requests-mock',
               'vcrpy',
-              'rstcheck'
+              'rstcheck',
+              'pytest-socket'
           ],
           'docs': [
               'sphinx',

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname, join
 
 import pytest
 import vcr
+from pytest_socket import disable_socket
 
 from .custom_serializer import BinaryContentSerializer
 
@@ -17,6 +18,8 @@ vcr_option = pytest.config.getoption("--vcr")
 record_mode = "none"
 if vcr_option == "use":
     print("Tests will use prerecorded query responses.")
+    # Guarantee that only prerecorded queries are used by blocking any network traffic
+    disable_socket()
 elif vcr_option == "record_new":
     print("Tests will use prerecorded query responses and record any new ones.")
     record_mode = "new_episodes"


### PR DESCRIPTION
Disable the `socket.socket` interface to block all network traffic when running unit tests against prerecorded queries. This should make writing unit tests a bit easier by explicitly enforcing our convention of not doing any network requests by default when running unit tests.

I wanted to add this very minor enhancement already about a year ago, but the `pytest-socket` extension needed [some tweaking](https://github.com/miketheman/pytest-socket/pull/1) first for this to work in a reasonable manner.