### PR TITLE
Handling non-existant 'Online' key in OData response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Change Log
 
 All notable changes to ``sentinelsat`` will be listed here.
 
-[master] – YYYY-MM-DD
+[master] – 2019-MM-DD
 ---------------------
 
 Added
@@ -17,6 +17,7 @@ Deprecated
 
 Fixed
 ~~~~~
+* Missing ``Online`` field in OData response defaults to ``Online: True`` instead of raising a ``KeyError`` (#281 @viktorbahr)
 
 [0.13] – 2019-04-05
 ---------------------

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1125,7 +1125,7 @@ def _parse_odata_response(product):
         'date': _parse_odata_timestamp(product['ContentDate']['Start']),
         'footprint': _parse_gml_footprint(product["ContentGeometry"]),
         'url': product['__metadata']['media_src'],
-        'Online': product.get('Online'),
+        'Online': product.get('Online', True),
         'Creation Date': _parse_odata_timestamp(product['CreationDate']),
         'Ingestion Date': _parse_odata_timestamp(product['IngestionDate']),
     }

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1125,7 +1125,7 @@ def _parse_odata_response(product):
         'date': _parse_odata_timestamp(product['ContentDate']['Start']),
         'footprint': _parse_gml_footprint(product["ContentGeometry"]),
         'url': product['__metadata']['media_src'],
-        'Online': product['Online'],
+        'Online': product.get('Online'),
         'Creation Date': _parse_odata_timestamp(product['CreationDate']),
         'Ingestion Date': _parse_odata_timestamp(product['IngestionDate']),
     }

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -501,6 +501,41 @@ def test_get_product_odata_short():
         for k in ret:
             assert ret[k] == expected[k]
 
+def scrub_string(string, replacement=''):
+    '''Scrub a string from a VCR response body string
+    '''
+    def before_record_response(response):
+        response['body']['string'] = response['body']['string'].replace(string, replacement)
+        return response
+    return before_record_response
+
+@pytest.mark.scihub
+def test_get_product_odata_short_with_missing_online_key():
+    api = SentinelAPI(**_api_auth)
+
+    uuid = '8df46c9e-a20c-43db-a19a-4240c2ed3b8b'
+    expected_short = {
+        'id': '8df46c9e-a20c-43db-a19a-4240c2ed3b8b',
+        'size': 143549851,
+        'md5': 'D5E4DF5C38C6E97BF7E7BD540AB21C05',
+        'url': "https://scihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/$value",
+        'date': datetime(2015, 11, 21, 10, 3, 56, 675000),
+        'footprint': 'POLYGON((-63.852531 -5.880887,-67.495872 -5.075419,-67.066071 -3.084356,-63.430576 -3.880541,'
+                     '-63.852531 -5.880887))',
+        'title': 'S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC',
+        'Online': None,
+        'Creation Date': datetime(2015, 11, 21, 13, 22, 1, 652000),
+        'Ingestion Date': datetime(2015, 11, 21, 13, 22, 4, 992000),
+    }
+
+    # scrub 'Online' key from response
+    with my_vcr.use_cassette("test_get_product_odata_short.yaml",
+                             before_record_response=scrub_string(b'"Online":false,', b'')):
+
+        ret = api.get_product_odata(uuid)
+        assert set(ret) == set(expected_short)
+        for k in ret:
+            assert ret[k] == expected_short[k]
 
 @my_vcr.use_cassette
 @pytest.mark.scihub
@@ -616,7 +651,6 @@ def test_get_product_odata_full():
         assert set(ret) == set(expected)
         for k in ret:
             assert ret[k] == expected[k]
-
 
 @my_vcr.use_cassette
 @pytest.mark.scihub

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -501,6 +501,7 @@ def test_get_product_odata_short():
         for k in ret:
             assert ret[k] == expected[k]
 
+
 def scrub_string(string, replacement=''):
     '''Scrub a string from a VCR response body string
     '''
@@ -523,7 +524,7 @@ def test_get_product_odata_short_with_missing_online_key():
         'footprint': 'POLYGON((-63.852531 -5.880887,-67.495872 -5.075419,-67.066071 -3.084356,-63.430576 -3.880541,'
                      '-63.852531 -5.880887))',
         'title': 'S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC',
-        'Online': None,
+        'Online': True,
         'Creation Date': datetime(2015, 11, 21, 13, 22, 1, 652000),
         'Ingestion Date': datetime(2015, 11, 21, 13, 22, 4, 992000),
     }
@@ -651,6 +652,7 @@ def test_get_product_odata_full():
         assert set(ret) == set(expected)
         for k in ret:
             assert ret[k] == expected[k]
+
 
 @my_vcr.use_cassette
 @pytest.mark.scihub


### PR DESCRIPTION
In reference to Issue #281 I am using dicts `get` method to avoid `KeyError` on missing `Online` key.

I also added a test for this that simply scrubs the key-value pair from a prerecorded response using pyVCRs `before_record_response` hook.