### PR TITLE
WIP: revert to dhus as default url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ Options
 +----+---------------+------+--------------------------------------------------------------------------------------------+
 | -p | -\-password   | TEXT | Password [required] (or environment variable DHUS_PASSWORD)                                |
 +----+---------------+------+--------------------------------------------------------------------------------------------+
-|    | -\-url        | TEXT | Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.             |
+|    | -\-url        | TEXT | Define another API URL. Default URL is 'https://scihub.copernicus.eu/dhus/'.             |
 +----+---------------+------+--------------------------------------------------------------------------------------------+
 | -s | -\-start      | TEXT | Start date of the query in the format YYYYMMDD.                                            |
 +----+---------------+------+--------------------------------------------------------------------------------------------+

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,7 +50,7 @@ Valid search query keywords can be found at the `Copernicus Open Access Hub docu
 Authentication
 --------------
 
-The Copernicus Open Access Hub and probably most Data Hubs require authentication.
+The Copernicus Open Access Hub and most other Data Hubs require authentication.
 You can provide your credentials with :meth:`SentinelAPI(<your username>, <your password>)`. 
 Alternatively, you can use :meth:`SentinelAPI(None, None)` and enter your credentials in a 
 file `.netrc` in your user home directory in the following form:
@@ -152,9 +152,9 @@ OpenSearch example
                  'instrumentshortname': 'SAR-C SAR',
                  'lastorbitnumber': 16302,
                  'lastrelativeorbitnumber': 130,
-                 'link': "https://scihub.copernicus.eu/apihub/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/$value",
-                 'link_alternative': "https://scihub.copernicus.eu/apihub/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/",
-                 'link_icon': "https://scihub.copernicus.eu/apihub/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/Products('Quicklook')/$value",
+                 'link': "https://scihub.copernicus.eu/dhus/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/$value",
+                 'link_alternative': "https://scihub.copernicus.eu/dhus/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/",
+                 'link_icon': "https://scihub.copernicus.eu/dhus/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/Products('Quicklook')/$value",
                  'missiondatatakeid': 110481,
                  'orbitdirection': 'ASCENDING',
                  'orbitnumber': 16302,
@@ -190,7 +190,7 @@ so it is not requested by default.
    'md5': 'E5855D1C974171D33EE4BC08B9D221AE',
    'size': 4633501134,
    'title': 'S1A_IW_SLC__1SDV_20170425T155612_20170425T155639_016302_01AF91_46FF',
-   'url': "https://scihub.copernicus.eu/apihub/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/$value"}
+   'url': "https://scihub.copernicus.eu/dhus/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/$value"}
 
 
 With `full=True` we receive the full metadata available for the product.
@@ -251,7 +251,7 @@ With `full=True` we receive the full metadata available for the product.
    'md5': 'E5855D1C974171D33EE4BC08B9D221AE',
    'size': 4633501134,
    'title': 'S1A_IW_SLC__1SDV_20170425T155612_20170425T155639_016302_01AF91_46FF',
-   'url': "https://scihub.copernicus.eu/apihub/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/$value"}
+   'url': "https://scihub.copernicus.eu/dhus/odata/v1/Products('04548172-c64a-418f-8e83-7a4d148adf1e')/$value"}
 
 
 Logging
@@ -316,12 +316,11 @@ To search for recent Sentinel 2 imagery by MGRS tile, use the `tileid` parameter
   api.download_all(products)
 
 NB: The `tileid` parameter only works for products from April 2017 onward due to
-missing metadata in SciHub's DHuS catalogue. Before that, but only from
-December 2016 onward (i.e. for single-tile products), you can use a `filename` pattern instead:
+missing metadata in SciHub's DHuS catalogue. Before that you can use a `filename` pattern instead:
 
 .. code-block:: python
 
-  kw['filename'] = '*_T{}_*'.format(tile)  # products after 2016-12-01
+  kw['filename'] = '*_T{}_*'.format(tile)  # products after 2016-12-01 or reprocessed to single-tile package
 
 API Reference
 -------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -104,7 +104,7 @@ Options:
 +----+---------------+------+--------------------------------------------------------------------------------------------+
 | -p | -\-password   | TEXT | Password [required] (or environment variable :envvar:`DHUS_PASSWORD`)                      |
 +----+---------------+------+--------------------------------------------------------------------------------------------+
-|    | -\-url        | TEXT | Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.             |
+|    | -\-url        | TEXT | Define another API URL. Default URL is 'https://scihub.copernicus.eu/dhus/'.             |
 +----+---------------+------+--------------------------------------------------------------------------------------------+
 | -s | -\-start      | TEXT | Start date of the query in the format YYYYMMDD.                                            |
 +----+---------------+------+--------------------------------------------------------------------------------------------+

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -8,27 +8,28 @@ Common Issues
 
 .. rubric:: I keep getting *HTTP 401 Unauthorized* messages*
 
-This means that the given username/password combination is incorrect. Note that
-if you created your account recently it could take a while (a few days?) until
-you can use that account on *apihub* and therefore ``sentinelsat`` too. You can go
-`here`__ to test access on the *apihub* endpoint.
+This means that the given username/password combination is incorrect or unknown at the given DHuS instance. Note that
+if you created your account recently on the Copernicus Open Access Hub you can use the endpoint `dhus`__ right away,
+but it takes about a week until the credentials are synced to the `apihub`__ endpoint.
 
-__ https://scihub.copernicus.eu/apihub/search?
+__ https://scihub.copernicus.eu/dhus/
+
+__ https://scihub.copernicus.eu/apihub/
 
 
 .. rubric:: The query fails with *HTTP 500 connection timed out*
 
-SciHub servers are known to have outages due to high demand, try again later.
+Commonly caused by server outages due to high demand. Try again later.
 
 .. rubric:: Query fails with 'Longitude/Latitude is out of bounds, check your JSON format or data.'
 
-Standard GeoJSON specification contains only WGS84 format, check if your data complies with it.
+Standard GeoJSON specification requires WGS84 coordinates, check if your data complies with it.
 
 
 .. rubric:: My search returns 0 results
 
-Maybe there are no images for the specified time period, by default
-``sentinelsat`` will query the last 24 hours only.
+By default ``sentinelsat`` will query the last 24 hours. There might be no available images in that area for that time.
+Try extending your search time period.
 
 
 .. rubric:: Anything else?

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -38,9 +38,9 @@ class CommaSeparatedString(click.ParamType):
     '--password', '-p', type=str, envvar='DHUS_PASSWORD', default=None,
     help='Password (or environment variable DHUS_PASSWORD is set)')
 @click.option(
-    '--url', type=str, default='https://scihub.copernicus.eu/apihub/', envvar='DHUS_URL',
+    '--url', type=str, default='https://scihub.copernicus.eu/dhus/', envvar='DHUS_URL',
     help="""Define API URL. Default URL is
-        'https://scihub.copernicus.eu/apihub/' (or environment variable DHUS_URL).
+        'https://scihub.copernicus.eu/dhus/' (or environment variable DHUS_URL).
         """)
 @click.option(
     '--start', '-s', type=str, default='NOW-1DAY',

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -37,7 +37,7 @@ class SentinelAPI:
         set to None to use ~/.netrc
     api_url : string, optional
         URL of the DataHub
-        defaults to 'https://scihub.copernicus.eu/apihub'
+        defaults to 'https://scihub.copernicus.eu/dhus/'
     show_progressbars : bool
         Whether progressbars should be shown or not, e.g. during download. Defaults to True.
     timeout : float or tuple, optional
@@ -52,14 +52,14 @@ class SentinelAPI:
         URL to the DataHub
     page_size : int
         Number of results per query page.
-        Current value: 100 (maximum allowed on ApiHub)
+        Current value: 100 (maximum allowed on DHuS)
     timeout : float or tuple
         How long to wait for DataHub response (in seconds).
     """
 
     logger = logging.getLogger('sentinelsat.SentinelAPI')
 
-    def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub/',
+    def __init__(self, user, password, api_url='https://scihub.copernicus.eu/dhus/',
                  show_progressbars=True, timeout=None):
         self.session = requests.Session()
         if user and password:


### PR DESCRIPTION
- [x] change default endpoint URL to `/dhus`
- [x] change documentation to new default endpoint
- [ ] fix failing tests and record new cassettes (e.g. #262)
- [ ] changelog