### PR TITLE
Fix filename for sentintel-5p

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -525,9 +525,17 @@ class SentinelAPI:
             If the MD5 checksum does not match the checksum on the server.
         """
         product_info = self.get_product_odata(id)
-        path = join(directory_path, product_info["title"] + ".zip")
-        product_info["path"] = path
-        product_info["downloaded_bytes"] = 0
+
+        # determine filename
+        req = self.session.head(product_info['url'], auth=self.session.auth)
+        filename = req.headers.get('Content-Disposition')
+        if filename:
+            filename = filename.split('=', 1)[1].strip('"')
+        else:
+            filename = product_info['title'] + '.zip'
+        path = join(directory_path, filename)
+        product_info['path'] = path
+        product_info['downloaded_bytes'] = 0
 
         self.logger.info("Downloading %s to %s", id, path)
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -525,17 +525,12 @@ class SentinelAPI:
             If the MD5 checksum does not match the checksum on the server.
         """
         product_info = self.get_product_odata(id)
-
-        # determine filename
-        req = self.session.head(product_info['url'], auth=self.session.auth)
-        filename = req.headers.get('Content-Disposition')
-        if filename:
-            filename = filename.split('=', 1)[1].strip('"')
-        else:
-            filename = product_info['title'] + '.zip'
+        filename = product_info["title"] + (
+            ".nc" if product_info["title"].startswith("S5P") else ".zip"
+        )
         path = join(directory_path, filename)
-        product_info['path'] = path
-        product_info['downloaded_bytes'] = 0
+        product_info["path"] = path
+        product_info["downloaded_bytes"] = 0
 
         self.logger.info("Downloading %s to %s", id, path)
 


### PR DESCRIPTION
This patch fixes the issue that sentinel-5p files are downloaded as
*.zip files and not as *.nc files. Instead of hard-coding the filename,
sentinelsat will now make an HTTP head request to determine the name. In
case this request yields no result, the code will still fall back to the
old pattern.

This fixes #270