### PR TITLE
test_cli: fix invalid exit code checking logic

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -401,7 +401,7 @@ def test_download_single(tmpdir):
                 command,
                 catch_exceptions=True
             )
-            assert result.exit_code != 1
+            assert result.exit_code != 0
             raise result.exception
 
     # clean up


### PR DESCRIPTION
This should fix the the build failures in other currently open pull requests.

test_download_single() was previously passing by sheer coincidence only, it seems.
The exact exit code is not important as long as it is non-zero.