### PR TITLE
query for multiple indentifiers using OR

### DIFF
--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -19,6 +19,16 @@ def _set_logger_handler(level='INFO'):
     logger.addHandler(h)
 
 
+class CommaSeparatedString(click.ParamType):
+    name = 'comma-string'
+
+    def convert(self, value, param, ctx):
+        if value:
+            return value.split(',')
+        else:
+            return value
+
+
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option(
     '--user', '-u', type=str, required=True, envvar='DHUS_USER',
@@ -41,10 +51,10 @@ def _set_logger_handler(level='INFO'):
     '--geometry', '-g', type=click.Path(exists=True),
     help='Search area geometry as GeoJSON file.')
 @click.option(
-    '--uuid', type=str,
-    help='Select a specific product UUID instead of a query. Multiple UUIDs can separated by commas.')
+    '--uuid', type=CommaSeparatedString(), default=None,
+    help='Select a specific product UUID instead of a query. Multiple UUIDs can separated by comma.')
 @click.option(
-    '--name', type=str,
+    '--name', type=CommaSeparatedString(), default=None,
     help='Select specific product(s) by filename. Supports wildcards.')
 @click.option(
     '--sentinel', type=click.Choice(['1', '2', '3']),
@@ -72,7 +82,7 @@ def _set_logger_handler(level='INFO'):
     '--path', type=click.Path(exists=True), default='.',
     help='Set the path where the files will be saved.')
 @click.option(
-    '--query', '-q', type=str, default=None,
+    '--query', '-q', type=CommaSeparatedString(), default=None,
     help="""Extra search keywords you want to use in the query. Separate
         keywords with comma. Example: 'producttype=GRD,polarisationmode=HH'.
         """)
@@ -112,13 +122,13 @@ def cli(user, password, geometry, start, end, uuid, name, download, sentinel, pr
         search_kwargs["cloudcoverpercentage"] = (0, cloud)
 
     if query is not None:
-        search_kwargs.update((x.split('=') for x in query.split(',')))
+        search_kwargs.update((x.split('=') for x in query))
 
     if geometry is not None:
         search_kwargs['area'] = geojson_to_wkt(read_geojson(geometry))
 
     if uuid is not None:
-        uuid_list = [x.strip() for x in uuid.split(',')]
+        uuid_list = [x.strip() for x in uuid]
         products = {}
         for productid in uuid_list:
             try:
@@ -130,7 +140,7 @@ def cli(user, password, geometry, start, end, uuid, name, download, sentinel, pr
                 else:
                     raise
     elif name is not None:
-        search_kwargs["identifier"] = name
+        search_kwargs["identifier"] = name[0] if len(name) == 1 else '(' + ' OR '.join(name) + ')'
         products = api.query(order_by=order_by, limit=limit, **search_kwargs)
     else:
         start = start or "19000101"

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -164,7 +164,7 @@ class SentinelAPI:
             # Escape spaces, where appropriate
             if isinstance(value, string_types):
                 value = value.strip()
-                if not any(value.startswith(s[0]) and value.endswith(s[1]) for s in ['[]', '{}', '//']):
+                if not any(value.startswith(s[0]) and value.endswith(s[1]) for s in ['[]', '{}', '//', '()']):
                     value = re.sub(r'\s', r'\ ', value, re.M)
 
             # Handle date keywords

--- a/tests/fixtures/vcr_cassettes/test_name_search_empty.yaml
+++ b/tests/fixtures/vcr_cassettes/test_name_search_empty.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: q=identifier%3A%28%29
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['21']
+      Content-Type: [application/x-www-form-urlencoded; charset=UTF-8]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=100&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: identifier:()","subtitle":"Displaying  results.
+        Request done in 0.002 seconds.","updated":"2018-10-11T11:21:24.489Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=identifier:()","opensearch:totalResults":null,"opensearch:startIndex":"0","opensearch:itemsPerPage":"100","opensearch:Query":{"role":"request","searchTerms":"identifier:()","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=identifier:()&start=0&rows=100"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=identifier:()&start=0&rows=100"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=identifier:()&start=NaN&rows=100"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['1075']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/vcr_cassettes/test_name_search_multiple.yaml
+++ b/tests/fixtures/vcr_cassettes/test_name_search_multiple.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: q=identifier%3A%28S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E+OR+S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3%29
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['159']
+      Content-Type: [application/x-www-form-urlencoded; charset=UTF-8]
+      User-Agent: [sentinelsat/0.12.2]
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=100&start=0
+  response:
+    body: {string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: identifier:(S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E
+        OR S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3)","subtitle":"Displaying
+        2 results. Request done in 0.001 seconds.","updated":"2018-10-11T10:59:37.806Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=identifier:(S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E
+        OR S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3)","opensearch:totalResults":"2","opensearch:startIndex":"0","opensearch:itemsPerPage":"100","opensearch:Query":{"role":"request","searchTerms":"identifier:(S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E
+        OR S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3)","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=identifier:(S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E
+        OR S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3)&start=0&rows=100"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=identifier:(S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E
+        OR S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3)&start=0&rows=100"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=identifier:(S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E
+        OR S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3)&start=1&rows=100"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}],"entry":[{"title":"S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b2ab53c9-abc4-4481-a9bf-1129f54c9707'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b2ab53c9-abc4-4481-a9bf-1129f54c9707'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b2ab53c9-abc4-4481-a9bf-1129f54c9707'')/Products(''Quicklook'')/$value"}],"id":"b2ab53c9-abc4-4481-a9bf-1129f54c9707","summary":"Date:
+        2018-10-07T16:43:49.773Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1,
+        Size: 1.65 GB","date":[{"name":"ingestiondate","content":"2018-10-07T20:23:18.692Z"},{"name":"beginposition","content":"2018-10-07T16:43:49.773Z"},{"name":"endposition","content":"2018-10-07T16:44:14.773Z"}],"int":[{"name":"missiondatatakeid","content":"98743"},{"name":"orbitnumber","content":"13049"},{"name":"lastorbitnumber","content":"13049"},{"name":"relativeorbitnumber","content":"73"},{"name":"lastrelativeorbitnumber","content":"73"},{"name":"slicenumber","content":"16"}],"str":[{"name":"acquisitiontype","content":"NOMINAL"},{"name":"filename","content":"S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>55.026794,12.979671
+        55.446896,17.079388 53.953140,17.472992 53.536812,13.518810 55.026794,12.979671</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3"},{"name":"instrumentshortname","content":"SAR-C
+        SAR"},{"name":"sensoroperationalmode","content":"IW"},{"name":"instrumentname","content":"Synthetic
+        Aperture Radar (C-band)"},{"name":"swathidentifier","content":"IW"},{"name":"footprint","content":"POLYGON
+        ((12.979671 55.026794,17.079388 55.446896,17.472992 53.953140,13.518810 53.536812,12.979671
+        55.026794))"},{"name":"platformidentifier","content":"2016-025A"},{"name":"orbitdirection","content":"ASCENDING"},{"name":"polarisationmode","content":"VV
+        VH"},{"name":"productclass","content":"S"},{"name":"producttype","content":"GRD"},{"name":"platformname","content":"Sentinel-1"},{"name":"size","content":"1.65
+        GB"},{"name":"status","content":"ARCHIVED"},{"name":"timeliness","content":"Fast-24h"},{"name":"uuid","content":"b2ab53c9-abc4-4481-a9bf-1129f54c9707"}]},{"title":"S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9e99eaa6-711e-40c3-aae5-83ea2048949d'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9e99eaa6-711e-40c3-aae5-83ea2048949d'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''9e99eaa6-711e-40c3-aae5-83ea2048949d'')/Products(''Quicklook'')/$value"}],"id":"9e99eaa6-711e-40c3-aae5-83ea2048949d","summary":"Date:
+        2018-10-07T16:44:14.774Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1,
+        Size: 1.65 GB","date":[{"name":"ingestiondate","content":"2018-10-07T19:58:04.778Z"},{"name":"beginposition","content":"2018-10-07T16:44:14.774Z"},{"name":"endposition","content":"2018-10-07T16:44:39.772Z"}],"int":[{"name":"missiondatatakeid","content":"98743"},{"name":"orbitnumber","content":"13049"},{"name":"lastorbitnumber","content":"13049"},{"name":"relativeorbitnumber","content":"73"},{"name":"lastrelativeorbitnumber","content":"73"},{"name":"slicenumber","content":"17"}],"str":[{"name":"acquisitiontype","content":"NOMINAL"},{"name":"filename","content":"S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E.SAFE"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>56.515373,12.414287
+        56.940186,16.674940 55.447117,17.080927 55.026886,12.979637 56.515373,12.414287</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"format","content":"SAFE"},{"name":"identifier","content":"S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E"},{"name":"instrumentshortname","content":"SAR-C
+        SAR"},{"name":"sensoroperationalmode","content":"IW"},{"name":"instrumentname","content":"Synthetic
+        Aperture Radar (C-band)"},{"name":"swathidentifier","content":"IW"},{"name":"footprint","content":"POLYGON
+        ((12.414287 56.515373,16.674940 56.940186,17.080927 55.447117,12.979637 55.026886,12.414287
+        56.515373))"},{"name":"platformidentifier","content":"2016-025A"},{"name":"orbitdirection","content":"ASCENDING"},{"name":"polarisationmode","content":"VV
+        VH"},{"name":"productclass","content":"S"},{"name":"producttype","content":"GRD"},{"name":"platformname","content":"Sentinel-1"},{"name":"size","content":"1.65
+        GB"},{"name":"status","content":"ARCHIVED"},{"name":"timeliness","content":"Fast-24h"},{"name":"uuid","content":"9e99eaa6-711e-40c3-aae5-83ea2048949d"}]}]}}'}
+    headers:
+      Content-Type: [application/json]
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      Vary: [Accept-Encoding]
+      content-length: ['7159']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 import requests_mock
 from click.testing import CliRunner
 
-from sentinelsat import InvalidChecksumError, SentinelAPI
+from sentinelsat import InvalidChecksumError, SentinelAPIError, SentinelAPI
 from sentinelsat.scripts.cli import cli
 from .shared import my_vcr, FIXTURES_DIR
 
@@ -317,6 +317,22 @@ def test_name_search_multiple():
         'Product 9e99eaa6-711e-40c3-aae5-83ea2048949d - Date: 2018-10-07T16:44:14.774Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1, Size: 1.65 GB'
     ]
     assert re.findall("^Product .+$", result.output, re.M) == expected
+
+
+@my_vcr.use_cassette
+@pytest.mark.scihub
+def test_name_search_empty():
+    runner = CliRunner()
+    with pytest.raises(SentinelAPIError):
+        result = runner.invoke(
+            cli,
+            ['--user', _api_auth[0],
+             '--password', _api_auth[1],
+             '--name', ''],
+            catch_exceptions=True
+        )
+        assert result.exit_code != 0
+        raise result.exception
 
 
 @my_vcr.use_cassette

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,26 @@ def test_name_search():
 
 @my_vcr.use_cassette
 @pytest.mark.scihub
+def test_name_search_multiple():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ['--user', _api_auth[0],
+         '--password', _api_auth[1],
+         '--name', 'S1B_IW_GRDH_1SDV_20181007T164414_20181007T164439_013049_0181B7_345E,S1B_IW_GRDH_1SDV_20181007T164349_20181007T164414_013049_0181B7_A8E3'],
+        catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    expected = [
+        'Product b2ab53c9-abc4-4481-a9bf-1129f54c9707 - Date: 2018-10-07T16:43:49.773Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1, Size: 1.65 GB',
+        'Product 9e99eaa6-711e-40c3-aae5-83ea2048949d - Date: 2018-10-07T16:44:14.774Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1, Size: 1.65 GB'
+    ]
+    assert re.findall("^Product .+$", result.output, re.M) == expected
+
+
+@my_vcr.use_cassette
+@pytest.mark.scihub
 def test_option_hierarchy():
     # expected hierarchy is producttype > instrument > platform from most to least specific
     runner = CliRunner()


### PR DESCRIPTION
Closes #156 

This makes it possible to pass multiple identifiers to `sentinelsat --name` as a comma-separated string, as envisioned in the linked issue.

For this, I turned off whitespace escape for query strings in parentheses `(...)`. Do you see any problems with that, @valgur and @Fernerkundung?