### PR TITLE
Make VCR.py matching more robust

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def vcr(vcr):
     vcr.register_serializer("custom", BinaryContentSerializer(CASSETTE_DIR))
     vcr.serializer = "custom"
     vcr.register_matcher("range_header", range_header_matcher)
-    vcr.match_on = ["uri", "method", "body", "range_header"]
+    vcr.match_on = ["method", "range_header", "host", "port", "path", "query", "body"]
     return vcr
 
 


### PR DESCRIPTION
Replace matching by full URI with matching on the host, port, path and query components instead. Scheme (https/http) is ignored.
This fixes the query parameter order issues encountered in #372.