### PR TITLE
Make exceptions more specific

### DIFF
--- a/sentinelsat/__init__.py
+++ b/sentinelsat/__init__.py
@@ -4,4 +4,4 @@ __version__ = '0.12.2'
 from . import sentinel
 
 from .sentinel import InvalidChecksumError, SentinelAPI, SentinelAPIError, SentinelAPILTAError, \
-    format_query_date, geojson_to_wkt, read_geojson
+    format_query_date, geojson_to_wkt, read_geojson, UnauthorizedError, ServerError


### PR DESCRIPTION
This commit splits SentinelAPIError into more specific exceptions,
such as UnauthorizedError and ServerError

This is WIP so more tests can be added if needed.

Closes #131 