### PR TITLE
Query length warning

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,3 +30,6 @@ Contributors
 * Gerald Baier `@gbaier <https://github.com/gbaier>`_
 * Olga Chebotaryova `@OlgaCh <https://github.com/OlgaCh>`_
 * Lukas Bindreiter `@lukasbindreiter <https://github.com/lukasbindreiter>`_
+* `@yepremyana <https://github.com/yepremyana>`_
+* Sarah Floris `@sdf94 <https://github.com/sdf94>`_
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 Changed
 ~~~~~~~
 * reorganize unit tests into small groups with their own files (#287)
+* warn users about complex queries (#290)
 
 Deprecated
 ~~~~~~~~~~

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -30,10 +30,11 @@ Standard GeoJSON specification contains only WGS84 format, check if your data co
 Maybe there are no images for the specified time period, by default
 ``sentinelsat`` will query the last 24 hours only.
 
-.. rubric:: My search just quits or I got a warning describing my query complexity.  
+.. rubric:: I get the warning 'The query string is too long and will likely cause a bad DHuS response'.  
 
-Have you checked your query length? It might be that your query is too complex or specific, causing the library
-to behave poorly. A suggestion in this case would be to create a query with fewer parameters. 
+The query sent to the DHuS server is too complex and will likely fail. You can counter this by decreasing the query 
+length by removing parameters or simplifying your polygon, i.e. remove vertices or decrease coordinate precision after
+the decimal point.
 
 .. rubric:: Anything else?
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -164,7 +164,9 @@ class SentinelAPI:
 
         # check query length - often caused by complex polygons
         if self.check_query_length(query) > 1.0:
-            self.logger.warning("The query string is too long and will likely cause a bad DHuS response.")
+            self.logger.warning(
+                "The query string is too long and will likely cause a bad DHuS response."
+            )
 
         self.logger.debug(
             "Running query: order_by=%s, limit=%s, offset=%s, query=%s",
@@ -902,7 +904,7 @@ class SentinelAPI:
         """
         # The server uses the Java's URLEncoder implementation internally, which we are replicating here
         effective_length = len(quote_plus(query, safe="-_.*").replace("~", "%7E"))
-        
+
         return effective_length / 3938
 
     def _query_names(self, names):

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -162,6 +162,10 @@ class SentinelAPI:
         """
         query = self.format_query(area, date, raw, area_relation, **keywords)
 
+        # check query length - often caused by complex polygons
+        if self.check_query_length(query) > 1.0:
+            self.logger.warning("The query string is too long and will likely cause a bad DHuS response.")
+
         self.logger.debug(
             "Running query: order_by=%s, limit=%s, offset=%s, query=%s",
             order_by,
@@ -898,10 +902,7 @@ class SentinelAPI:
         """
         # The server uses the Java's URLEncoder implementation internally, which we are replicating here
         effective_length = len(quote_plus(query, safe="-_.*").replace("~", "%7E"))
-        if effective_length / 3938 > 1.0:
-            warnings.warn(
-                "Your query, {}, is complex and may cause a bad SciHub response.".format(query)
-            )
+        
         return effective_length / 3938
 
     def _query_names(self, names):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from os.path import join, isfile, dirname, abspath, exists
 
 import pytest
 import yaml
-import warnings
 from pytest_socket import disable_socket
 from vcr import VCR
 
@@ -194,21 +193,20 @@ def large_query():
 @pytest.fixture(scope="session")
 def test_check_query_length(**api_kwargs):
     api = SentinelAPI(**api_kwargs)
-    # short query to make sure it does not show the warning
+    # query length is determined by number of parameters and polygon compleyity
     query = api.format_query(
-        date=("20170801", "20170830"), platformname="Sentinel-2", cloudcoverpercentage=(0, 100)
-    )
-
-    # super long query to make sure it does show the warning
-    query1 = api.format_query(
         date=("20170801", "20170830"),
         platformname="Sentinel-3",
-        producttype="Sentinel-3: SR_1_SRA___, SR_1_SRA_A, SR_1_SRA_BS, SR_2_LAN___, OL_1_EFR___, OL_1_ERR___, OL_2_LFR___, OL_2_LRR___, SL_1_RBT___, SL_2_LST___, SY_2_SYN___, SY_2_V10___, SY_2_VG1___, SY_2_VGP___.",
+        producttype="Sentinel-3: SR_1_SRA___, SR_1_SRA_A, SR_1_SRA_BS, SR_2_LAN___, OL_1_EFR___, OL_1_ERR___, \\
+            OL_2_LFR___, OL_2_LRR___, SL_1_RBT___, SL_2_LST___, SY_2_SYN___, SY_2_V10___, SY_2_VG1___, SY_2_VGP___.",
         area_relation="intersects",
-        footprint="Intersects(POLYGON((-4.53 29.85, 26.75 29.85, 26.75 46.80,-4.53 46.80,-4.53 29.85)))",
+        footprint="Intersects(POLYGON((-4.530000 29.8500000, 26.75000000 29.8500000, 26.7000005 46.8000000, \\
+            -4.5300000 46.80000000,-4.530000000 29.850000000)))",
         cloudcoverpercentage=(0, 100),
         timeliness="Near Real Time",
     )
+
+    
 
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,33 +188,3 @@ def large_query():
         area="POLYGON((0 0,0 10,10 10,10 0,0 0))",
         date=(datetime(2015, 12, 1), datetime(2015, 12, 31)),
     )
-
-
-@pytest.fixture(scope="session")
-def test_check_query_length(**api_kwargs):
-    api = SentinelAPI(**api_kwargs)
-    # query length is determined by number of parameters and polygon compleyity
-    query = api.format_query(
-        date=("20170801", "20170830"),
-        platformname="Sentinel-3",
-        producttype="Sentinel-3: SR_1_SRA___, SR_1_SRA_A, SR_1_SRA_BS, SR_2_LAN___, OL_1_EFR___, OL_1_ERR___, \\
-            OL_2_LFR___, OL_2_LRR___, SL_1_RBT___, SL_2_LST___, SY_2_SYN___, SY_2_V10___, SY_2_VG1___, SY_2_VGP___.",
-        area_relation="intersects",
-        footprint="Intersects(POLYGON((-4.530000 29.8500000, 26.75000000 29.8500000, 26.7000005 46.8000000, \\
-            -4.5300000 46.80000000,-4.530000000 29.850000000)))",
-        cloudcoverpercentage=(0, 100),
-        timeliness="Near Real Time",
-    )
-
-    
-
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter("always")
-        w = api.check_query_length(query)
-        # Activate the function which should or should not cause a warning.
-        assert len(w) == 0
-        w1 = api.check_query_length(query1)
-
-        assert len(w1) == 1
-        assert "Your query" in str(w1[-1].message)


### PR DESCRIPTION
Closing #290 #318 #327 

Thank you for your contributions @yepremyana and @sdf94!

After looking into the task in more detail it turns out I underestimated the complexity in terms of design decisions. Our test for `check_query_length` works reasonably well with https://scihub.copernicus.eu but gives no indication if a query is too complex for other manifestations of SciHub.

I therefore opted for a warning instead of a exception. The warning provides more info than the weird server response while at the same time not obstructing the usage of `sentinelsat` with a DHuS that accepts more complex queries.