### PR TITLE
fix `area_relation` docstring options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 ~~~~~
 * Spaces in query parameter values are now escaped by adding a backslash before them, where appropriate. (#169, #211)
 * Fixed some CLI errors not returning with a non-zero exit code. (#209)
+* Fixed typo for ``area_relation`` query parameter documentation from ``'Intersection'`` to ``'Intersects'``. (#225)
 
 [0.12.2] – 2018-06-20
 ---------------------

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -94,7 +94,7 @@ class SentinelAPI:
             used as well.
         raw : str, optional
             Additional query text that will be appended to the query.
-        area_relation : {'Intersection', 'Contains', 'IsWithin'}, optional
+        area_relation : {'Intersects', 'Contains', 'IsWithin'}, optional
             What relation to use for testing the AOI. Case insensitive.
 
                 - Intersects: true if the AOI and the footprint intersect (default)


### PR DESCRIPTION
Doesn't match the current options, and `Intersection` throws an error 