### PR TITLE
Adds support for Sentinel-5P to the CLI (#272)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Added
 * Parsing the ``Online``, ``CreationDate`` and ``IngestionDate`` fields of an OData response
 * Trying to download an offline product from the Copernicus Open Access Hub triggers its retrieval from the long term archive.
   Downloading of the product is **not** scheduled.
+* Added support for downloading Sentinel 5P data in the CLI via the '--sentinel 5' flag
 
 Changed
 ~~~~~~~

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -58,7 +58,7 @@ class CommaSeparatedString(click.ParamType):
     '--name', type=CommaSeparatedString(), default=None,
     help='Select specific product(s) by filename. Supports wildcards.')
 @click.option(
-    '--sentinel', type=click.Choice(['1', '2', '3']),
+    '--sentinel', type=click.Choice(['1', '2', '3', '5']),
     help='Limit search to a Sentinel satellite (constellation)')
 @click.option(
     '--instrument', type=click.Choice(['MSI', 'SAR-C SAR', 'SLSTR', 'OLCI', 'SRAL']),


### PR DESCRIPTION
Fixes #272 

Testing with 
`sentinelsat -u s5pguest -p s5pguest --sentinel 5 --url https://s5phub.copernicus.eu/dhus `

and https://pastebin.com/RN0YxG6X yields 15 results.

