### PR TITLE
fix readthedocs requirements

### DIFF
--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -1,2 +1,8 @@
-numpydoc
--r ../requirements.txt
+requests
+click
+html2text
+geojson >= 2
+tqdm
+six
+geomet
+sphinx >= 1.3


### PR DESCRIPTION
RTD was recursively pulling in `requirements.txt` - after removal the docs build failed.