### PR TITLE
to_geodataframe(): handle empty product list input correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 Added
 ~~~~~
 * Query keywords with interval ranges now also support single-sided ranges by using ``None`` or ``'*'`` to denote no bound,
-  for example ``query(date=(None, 'NOW-1YEAR'))``. If both bounds are set to unlimited, the keyword will be removed 
+  for example ``query(date=(None, 'NOW-1YEAR'))``. If both bounds are set to unlimited, the keyword will be removed
   from the query. (#210)
 * Raise an exception in case of duplicate keywords present in a query. Case is ignored to match the server-side behavior. (#210)
 * Support for Python 3.7
@@ -32,6 +32,7 @@ Fixed
 * Fixed typo for ``area_relation`` query parameter documentation from ``'Intersection'`` to ``'Intersects'``. (#225 @scottstanie)
 * Updated ``check_query_length()`` logic to match the changed server-side behavior. (#230)
 * Clarify usage of GeoJSON files with CLI in docs (#229 @psal93)
+* ``to_geopandas()`` now returns an empty GeoDataFrame for an empty product list input.
 
 Development Changes
 ~~~~~~~~~~~~~~~~~~~

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -373,8 +373,11 @@ class SentinelAPI:
         except ImportError:
             raise ImportError("to_geodataframe requires the optional dependencies GeoPandas and Shapely.")
 
-        df = SentinelAPI.to_dataframe(products)
         crs = {'init': 'epsg:4326'}  # WGS84
+        if len(products) == 0:
+            return gpd.GeoDataFrame(crs=crs)
+
+        df = SentinelAPI.to_dataframe(products)
         geometry = [shapely.wkt.loads(fp) for fp in df['footprint']]
         # remove useless columns
         df.drop(['footprint', 'gmlfootprint'], axis=1, inplace=True)

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -870,7 +870,19 @@ def test_missing_dependency_dataframe(monkeypatch):
                     reason="Pandas requires Python 2.7 or >=3.5")
 def test_to_pandas(products):
     df = SentinelAPI.to_dataframe(products)
+    assert type(df).__name__ == 'DataFrame'
     assert '44517f66-9845-4792-a988-b5ae6e81fd3e' in df.index
+    assert len(products) == len(df)
+
+
+@pytest.mark.pandas
+@pytest.mark.scihub
+@pytest.mark.skipif(sys.version_info < (3,5),
+                    reason="Pandas requires Python 2.7 or >=3.5")
+def test_to_pandas_empty(products):
+    df = SentinelAPI.to_dataframe({})
+    assert type(df).__name__ == 'DataFrame'
+    assert len(df) == 0
 
 
 @pytest.mark.pandas
@@ -880,7 +892,21 @@ def test_to_pandas(products):
                     reason="Pandas requires Python 2.7 or >=3.5")
 def test_to_geopandas(products):
     gdf = SentinelAPI.to_geodataframe(products)
+    assert type(gdf).__name__ == 'GeoDataFrame'
     assert abs(gdf.unary_union.area - 132.16) < 0.01
+    assert len(gdf) == len(products)
+    assert gdf.crs == {'init': 'epsg:4326'}
+
+
+@pytest.mark.pandas
+@pytest.mark.geopandas
+@pytest.mark.scihub
+@pytest.mark.skipif(sys.version_info < (3,5),
+                    reason="Pandas requires Python 2.7 or >=3.5")
+def test_to_geopandas_empty(products):
+    gdf = SentinelAPI.to_geodataframe({})
+    assert type(gdf).__name__ == 'GeoDataFrame'
+    assert len(gdf) == 0
 
 
 @my_vcr.use_cassette


### PR DESCRIPTION
`to_geodataframe()` now returns an empty GeoDataFrame for an empty product list input instead of throwing a random error.