### PR TITLE
improve docs on S2 query by tile

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -351,19 +351,21 @@ To search for recent Sentinel 2 imagery by MGRS tile, use the `tileid` parameter
   products = OrderedDict()
   for tile in tiles:
       kw = query_kwargs.copy()
-      kw['tileid'] = tile  # products after 2017-03-31
+      kw['tileid'] = tile
       pp = api.query(**kw)
       products.update(pp)
 
   api.download_all(products)
 
-NB: The `tileid` parameter only works for products from April 2017 onward due to
-missing metadata in SciHub's DHuS catalogue. Before that, but only from
-December 2016 onward (i.e. for single-tile products), you can use a `filename` pattern instead:
+NB: The `tileid` parameter may be missing from the metadata in SciHub's DHuS catalogue,
+in particular for older products. To be on the safe side, combine the `tileid` search
+with a `filename` pattern search:
 
 .. code-block:: python
 
-  kw['filename'] = '*_T{}_*'.format(tile)  # products after 2016-12-01
+  kw = query_kwargs.copy()
+  kw['raw'] = 'tileid:{tileid} OR filename:*_T{tileid}_*'.format(tileid=tile)
+  pp = api.query(**kw)
 
 API Reference
 -------------


### PR DESCRIPTION
The docs have an example on how to query for Sentinel-2 products by tile, which is a rather common use case. The explanation of a related metadata inconsistency was inaccurate and @valgur [suggested](https://github.com/sentinelsat/sentinelsat/issues/277#issuecomment-481642551) a nice way of handling this issue, which I include in the docs with this change.

Closes #277
Fixes #279 
