### PR TITLE
Add timeout to requests to avoid blocking

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -40,6 +40,9 @@ class SentinelAPI:
         defaults to 'https://scihub.copernicus.eu/apihub'
     show_progressbars : bool
         Whether progressbars should be shown or not, e.g. during download. Defaults to True.
+    timeout : float or tuple, optional
+        How long to wait for DataHub response (in seconds).
+        Tuple (connect, read) allowed.
 
     Attributes
     ----------
@@ -50,12 +53,14 @@ class SentinelAPI:
     page_size : int
         Number of results per query page.
         Current value: 100 (maximum allowed on ApiHub)
+    timeout : float or tuple
+        How long to wait for DataHub response (in seconds).
     """
 
     logger = logging.getLogger('sentinelsat.SentinelAPI')
 
     def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub/',
-                 show_progressbars=True):
+                 show_progressbars=True, timeout=None):
         self.session = requests.Session()
         if user and password:
             self.session.auth = (user, password)
@@ -64,6 +69,7 @@ class SentinelAPI:
         self.user_agent = 'sentinelsat/' + sentinelsat_version
         self.session.headers['User-Agent'] = self.user_agent
         self.show_progressbars = show_progressbars
+        self.timeout = timeout
         # For unit tests
         self._last_query = None
         self._last_response = None
@@ -293,7 +299,8 @@ class SentinelAPI:
         # load query results
         url = self._format_url(order_by, limit, offset)
         response = self.session.post(url, {'q': query}, auth=self.session.auth,
-                                     headers={'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'})
+                                     headers={'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+                                     timeout=self.timeout)
         _check_scihub_response(response)
 
         # store last status code (for testing)

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -422,7 +422,8 @@ class SentinelAPI:
         url = urljoin(self.api_url, u"odata/v1/Products('{}')?$format=json".format(id))
         if full:
             url += '&$expand=Attributes'
-        response = self.session.get(url, auth=self.session.auth)
+        response = self.session.get(url, auth=self.session.auth,
+                                    timeout=self.timeout)
         _check_scihub_response(response)
         values = _parse_odata_response(response.json()['d'])
         return values

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -764,7 +764,8 @@ class SentinelAPI:
         else:
             already_downloaded_bytes = 0
         downloaded_bytes = 0
-        with closing(session.get(url, stream=True, auth=session.auth, headers=headers)) as r, \
+        with closing(session.get(url, stream=True, auth=session.auth,
+                                 headers=headers, timeout=self.timeout)) as r, \
                 closing(self._tqdm(desc="Downloading", total=file_size, unit="B",
                                    unit_scale=True, initial=already_downloaded_bytes)) as progress:
             _check_scihub_response(r, test_json=False)

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -696,8 +696,6 @@ def test_scihub_unresponsive():
 
     api = SentinelAPI("mock_user", "mock_password", timeout=timeout)
 
-    assert api.timeout == timeout
-
     with requests_mock.mock() as rqst:
         rqst.request(requests_mock.ANY, requests_mock.ANY, exc=requests.exceptions.ConnectTimeout)
         with pytest.raises(requests.exceptions.ConnectTimeout):

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -690,20 +690,40 @@ def test_get_product_odata_scihub_down():
 
 @pytest.mark.mock_api
 def test_scihub_unresponsive():
-    api = SentinelAPI("mock_user", "mock_password")
+    timeout_connect = 6
+    timeout_read = 6.6
+    timeout = (timeout_connect, timeout_read)
+
+    api = SentinelAPI("mock_user", "mock_password", timeout=timeout)
+
+    assert api.timeout == timeout
 
     with requests_mock.mock() as rqst:
         rqst.request(requests_mock.ANY, requests_mock.ANY, exc=requests.exceptions.ConnectTimeout)
-        with pytest.raises(requests.exceptions.Timeout):
+        with pytest.raises(requests.exceptions.ConnectTimeout):
             api.query(**_small_query)
 
-        with pytest.raises(requests.exceptions.Timeout):
+        with pytest.raises(requests.exceptions.ConnectTimeout):
             api.get_product_odata('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
 
-        with pytest.raises(requests.exceptions.Timeout):
+        with pytest.raises(requests.exceptions.ConnectTimeout):
             api.download('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
 
-        with pytest.raises(requests.exceptions.Timeout):
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            api.download_all(['8df46c9e-a20c-43db-a19a-4240c2ed3b8b'])
+
+    with requests_mock.mock() as rqst:
+        rqst.request(requests_mock.ANY, requests_mock.ANY, exc=requests.exceptions.ReadTimeout)
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            api.query(**_small_query)
+
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            api.get_product_odata('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
+
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            api.download('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
+
+        with pytest.raises(requests.exceptions.ReadTimeout):
             api.download_all(['8df46c9e-a20c-43db-a19a-4240c2ed3b8b'])
 
 


### PR DESCRIPTION
In reference to Issue #256 I added the `timeout` attribute to `SentinelAPI`, passing it to `_load_subquery`, `get_product_odata` and `_download` methods in order to avoid indefinite blocking in case of unresponsive DHuS.

As testing for `requests.exceptions.Timeout` was already being handled in `test_scihub_unresponsive` method I just added timeout attribute assignment and specific tests for both `requests.exceptions.ConnectTimeout` and `requests.exceptions.ReadTimeout`.