### PR TITLE
Fix unit test regressions

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -464,9 +464,9 @@ class SentinelAPI:
                 "to_geodataframe requires the optional dependencies GeoPandas and Shapely."
             )
 
-        crs = {"init": "epsg:4326"}  # WGS84
+        crs = "EPSG:4326"  # WGS84
         if len(products) == 0:
-            return gpd.GeoDataFrame(crs=crs)
+            return gpd.GeoDataFrame(crs=crs, geometry=[])
 
         df = SentinelAPI.to_dataframe(products)
         geometry = [shapely.wkt.loads(fp) for fp in df["footprint"]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,15 +37,12 @@ def vcr(vcr):
         return request
 
     def scrub_response(response):
-        for header in (
-            "Authorization",
-            "Set-Cookie",
-            "Cookie",
-            "Date",
-            "Expires",
-            "Transfer-Encoding",
-        ):
-            if header in response["headers"]:
+        ignore = set(
+            x.lower() for x in ["Authorization", "Set-Cookie", "Cookie", "Date", "Expires",]
+        )
+        for header in list(response["headers"]):
+            header = header.lower()
+            if header in ignore or header.startswith("access-control"):
                 del response["headers"][header]
         return response
 

--- a/tests/custom_serializer.py
+++ b/tests/custom_serializer.py
@@ -17,8 +17,8 @@ class BinaryContentSerializer:
         cassette_dict = self.base_serializer.deserialize(cassette_string)
         for interaction in cassette_dict["interactions"]:
             response = interaction["response"]
-            headers = response["headers"]
-            if "Content-Range" in headers and "Content-Disposition" in headers:
+            headers = {k.lower(): v for k, v in response["headers"].items()}
+            if "content-range" in headers and "content-disposition" in headers:
                 rg, size, filename = self._parse_headers(headers)
                 with open(join(self.directory, filename), "rb") as f:
                     f.seek(rg[0])
@@ -29,8 +29,8 @@ class BinaryContentSerializer:
     def serialize(self, cassette_dict):
         for interaction in cassette_dict["interactions"]:
             response = interaction["response"]
-            headers = response["headers"]
-            if "Content-Range" in headers and "Content-Disposition" in headers:
+            headers = {k.lower(): v for k, v in response["headers"].items()}
+            if "content-range" in headers and "content-disposition" in headers:
                 rg, size, filename = self._parse_headers(headers)
                 content = response["body"]["string"]
                 if rg[0] == 0 and rg[1] + 1 == size:
@@ -41,9 +41,9 @@ class BinaryContentSerializer:
 
     @staticmethod
     def _parse_headers(headers):
-        range_hdr = headers["Content-Range"][0]
+        range_hdr = headers["content-range"][0]
         m = re.match(r"^bytes (\d+)-(\d+)/(\d+)", range_hdr)
         rg = (int(m.group(1)), int(m.group(2)))
         size = int(m.group(3))
-        filename = headers["Content-Disposition"][0].split('"')[1]
+        filename = headers["content-disposition"][0].split('"')[1]
         return rg, size, filename

--- a/tests/fixtures/vcr_cassettes/test_unicode_support.yaml
+++ b/tests/fixtures/vcr_cassettes/test_unicode_support.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: q=%D9%A9%28%E2%97%8F%CC%AE%CC%AE%CC%83%E2%80%A2%CC%83%29%DB%B6%3A
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      User-Agent:
+      - sentinelsat/0.14
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=0&start=0
+  response:
+    body:
+      string: "{\"feed\":{\"xmlns:opensearch\":\"http://a9.com/-/spec/opensearch/1.1/\",\"xmlns\":\"http://www.w3.org/2005/Atom\",\"title\":\"Sentinels
+        Scientific Data Hub search results for: \u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:\",\"subtitle\":\"Displaying
+        \ results. Request done in 0 seconds.\",\"updated\":\"2020-06-26T20:42:49.044Z\",\"author\":{\"name\":\"Sentinels
+        Scientific Data Hub\"},\"id\":\"https://scihub.copernicus.eu/apihub/search?q=\u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:\",\"opensearch:totalResults\":null,\"opensearch:startIndex\":\"0\",\"opensearch:itemsPerPage\":\"0\",\"opensearch:Query\":{\"role\":\"request\",\"searchTerms\":\"\u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:\",\"startPage\":\"1\"},\"link\":[{\"rel\":\"self\",\"type\":\"application/atom+xml\",\"href\":\"https://scihub.copernicus.eu/apihub/search?q=\u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:&start=0&rows=0\"},{\"rel\":\"first\",\"type\":\"application/atom+xml\",\"href\":\"https://scihub.copernicus.eu/apihub/search?q=\u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:&start=0&rows=0\"},{\"rel\":\"last\",\"type\":\"application/atom+xml\",\"href\":\"https://scihub.copernicus.eu/apihub/search?q=\u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:&start=NaN&rows=0\"},{\"rel\":\"search\",\"type\":\"application/opensearchdescription+xml\",\"href\":\"opensearch_description.xml\"}]}}"
+    headers:
+      content-length:
+      - '1111'
+      content-type:
+      - application/json
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - sentinelsat/0.14
+    method: GET
+    uri: https://scihub.copernicus.eu/apihub/odata/v1/Products('%D9%A9(%E2%97%8F%CC%AE%CC%AE%CC%83%E2%80%A2%CC%83)%DB%B6:')?$format=json
+  response:
+    body:
+      string: "{\"error\":{\"code\":null,\"message\":{\"lang\":\"en\",\"value\":\"Invalid
+        key (\u0669(\u25CF\u032E\u032E\u0303\u2022\u0303)\u06F6:) to access Products\"}}}"
+    headers:
+      cause-message:
+      - 'InvalidKeyException : Invalid key (?(??????)?:) to access Products'
+      content-length:
+      - '112'
+      content-type:
+      - application/json
+      dataserviceversion:
+      - '1.0'
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+markers =
+    fast: the test is running locally without doing any queries
+    mock_api: the test is using mocked responses for queries
+    scihub: the test is using recorded responses for queries
+    pandas: the test requires pandas to run
+    geopandas: the test requires geopandas to run

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -29,8 +29,6 @@ def test_checksumming_progressbars(capsys, fixture_path):
 
 
 @pytest.mark.vcr
-# Relevant pull request: https://github.com/kevin1024/vcrpy/pull/386
-@pytest.mark.skip(reason="Cannot mock since VCR.py has issues with Unicode request bodies.")
 @pytest.mark.scihub
 def test_unicode_support(api):
     test_str = "٩(●̮̮̃•̃)۶:"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import hashlib
+import sys
 
 import pytest
 import requests
@@ -30,6 +31,7 @@ def test_checksumming_progressbars(capsys, fixture_path):
 
 @pytest.mark.vcr
 @pytest.mark.scihub
+@pytest.mark.skipif(sys.version_info[0] < 3, reason="ignored for Python 2.7")
 def test_unicode_support(api):
     test_str = "٩(●̮̮̃•̃)۶:"
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -50,7 +50,7 @@ def test_to_geopandas(products):
     print(gdf.unary_union.area)
     assert gdf.unary_union.area == pytest.approx(89.6, abs=0.1)
     assert len(gdf) == len(products)
-    assert gdf.crs == {"init": "epsg:4326"}
+    assert gdf.crs == "EPSG:4326"
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
* Fixes geopandas deprecation warnings for CRS format definition and missing geometry input.
* Fixes pytest warnings about missing marker definitions.
* Re-enable Unicode handling unit test as the [blocking VCR.py issue has been fixed](https://github.com/kevin1024/vcrpy/pull/386).
* Fix VCR.py header handling regression, which broke scrubbing of cookies (affects #372) and handling of downloaded files in cassettes.