### PR TITLE
Reorder changelog items a bit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,6 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 Added
 ~~~~~
-* force unit tests to include on of the markers 'fast', 'scihub' or 'mock_api' (#287 @valgur)
-* automatic return code checking of CLI tests (#287) 
-* code formatting with `black` checked by Travis-CI
 * trigger retrieval of offline products from LTA, while downloading online products (#297 @gbaier)
 * allow input of multiple values per query parameter as logical OR (#321 @OlgaCh)
 * document CODA password limitations (#315 @nishadhka)
@@ -36,6 +33,9 @@ Development Changes
   ``--vcr [use|record_new|reset]`` to ``--vcr-record [once|record_new|all``.
   See `vcrpy docs <https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes>`_ for details.
 * Reduced code duplication in unit tests by making greater use of pytest fixtures.
+* force unit tests to include on of the markers 'fast', 'scihub' or 'mock_api' (#287 @valgur)
+* automatic return code checking of CLI tests (#287) 
+* code formatting with `black` checked by Travis-CI
 
 
 [0.13] – 2019-04-05

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,6 @@ Added
 
 Changed
 ~~~~~~~
-* reorganize unit tests into small groups with their own files (#287)
 * warn users about complex queries (#290)
 
 Deprecated
@@ -28,14 +27,15 @@ Fixed
 
 Development Changes
 ~~~~~~~~~~~~~~~~~~~
+* code formatting with `black` checked by Travis-CI (#296)
+* reorganize unit tests into small groups with their own files (#287)
+* reduced code duplication in unit tests by making greater use of pytest fixtures. (#287)
+* force unit tests to include on of the markers 'fast', 'scihub' or 'mock_api' (#287)
+* automatic return code checking of CLI tests (#287)
 * Replaced direct ``vcrpy`` usage in unit tests with ``pytest-vcr``.
   The ``pytest`` command line options changed from ``--vcr disable`` to ``--disable-vcr`` and
   ``--vcr [use|record_new|reset]`` to ``--vcr-record [once|record_new|all``.
-  See `vcrpy docs <https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes>`_ for details.
-* Reduced code duplication in unit tests by making greater use of pytest fixtures.
-* force unit tests to include on of the markers 'fast', 'scihub' or 'mock_api' (#287 @valgur)
-* automatic return code checking of CLI tests (#287) 
-* code formatting with `black` checked by Travis-CI
+  See `vcrpy docs <https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes>`_ for details. (#283)
 
 
 [0.13] – 2019-04-05

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Development Changes
 * code formatting with `black` checked by Travis-CI (#352)
 * reorganize unit tests into small groups with their own files (#287)
 * reduced code duplication in unit tests by making greater use of pytest fixtures. (#287)
-* force unit tests to include on of the markers 'fast', 'scihub' or 'mock_api' (#287)
+* force unit tests to include one of the markers 'fast', 'scihub' or 'mock_api' (#287)
 * automatic return code checking of CLI tests (#287)
 * Replaced direct ``vcrpy`` usage in unit tests with ``pytest-vcr``.
   The ``pytest`` command line options changed from ``--vcr disable`` to ``--disable-vcr`` and

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Fixed
 
 Development Changes
 ~~~~~~~~~~~~~~~~~~~
-* code formatting with `black` checked by Travis-CI (#296)
+* code formatting with `black` checked by Travis-CI (#352)
 * reorganize unit tests into small groups with their own files (#287)
 * reduced code duplication in unit tests by making greater use of pytest fixtures. (#287)
 * force unit tests to include on of the markers 'fast', 'scihub' or 'mock_api' (#287)


### PR DESCRIPTION
Thanks for publishing a new release, @Fernerkundung!
Just a minor edit to the changelog. I think the changelog should be oriented towards end-users first, developers second. So, I suggest moving the development and testing change notes to the separate dedicated section.