### PR TITLE
Add check for 'geometry' key in geojson_to_wkt

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -843,6 +843,8 @@ def geojson_to_wkt(geojson_obj, feature_number=0, decimals=4):
     """
     if 'coordinates' in geojson_obj:
         geometry = geojson_obj
+    elif 'geometry' in geojson_obj:
+        geometry = geojson_obj['geometry']
     else:
         geometry = geojson_obj['features'][feature_number]['geometry']
 


### PR DESCRIPTION
This solves issue #223 , allows for geojson objects with the coordinates nested one level deep that are still simple Polygons.