### PR TITLE
Add support for single-sided ranges, check for duplicate keywords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 Added
 ~~~~~
-*
+* Date ranges now also support '\*' for single-sided ranges, e.g. ``query(date=('*', 'NOW-1YEAR'))``.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,11 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 Added
 ~~~~~
-* Date ranges now also support '\*' for single-sided ranges, e.g. ``query(date=('*', 'NOW-1YEAR'))``.
+* Query keywords with interval ranges now support single-sided ranges by using ``None`` or ``'*'`` to note no bounds,
+  for example ``query(date=(None, 'NOW-1YEAR'))``. In case both bounds are set to unlimited, the keyword will be removed
+  from the query. (#210)
+* Raise an exception in case of duplicate keywords present in a query, taking into account the fact that query keywords
+  are allowed to be case-insensitive on the server side. (#210)
 
 Changed
 ~~~~~~~

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -850,6 +850,11 @@ def format_query_date(in_date):
     elif not isinstance(in_date, string_types):
         raise ValueError('Expected a string or a datetime object. Received {}.'.format(in_date))
 
+    in_date = in_date.strip()
+    if in_date == '*':
+        # '*' can be used for one-sided range queries e.g. ingestiondate:[* TO NOW-1YEAR]
+        return in_date
+
     # Reference: https://cwiki.apache.org/confluence/display/solr/Working+with+Dates
 
     # ISO-8601 date or NOW

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -149,11 +149,14 @@ class SentinelAPI:
         if area_relation.lower() not in {"intersects", "contains", "iswithin"}:
             raise ValueError("Incorrect AOI relation provided ({})".format(area_relation))
 
-        query_parts = []
-
+        # Check for duplicate keywords
         kw_lower = set(x.lower() for x in keywords)
-        if len(kw_lower) != len(keywords) or (date is not None and 'beginposition' in kw_lower):
+        if (len(kw_lower) != len(keywords) or
+                (date is not None and 'beginposition' in kw_lower) or
+                (area is not None and 'footprint' in kw_lower)):
             raise ValueError("Query contains duplicate keywords. Note that query keywords are case-insensitive.")
+
+        query_parts = []
 
         if date is not None:
             keywords['beginPosition'] = date

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -151,6 +151,10 @@ class SentinelAPI:
 
         query_parts = []
 
+        kw_lower = set(x.lower() for x in keywords)
+        if len(kw_lower) != len(keywords) or (date is not None and 'beginposition' in kw_lower):
+            raise ValueError("Query contains duplicate keywords. Note that query keywords are case-insensitive.")
+
         if date is not None:
             keywords['beginPosition'] = date
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -842,9 +842,29 @@ def geojson_to_wkt(geojson_obj, feature_number=0, decimals=4):
 
 
 def format_query_date(in_date):
-    """Format a date, datetime or a YYYYMMDD string input as YYYY-MM-DDThh:mm:ssZ
-    or validate a string input as suitable for the full text search interface and return it.
     """
+    Format a date, datetime or a YYYYMMDD string input as YYYY-MM-DDThh:mm:ssZ
+    or validate a date string as suitable for the full text search interface and return it.
+
+    `None` will be converted to '\*', meaning an unlimited date bound in date ranges.
+
+    Parameters
+    ----------
+    in_date : str or datetime or date or None
+        Date to be formatted
+
+    Returns
+    -------
+    str
+        Formatted string
+
+    Raises
+    ------
+    ValueError
+        If the input date type is incorrect or passed date string is invalid
+    """
+    if in_date is None:
+        return '*'
     if isinstance(in_date, (datetime, date)):
         return in_date.strftime('%Y-%m-%dT%H:%M:%SZ')
     elif not isinstance(in_date, string_types):

--- a/tests/fixtures/vcr_cassettes/test_format_date.yaml
+++ b/tests/fixtures/vcr_cassettes/test_format_date.yaml
@@ -1,0 +1,601 @@
+interactions:
+- request:
+    body: q=ingestiondate%3A%5BNOW+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW TO *]","subtitle":"Displaying
+        0 results. Request done in 0.002 seconds.","updated":"2018-06-24T21:35:31.273Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        TO *]","opensearch:totalResults":"0","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        TO *]&start=-1&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1132']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-1DAY+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['39']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-1DAY TO *]","subtitle":"Displaying
+        0 to -1 of 18260 total results. Request done in 0.004 seconds.","updated":"2018-06-24T21:35:31.614Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAY
+        TO *]","opensearch:totalResults":"18260","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-1DAY
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAY
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAY
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAY
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAY
+        TO *]&start=18259&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1336']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-1DAYS+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-1DAYS TO *]","subtitle":"Displaying
+        0 to -1 of 18260 total results. Request done in 0.004 seconds.","updated":"2018-06-24T21:35:31.965Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAYS
+        TO *]","opensearch:totalResults":"18260","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-1DAYS
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAYS
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAYS
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAYS
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1DAYS
+        TO *]&start=18259&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1343']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-500DAY+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['41']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-500DAY TO *]","subtitle":"Displaying
+        0 to -1 of 6001484 total results. Request done in 0.235 seconds.","updated":"2018-06-24T21:35:32.392Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAY
+        TO *]","opensearch:totalResults":"6001484","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-500DAY
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAY
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAY
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAY
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAY
+        TO *]&start=6001483&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1356']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-500DAYS+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['42']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-500DAYS TO *]","subtitle":"Displaying
+        0 to -1 of 6001484 total results. Request done in 0.237 seconds.","updated":"2018-06-24T21:35:33.016Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAYS
+        TO *]","opensearch:totalResults":"6001484","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-500DAYS
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAYS
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAYS
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAYS
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-500DAYS
+        TO *]&start=6001483&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1363']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-2MONTH+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['41']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-2MONTH TO *]","subtitle":"Displaying
+        0 to -1 of 1037601 total results. Request done in 0.04 seconds.","updated":"2018-06-24T21:35:33.741Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTH
+        TO *]","opensearch:totalResults":"1037601","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-2MONTH
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTH
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTH
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTH
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTH
+        TO *]&start=1037600&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1355']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-2MONTHS+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['42']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-2MONTHS TO *]","subtitle":"Displaying
+        0 to -1 of 1037601 total results. Request done in 0.038 seconds.","updated":"2018-06-24T21:35:34.019Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTHS
+        TO *]","opensearch:totalResults":"1037601","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-2MONTHS
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTHS
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTHS
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTHS
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-2MONTHS
+        TO *]&start=1037600&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1363']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-20MINUTE+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['43']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-20MINUTE TO *]","subtitle":"Displaying
+        0 to -1 of 64 total results. Request done in 0.005 seconds.","updated":"2018-06-24T21:35:34.535Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTE
+        TO *]","opensearch:totalResults":"64","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-20MINUTE
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTE
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTE
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTE
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTE
+        TO *]&start=63&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1355']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-20MINUTES+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['44']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-20MINUTES TO *]","subtitle":"Displaying
+        0 to -1 of 64 total results. Request done in 0.003 seconds.","updated":"2018-06-24T21:35:34.843Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTES
+        TO *]","opensearch:totalResults":"64","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-20MINUTES
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTES
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTES
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTES
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-20MINUTES
+        TO *]&start=63&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1362']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW%2B10HOUR+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['43']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW+10HOUR TO *]","subtitle":"Displaying
+        0 results. Request done in 0.002 seconds.","updated":"2018-06-24T21:35:35.053Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+10HOUR
+        TO *]","opensearch:totalResults":"0","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW+10HOUR
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+10HOUR
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+10HOUR
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+10HOUR
+        TO *]&start=-1&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1174']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5B2015-01-01T00%3A00%3A00Z%2B1DAY+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['62']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]","subtitle":"Displaying 0 to -1 of 7336902 total results. Request done
+        in 0 seconds.","updated":"2018-06-24T21:35:35.316Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]","opensearch:totalResults":"7336902","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[2015-01-01T00:00:00Z+1DAY
+        TO *]&start=7336901&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1457']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW%2B3MONTHS-7DAYS%2FDAYS+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['57']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW+3MONTHS-7DAYS/DAYS
+        TO *]","subtitle":"Displaying 0 results. Request done in 0 seconds.","updated":"2018-06-24T21:35:35.673Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+3MONTHS-7DAYS/DAYS
+        TO *]","opensearch:totalResults":"0","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW+3MONTHS-7DAYS/DAYS
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+3MONTHS-7DAYS/DAYS
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+3MONTHS-7DAYS/DAYS
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW+3MONTHS-7DAYS/DAYS
+        TO *]&start=-1&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1242']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5B%2A+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[* TO *]","subtitle":"Displaying
+        0 to -1 of 7360634 total results. Request done in 0 seconds.","updated":"2018-06-24T21:35:35.923Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[*
+        TO *]","opensearch:totalResults":"7360634","opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[*
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[*
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[*
+        TO *]&start=0&rows=0"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[*
+        TO *]&start=NaN&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[*
+        TO *]&start=7360633&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1289']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW+-+1HOUR+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['42']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW - 1HOUR TO *]","subtitle":"Displaying  results.
+        Request done in 0.001 seconds.","updated":"2018-06-24T21:35:36.110Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        - 1HOUR TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW
+        - 1HOUR TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        - 1HOUR TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        - 1HOUR TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        - 1HOUR TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1181']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW+-+++1HOURS+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['45']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW -   1HOURS TO *]","subtitle":"Displaying  results.
+        Request done in 0.002 seconds.","updated":"2018-06-24T21:35:36.618Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        -   1HOURS TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW
+        -   1HOURS TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        -   1HOURS TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        -   1HOURS TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW
+        -   1HOURS TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-1+HOURS+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['42']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-1 HOURS TO *]","subtitle":"Displaying  results.
+        Request done in 0.001 seconds.","updated":"2018-06-24T21:35:36.810Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        HOURS TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-1
+        HOURS TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        HOURS TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        HOURS TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        HOURS TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1181']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-1+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW-1 TO *]","subtitle":"Displaying  results.
+        Request done in 0.001 seconds.","updated":"2018-06-24T21:35:37.090Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-1
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-1
+        TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1145']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5BNOW-+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['35']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[NOW- TO *]","subtitle":"Displaying  results.
+        Request done in 0.001 seconds.","updated":"2018-06-24T21:35:37.290Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-
+        TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[NOW-
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[NOW-
+        TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1139']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5B%2A%2A+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['37']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[** TO *]","subtitle":"Displaying  results.
+        Request done in 0 seconds.","updated":"2018-06-24T21:35:37.556Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[**
+        TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[**
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[**
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[**
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[**
+        TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1123']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5B%2B+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[+ TO *]","subtitle":"Displaying  results.
+        Request done in 0 seconds.","updated":"2018-06-24T21:35:37.769Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[+
+        TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[+
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[+
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[+
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[+
+        TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1117']
+    status: {code: 200, message: OK}
+- request:
+    body: q=ingestiondate%3A%5B-+TO+%2A%5D
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['32']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: ingestiondate:[- TO *]","subtitle":"Displaying  results.
+        Request done in 0.002 seconds.","updated":"2018-06-24T21:35:38.229Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[-
+        TO *]","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"0","opensearch:Query":{"role":"request","searchTerms":"ingestiondate:[-
+        TO *]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[-
+        TO *]&start=0&rows=0"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[-
+        TO *]&start=0&rows=0"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=ingestiondate:[-
+        TO *]&start=NaN&rows=0"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1121']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -173,6 +173,19 @@ def test_api_query_format_ranges():
     query = SentinelAPI.format_query(cloudcoverpercentage=[0, 30])
     assert query == 'cloudcoverpercentage:[0 TO 30]'
 
+    query = SentinelAPI.format_query(cloudcoverpercentage=[None, 30])
+    assert query == 'cloudcoverpercentage:[* TO 30]'
+
+    query = SentinelAPI.format_query(orbitnumber=(16302, None))
+    assert query == 'orbitnumber:[16302 TO *]'
+
+    query = SentinelAPI.format_query(orbitnumber=(16302, '*'))
+    assert query == 'orbitnumber:[16302 TO *]'
+
+    for value in [(None, None), ('*', None), (None, '*'), ('*', '*')]:
+        query = SentinelAPI.format_query(orbitnumber=value)
+        assert query == ''
+
     with pytest.raises(ValueError):
         SentinelAPI.format_query(cloudcoverpercentage=[])
 
@@ -194,6 +207,13 @@ def test_api_query_format_dates():
     query = SentinelAPI.format_query(ingestiondate='[NOW-1DAY TO NOW]')
     assert query == 'ingestiondate:[NOW-1DAY TO NOW]'
 
+    query = SentinelAPI.format_query(ingestiondate=[None, 'NOW'])
+    assert query == 'ingestiondate:[* TO NOW]'
+
+    for value in [(None, None), ('*', None), (None, '*'), ('*', '*')]:
+        query = SentinelAPI.format_query(ingestiondate=value)
+        assert query == ''
+
     with pytest.raises(ValueError):
         SentinelAPI.format_query(date="NOW")
 
@@ -202,9 +222,6 @@ def test_api_query_format_dates():
 
     with pytest.raises(ValueError):
         SentinelAPI.format_query(ingestiondate=[])
-
-    with pytest.raises(ValueError):
-        SentinelAPI.format_query(ingestiondate=[None, 'NOW'])
 
 
 @my_vcr.use_cassette

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -166,6 +166,16 @@ def test_api_query_format():
 
 
 @pytest.mark.fast
+def test_api_query_format_with_duplicates():
+    with pytest.raises(ValueError) as excinfo:
+        SentinelAPI.format_query(date=('NOW-1DAY', 'NOW'), beginPosition=('NOW-3DAY', 'NOW'))
+    assert 'duplicate' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        SentinelAPI.format_query(ingestiondate=('NOW-1DAY', 'NOW'), ingestionDate=('NOW-3DAY', 'NOW'))
+    assert 'duplicate' in str(excinfo.value)
+
+
+@pytest.mark.fast
 def test_api_query_format_ranges():
     query = SentinelAPI.format_query(cloudcoverpercentage=(0, 30))
     assert query == 'cloudcoverpercentage:[0 TO 30]'

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -60,6 +60,7 @@ def test_format_date():
     assert format_query_date('2015-01-01T00:00:00Z') == '2015-01-01T00:00:00Z'
     assert format_query_date('20150101') == '2015-01-01T00:00:00Z'
     assert format_query_date(' NOW ') == 'NOW'
+    assert format_query_date(None) == '*'
 
     api = SentinelAPI(**_api_auth)
     for date_str in ("NOW", "NOW-1DAY", "NOW-1DAYS", "NOW-500DAY", "NOW-500DAYS",

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -169,8 +169,13 @@ def test_api_query_format_with_duplicates():
     with pytest.raises(ValueError) as excinfo:
         SentinelAPI.format_query(date=('NOW-1DAY', 'NOW'), beginPosition=('NOW-3DAY', 'NOW'))
     assert 'duplicate' in str(excinfo.value)
+
     with pytest.raises(ValueError) as excinfo:
         SentinelAPI.format_query(ingestiondate=('NOW-1DAY', 'NOW'), ingestionDate=('NOW-3DAY', 'NOW'))
+    assert 'duplicate' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        SentinelAPI.format_query(area='POINT(0, 0)', footprint='POINT(0, 0)')
     assert 'duplicate' in str(excinfo.value)
 
 

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -137,8 +137,7 @@ def test_SentinelAPI_wrong_credentials():
     assert excinfo.value.response.status_code == 401
 
 
-@my_vcr.use_cassette
-@pytest.mark.scihub
+@pytest.mark.fast
 def test_api_query_format():
     wkt = 'POLYGON((0 0,1 1,0 1,0 0))'
 
@@ -238,7 +237,7 @@ def test_api_query_format_dates():
 @pytest.mark.scihub
 def test_invalid_query():
     api = SentinelAPI(**_api_auth)
-    with pytest.raises(SentinelAPIError) as excinfo:
+    with pytest.raises(SentinelAPIError):
         api.query(raw="xxx:yyy")
 
 
@@ -284,7 +283,7 @@ def test_format_order_by():
     res = _format_order_by(" +cloudcoverpercentage, -beginposition ")
     assert res == "cloudcoverpercentage asc,beginposition desc"
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         _format_order_by("+cloudcoverpercentage-beginposition")
 
 
@@ -628,16 +627,16 @@ def test_scihub_unresponsive():
 
     with requests_mock.mock() as rqst:
         rqst.request(requests_mock.ANY, requests_mock.ANY, exc=requests.exceptions.ConnectTimeout)
-        with pytest.raises(requests.exceptions.Timeout) as excinfo:
+        with pytest.raises(requests.exceptions.Timeout):
             api.query(**_small_query)
 
-        with pytest.raises(requests.exceptions.Timeout) as excinfo:
+        with pytest.raises(requests.exceptions.Timeout):
             api.get_product_odata('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
 
-        with pytest.raises(requests.exceptions.Timeout) as excinfo:
+        with pytest.raises(requests.exceptions.Timeout):
             api.download('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
 
-        with pytest.raises(requests.exceptions.Timeout) as excinfo:
+        with pytest.raises(requests.exceptions.Timeout):
             api.download_all(['8df46c9e-a20c-43db-a19a-4240c2ed3b8b'])
 
 
@@ -751,7 +750,7 @@ def test_area_relation():
     assert n_iswithin == 0
 
     # Check that unsupported relations raise an error
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         api.query(area_relation="disjoint", **params)
 
 
@@ -935,7 +934,7 @@ def test_download_invalid_id():
     uuid = "1f62a176-c980-41dc-xxxx-c735d660c910"
     with pytest.raises(SentinelAPIError) as excinfo:
         api.download(uuid)
-        assert 'Invalid key' in excinfo.value.msg
+    assert 'Invalid key' in excinfo.value.msg
 
 
 @my_vcr.use_cassette


### PR DESCRIPTION
Date ranges can now also use `*` for single-sided ranges, e.g. `query(date=('*', 'NOW-1YEAR'))`.

Improved `test_format_date` by checking that all of the tested date strings are also accepted/rejected on the server as expected.