### PR TITLE
Restore requirements.txt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 
 Changed
 ~~~~~~~
-* Replaced ``[test]`` and ``[docs]`` with a single ``[dev]`` installation extras target. Removed 'requirements.txt'. (#208)
+* Replaced ``[test]`` and ``[docs]`` with a single ``[dev]`` installation extras target. (#208)
 
 Deprecated
 ~~~~~~~~~~

--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -1,8 +1,2 @@
-requests
-click
-html2text
-geojson >= 2
-tqdm
-six
-geomet
+-r ../requirements.txt
 sphinx >= 1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+requests
+click
+html2text
+geojson >= 2
+tqdm
+six
+geomet

--- a/setup.py
+++ b/setup.py
@@ -31,15 +31,7 @@ setup(name='sentinelsat',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=[
-        'requests',
-        'click',
-        'html2text',
-        'geojson >= 2',
-        'tqdm',
-        'six',
-        'geomet'
-      ],
+      install_requires=open('requirements.txt').read().splitlines(),
       extras_require={
           'dev': [
               'pandas',


### PR DESCRIPTION
I did not notice that a separate requirements.txt file is useful to have for ReadTheDocs builds, so I suggest we restore it. (related to #208 and #212)