### PR TITLE
Improve location formatting, fix cassettes

### DIFF
--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 
 import click
@@ -212,8 +213,21 @@ def cli(
         search_kwargs.update((x.split("=") for x in query))
 
     if location is not None:
-        wkt, place_name = placename_to_wkt(location)
-        logger.info("The location we are querying is: '%s', '%s'".format(place_name, wkt))
+        wkt, info = placename_to_wkt(location)
+        minX, minY, maxX, maxY = info["bbox"]
+        r = 6371  # average radius, km
+        extent_east = r * math.radians(maxX - minX) * math.cos(math.radians((minY + maxY) / 2))
+        extent_north = r * math.radians(maxY - minY)
+        logger.info(
+            "Querying location: '%s' with %.1f x %.1f km, %f, %f to %f, %f bounding box",
+            info["display_name"],
+            extent_north,
+            extent_east,
+            minY,
+            minX,
+            maxY,
+            maxX,
+        )
         search_kwargs["area"] = wkt
 
     if geometry is not None:

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1149,15 +1149,15 @@ def geojson_to_wkt(geojson_obj, feature_number=0, decimals=4):
         a GeoJSON object
     feature_number : int, optional
         Feature to extract polygon from (in case of MultiPolygon
-        FeatureCollection), defaults to first Feature
+        FeatureCollection), defaults to first feature
     decimals : int, optional
         Number of decimal figures after point to round coordinate to. Defaults to 4 (about 10
         meters).
 
     Returns
     -------
-    polygon coordinates
-        string of comma separated coordinate tuples (lon, lat) to be used by SentinelAPI
+    str
+        Well-Known Text string corresponding to the GeoJSON geometry.
     """
     if "coordinates" in geojson_obj:
         geometry = geojson_obj
@@ -1427,33 +1427,42 @@ def _parse_odata_response(product):
     return output
 
 
-def placename_to_wkt(placename):
-    """Geocodes the placename to rectangular bounding extents using Nominatim API and
+def placename_to_wkt(place_name):
+    """Geocodes the place name to rectangular bounding extents using Nominatim API and
        returns the corresponding 'ENVELOPE' form Well-Known-Text.
 
     Parameters
     ----------
-    placename : str
+    place_name : str
         the query to geocode
+
+    Raises
+    ------
+    ValueError
+        If no matches to the place name were found.
 
     Returns
     -------
-    full name and coordinates of the queried placename
-        list in the form [wkt string in form 'ENVELOPE(minX, maxX, maxY, minY)', string placeinfo]
+    wkt_envelope : str
+        Bounding box of the location as an 'ENVELOPE(minX, maxX, maxY, minY)' WKT string.
+    info : Dict[str, any]
+        Matched location's metadata returned by Nominatim.
     """
-
-    rqst = requests.post(
-        "https://nominatim.openstreetmap.org/search", params={"q": placename, "format": "geojson"}
+    rqst = requests.get(
+        "https://nominatim.openstreetmap.org/search",
+        params={"q": place_name, "format": "geojson"},
+        headers={"User-Agent": "sentinelsat/" + sentinelsat_version},
     )
-    # Check that the response from Openstreetmapserver has status code 2xx
-    # and that the response is valid JSON.
     rqst.raise_for_status()
-    jsonlist = rqst.json()
-    if len(jsonlist["features"]) == 0:
-        raise ValueError('Unable to find a matching location for "{}"'.format(placename))
+    features = rqst.json()["features"]
+    if len(features) == 0:
+        raise ValueError('Unable to find a matching location for "{}"'.format(place_name))
     # Get the First result's bounding box and description.
-    feature = jsonlist["features"][0]
+    feature = features[0]
     minX, minY, maxX, maxY = feature["bbox"]
-    footprint = "ENVELOPE({}, {}, {}, {})".format(minX, maxX, maxY, minY)
-    placeinfo = feature["properties"]["display_name"]
-    return footprint, placeinfo
+    # ENVELOPE is a non-standard WKT format supported by Solr
+    # https://lucene.apache.org/solr/guide/6_6/spatial-search.html#SpatialSearch-BBoxField
+    wkt_envelope = "ENVELOPE({}, {}, {}, {})".format(minX, maxX, maxY, minY)
+    info = feature["properties"]
+    info["bbox"] = feature["bbox"]
+    return wkt_envelope, info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,15 @@ def vcr(vcr):
 
     def scrub_response(response):
         ignore = set(
-            x.lower() for x in ["Authorization", "Set-Cookie", "Cookie", "Date", "Expires",]
+            x.lower()
+            for x in [
+                "Authorization",
+                "Set-Cookie",
+                "Cookie",
+                "Date",
+                "Expires",
+                "Transfer-Encoding",
+            ]
         )
         for header in list(response["headers"]):
             if header.lower() in ignore or header.lower().startswith("access-control"):

--- a/tests/fixtures/vcr_cassettes/test_location_cli.yaml
+++ b/tests/fixtures/vcr_cassettes/test_location_cli.yaml
@@ -1,124 +1,5 @@
 interactions:
 - request:
-    body: q=beginPosition%3A%5BNOW-1DAY+TO+NOW%5D
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '39'
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=UTF-8
-      User-Agent:
-      - sentinelsat/0.14
-    method: POST
-    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=5&start=0
-  response:
-    body:
-      string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
-        Scientific Data Hub search results for: beginPosition:[NOW-1DAY TO NOW]","subtitle":"Displaying
-        0 to 4 of 23031 total results. Request done in 0.009 seconds.","updated":"2020-06-30T13:06:55.292Z","author":{"name":"Sentinels
-        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
-        TO NOW]","opensearch:totalResults":"23031","opensearch:startIndex":"0","opensearch:itemsPerPage":"5","opensearch:Query":{"role":"request","searchTerms":"beginPosition:[NOW-1DAY
-        TO NOW]","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
-        TO NOW]&start=0&rows=5"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
-        TO NOW]&start=0&rows=5"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
-        TO NOW]&start=5&rows=5"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
-        TO NOW]&start=23030&rows=5"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}],"entry":[{"title":"S2B_MSIL1C_20200630T074619_N0209_R135_T42XWK_20200630T094849","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''169c2407-de3b-4e00-8575-0c4fcb87a312'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''169c2407-de3b-4e00-8575-0c4fcb87a312'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''169c2407-de3b-4e00-8575-0c4fcb87a312'')/Products(''Quicklook'')/$value"}],"id":"169c2407-de3b-4e00-8575-0c4fcb87a312","summary":"Date:
-        2020-06-30T07:46:19.024Z, Instrument: MSI, Mode: , Satellite: Sentinel-2,
-        Size: 328.08 MB","date":[{"name":"datatakesensingstart","content":"2020-06-30T07:46:19.024Z"},{"name":"beginposition","content":"2020-06-30T07:46:19.024Z"},{"name":"endposition","content":"2020-06-30T07:46:19.024Z"},{"name":"ingestiondate","content":"2020-06-30T13:04:35.621Z"}],"int":[{"name":"orbitnumber","content":"17321"},{"name":"relativeorbitnumber","content":"135"}],"double":{"name":"cloudcoverpercentage","content":"7.6248"},"str":[{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"gmlfootprint","content":"<gml:Polygon
-        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>75.59144638489266,69.66910525712633
-        75.63401690173706,69.7721853382393 75.76178887706592,70.08786110285496 75.88913398434852,70.4090809857857
-        76.01609526609185,70.7357760814996 76.14268445652584,71.06777728135704 76.26887962790255,71.4055589355239
-        76.39465633922454,71.74943633137758 76.5199420809625,72.09999765473772 76.55430887999826,72.19833463723029
-        76.54569065714992,73.23017413561635 75.56417818230878,72.94770679558897 75.59144638489266,69.66910525712633</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"footprint","content":"MULTIPOLYGON
-        (((72.94770679558897 75.56417818230878, 73.23017413561635 76.54569065714992,
-        72.19833463723029 76.55430887999826, 72.09999765473772 76.5199420809625, 71.74943633137758
-        76.39465633922454, 71.4055589355239 76.26887962790255, 71.06777728135704 76.14268445652584,
-        70.7357760814996 76.01609526609185, 70.4090809857857 75.88913398434852, 70.08786110285496
-        75.76178887706592, 69.7721853382393 75.63401690173706, 69.66910525712633 75.59144638489266,
-        72.94770679558897 75.56417818230878)))"},{"name":"level1cpdiidentifier","content":"S2B_OPER_MSI_L1C_TL_SGS__20200630T094849_A017321_T42XWK_N02.09"},{"name":"tileid","content":"42XWK"},{"name":"hv_order_tileid","content":"XK42W"},{"name":"format","content":"SAFE"},{"name":"processingbaseline","content":"02.09"},{"name":"platformname","content":"Sentinel-2"},{"name":"filename","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T42XWK_20200630T094849.SAFE"},{"name":"instrumentname","content":"Multi-Spectral
-        Instrument"},{"name":"instrumentshortname","content":"MSI"},{"name":"size","content":"328.08
-        MB"},{"name":"s2datatakeid","content":"GS2B_20200630T074619_017321_N02.09"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformidentifier","content":"2017-013A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2B"},{"name":"processinglevel","content":"Level-1C"},{"name":"identifier","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T42XWK_20200630T094849"},{"name":"uuid","content":"169c2407-de3b-4e00-8575-0c4fcb87a312"}]},{"title":"S2B_MSIL1C_20200630T074619_N0209_R135_T40VEP_20200630T094849","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''313c1712-5ed6-4d07-af25-658af459da41'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''313c1712-5ed6-4d07-af25-658af459da41'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''313c1712-5ed6-4d07-af25-658af459da41'')/Products(''Quicklook'')/$value"}],"id":"313c1712-5ed6-4d07-af25-658af459da41","summary":"Date:
-        2020-06-30T07:46:19.024Z, Instrument: MSI, Mode: , Satellite: Sentinel-2,
-        Size: 554.53 MB","date":[{"name":"datatakesensingstart","content":"2020-06-30T07:46:19.024Z"},{"name":"beginposition","content":"2020-06-30T07:46:19.024Z"},{"name":"endposition","content":"2020-06-30T07:46:19.024Z"},{"name":"ingestiondate","content":"2020-06-30T13:04:30.61Z"}],"int":[{"name":"orbitnumber","content":"17321"},{"name":"relativeorbitnumber","content":"135"}],"double":{"name":"cloudcoverpercentage","content":"76.3246"},"str":[{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"gmlfootprint","content":"<gml:Polygon
-        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>62.216454755818035,59.01272097641174
-        62.18404371229524,58.98304975386334 62.04489963928736,58.8573370006088 61.9056933976864,58.732606097434
-        61.766405080926624,58.60901333539245 61.658024157983355,58.51449819005229
-        61.62581054852495,58.486322068884014 61.48644370446762,58.36479704224417 61.34676639981974,58.245154279915006
-        61.23741899044039,58.151627923759214 61.246103699767175,56.99962733070455
-        62.23177006410344,56.99961522897759 62.216454755818035,59.01272097641174</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"footprint","content":"MULTIPOLYGON
-        (((58.151627923759214 61.23741899044039, 58.245154279915006 61.34676639981974,
-        58.36479704224417 61.48644370446762, 58.486322068884014 61.62581054852495,
-        58.51449819005229 61.658024157983355, 58.60901333539245 61.766405080926624,
-        58.732606097434 61.9056933976864, 58.8573370006088 62.04489963928736, 58.98304975386334
-        62.18404371229524, 59.01272097641174 62.216454755818035, 56.99961522897759
-        62.23177006410344, 56.99962733070455 61.246103699767175, 58.151627923759214
-        61.23741899044039)))"},{"name":"level1cpdiidentifier","content":"S2B_OPER_MSI_L1C_TL_SGS__20200630T094849_A017321_T40VEP_N02.09"},{"name":"tileid","content":"40VEP"},{"name":"hv_order_tileid","content":"VP40E"},{"name":"format","content":"SAFE"},{"name":"processingbaseline","content":"02.09"},{"name":"platformname","content":"Sentinel-2"},{"name":"filename","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T40VEP_20200630T094849.SAFE"},{"name":"instrumentname","content":"Multi-Spectral
-        Instrument"},{"name":"instrumentshortname","content":"MSI"},{"name":"size","content":"554.53
-        MB"},{"name":"s2datatakeid","content":"GS2B_20200630T074619_017321_N02.09"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformidentifier","content":"2017-013A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2B"},{"name":"processinglevel","content":"Level-1C"},{"name":"identifier","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T40VEP_20200630T094849"},{"name":"uuid","content":"313c1712-5ed6-4d07-af25-658af459da41"}]},{"title":"S2B_MSIL1C_20200630T074619_N0209_R135_T43XDE_20200630T094849","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''570099e1-8640-425a-9560-1af76ce8ea09'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''570099e1-8640-425a-9560-1af76ce8ea09'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''570099e1-8640-425a-9560-1af76ce8ea09'')/Products(''Quicklook'')/$value"}],"id":"570099e1-8640-425a-9560-1af76ce8ea09","summary":"Date:
-        2020-06-30T07:46:19.024Z, Instrument: MSI, Mode: , Satellite: Sentinel-2,
-        Size: 524.68 MB","date":[{"name":"datatakesensingstart","content":"2020-06-30T07:46:19.024Z"},{"name":"beginposition","content":"2020-06-30T07:46:19.024Z"},{"name":"endposition","content":"2020-06-30T07:46:19.024Z"},{"name":"ingestiondate","content":"2020-06-30T13:04:30.333Z"}],"int":[{"name":"orbitnumber","content":"17321"},{"name":"relativeorbitnumber","content":"135"}],"double":{"name":"cloudcoverpercentage","content":"1.9057"},"str":[{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"gmlfootprint","content":"<gml:Polygon
-        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>76.20512424786345,71.23490741616143
-        76.26887962790255,71.4055589355239 76.39465633922454,71.74943633137758 76.5199420809625,72.09999765473772
-        76.55901033389337,72.21178735329185 76.5807490401923,75.37674503603093 75.59675745729632,75.35150611502145
-        75.56974114227089,71.40161018813914 76.20512424786345,71.23490741616143</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"footprint","content":"MULTIPOLYGON
-        (((71.40161018813914 75.56974114227089, 75.35150611502145 75.59675745729632,
-        75.37674503603093 76.5807490401923, 72.21178735329185 76.55901033389337, 72.09999765473772
-        76.5199420809625, 71.74943633137758 76.39465633922454, 71.4055589355239 76.26887962790255,
-        71.23490741616143 76.20512424786345, 71.40161018813914 75.56974114227089)))"},{"name":"level1cpdiidentifier","content":"S2B_OPER_MSI_L1C_TL_SGS__20200630T094849_A017321_T43XDE_N02.09"},{"name":"tileid","content":"43XDE"},{"name":"hv_order_tileid","content":"XE43D"},{"name":"format","content":"SAFE"},{"name":"processingbaseline","content":"02.09"},{"name":"platformname","content":"Sentinel-2"},{"name":"filename","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T43XDE_20200630T094849.SAFE"},{"name":"instrumentname","content":"Multi-Spectral
-        Instrument"},{"name":"instrumentshortname","content":"MSI"},{"name":"size","content":"524.68
-        MB"},{"name":"s2datatakeid","content":"GS2B_20200630T074619_017321_N02.09"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformidentifier","content":"2017-013A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2B"},{"name":"processinglevel","content":"Level-1C"},{"name":"identifier","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T43XDE_20200630T094849"},{"name":"uuid","content":"570099e1-8640-425a-9560-1af76ce8ea09"}]},{"title":"S2B_MSIL1C_20200630T074619_N0209_R135_T40WEA_20200630T094849","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b89330b8-dc06-439c-b20a-bc0e1ebf0216'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b89330b8-dc06-439c-b20a-bc0e1ebf0216'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''b89330b8-dc06-439c-b20a-bc0e1ebf0216'')/Products(''Quicklook'')/$value"}],"id":"b89330b8-dc06-439c-b20a-bc0e1ebf0216","summary":"Date:
-        2020-06-30T07:46:19.024Z, Instrument: MSI, Mode: , Satellite: Sentinel-2,
-        Size: 511.25 MB","date":[{"name":"datatakesensingstart","content":"2020-06-30T07:46:19.024Z"},{"name":"beginposition","content":"2020-06-30T07:46:19.024Z"},{"name":"endposition","content":"2020-06-30T07:46:19.024Z"},{"name":"ingestiondate","content":"2020-06-30T13:04:16.577Z"}],"int":[{"name":"orbitnumber","content":"17321"},{"name":"relativeorbitnumber","content":"135"}],"double":{"name":"cloudcoverpercentage","content":"71.1144"},"str":[{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"gmlfootprint","content":"<gml:Polygon
-        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>67.5254632637765,57.294142008652386
-        67.64834393221784,57.41649643732348 67.7884703993949,57.55698513025845 67.92837891660456,57.69987252048762
-        68.06820441258667,57.844382599581685 68.20795529165834,57.99057514414432 68.34756827664556,58.1387254504755
-        68.48715556327112,58.288311404976575 68.50219882247649,58.30461403746961 68.49117404059432,59.683704859937144
-        67.50737709315482,59.572052535873716 67.5254632637765,57.294142008652386</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"footprint","content":"MULTIPOLYGON
-        (((59.572052535873716 67.50737709315482, 59.683704859937144 68.49117404059432,
-        58.30461403746961 68.50219882247649, 58.288311404976575 68.48715556327112,
-        58.1387254504755 68.34756827664556, 57.99057514414432 68.20795529165834, 57.844382599581685
-        68.06820441258667, 57.69987252048762 67.92837891660456, 57.55698513025845
-        67.7884703993949, 57.41649643732348 67.64834393221784, 57.294142008652386
-        67.5254632637765, 59.572052535873716 67.50737709315482)))"},{"name":"level1cpdiidentifier","content":"S2B_OPER_MSI_L1C_TL_SGS__20200630T094849_A017321_T40WEA_N02.09"},{"name":"tileid","content":"40WEA"},{"name":"hv_order_tileid","content":"WA40E"},{"name":"format","content":"SAFE"},{"name":"processingbaseline","content":"02.09"},{"name":"platformname","content":"Sentinel-2"},{"name":"filename","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T40WEA_20200630T094849.SAFE"},{"name":"instrumentname","content":"Multi-Spectral
-        Instrument"},{"name":"instrumentshortname","content":"MSI"},{"name":"size","content":"511.25
-        MB"},{"name":"s2datatakeid","content":"GS2B_20200630T074619_017321_N02.09"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformidentifier","content":"2017-013A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2B"},{"name":"processinglevel","content":"Level-1C"},{"name":"identifier","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T40WEA_20200630T094849"},{"name":"uuid","content":"b89330b8-dc06-439c-b20a-bc0e1ebf0216"}]},{"title":"S2B_MSIL1C_20200630T074619_N0209_R135_T43XEC_20200630T094849","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''168fad42-8e9c-4430-b9da-252a4bccbbd2'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''168fad42-8e9c-4430-b9da-252a4bccbbd2'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''168fad42-8e9c-4430-b9da-252a4bccbbd2'')/Products(''Quicklook'')/$value"}],"id":"168fad42-8e9c-4430-b9da-252a4bccbbd2","summary":"Date:
-        2020-06-30T07:46:19.024Z, Instrument: MSI, Mode: , Satellite: Sentinel-2,
-        Size: 663.03 MB","date":[{"name":"datatakesensingstart","content":"2020-06-30T07:46:19.024Z"},{"name":"beginposition","content":"2020-06-30T07:46:19.024Z"},{"name":"endposition","content":"2020-06-30T07:46:19.024Z"},{"name":"ingestiondate","content":"2020-06-30T13:04:15.599Z"}],"int":[{"name":"orbitnumber","content":"17321"},{"name":"relativeorbitnumber","content":"135"}],"double":{"name":"cloudcoverpercentage","content":"47.88269999999999"},"str":[{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"gmlfootprint","content":"<gml:Polygon
-        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>74.268402409824,78.63297462320097
-        74.20489523216686,78.43829556159939 74.11292785727791,78.16156530643427 74.08750211145961,78.08492854497568
-        73.97071025036327,77.73925458718443 73.8533730805148,77.39840092624277 73.8165190147874,77.29329621666646
-        73.78640431801828,77.20709142021279 73.80461107106909,74.99935758190774 74.78877616349004,74.99931711599946
-        74.75775316048662,78.74319963155438 74.268402409824,78.63297462320097</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"footprint","content":"MULTIPOLYGON
-        (((77.20709142021279 73.78640431801828, 77.29329621666646 73.8165190147874,
-        77.39840092624277 73.8533730805148, 77.73925458718443 73.97071025036327, 78.08492854497568
-        74.08750211145961, 78.16156530643427 74.11292785727791, 78.43829556159939
-        74.20489523216686, 78.63297462320097 74.268402409824, 78.74319963155438 74.75775316048662,
-        74.99931711599946 74.78877616349004, 74.99935758190774 73.80461107106909,
-        77.20709142021279 73.78640431801828)))"},{"name":"level1cpdiidentifier","content":"S2B_OPER_MSI_L1C_TL_SGS__20200630T094849_A017321_T43XEC_N02.09"},{"name":"tileid","content":"43XEC"},{"name":"hv_order_tileid","content":"XC43E"},{"name":"format","content":"SAFE"},{"name":"processingbaseline","content":"02.09"},{"name":"platformname","content":"Sentinel-2"},{"name":"filename","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T43XEC_20200630T094849.SAFE"},{"name":"instrumentname","content":"Multi-Spectral
-        Instrument"},{"name":"instrumentshortname","content":"MSI"},{"name":"size","content":"663.03
-        MB"},{"name":"s2datatakeid","content":"GS2B_20200630T074619_017321_N02.09"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformidentifier","content":"2017-013A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2B"},{"name":"processinglevel","content":"Level-1C"},{"name":"identifier","content":"S2B_MSIL1C_20200630T074619_N0209_R135_T43XEC_20200630T094849"},{"name":"uuid","content":"168fad42-8e9c-4430-b9da-252a4bccbbd2"}]}]}}'
-    headers:
-      content-length:
-      - '18208'
-      content-type:
-      - application/json
-      pragma:
-      - no-cache
-      server:
-      - Apache-Coyote/1.1
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -127,11 +8,9 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       User-Agent:
-      - python-requests/2.23.0
-    method: POST
+      - sentinelsat/0.14
+    method: GET
     uri: https://nominatim.openstreetmap.org/search?q=Metz&format=geojson
   response:
     body:
@@ -157,8 +36,60 @@ interactions:
       - timeout=20
       Server:
       - nginx
-      Transfer-Encoding:
-      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: q=beginPosition%3A%5BNOW-1DAY+TO+NOW%5D+footprint%3A%22Intersects%28ENVELOPE%286.1360042%2C+6.256451%2C+49.1487955%2C+49.0608244%29%29%22
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      User-Agent:
+      - sentinelsat/0.14
+    method: POST
+    uri: https://scihub.copernicus.eu/apihub/search?format=json&rows=1&start=0
+  response:
+    body:
+      string: '{"feed":{"xmlns:opensearch":"http://a9.com/-/spec/opensearch/1.1/","xmlns":"http://www.w3.org/2005/Atom","title":"Sentinels
+        Scientific Data Hub search results for: beginPosition:[NOW-1DAY TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042,
+        6.256451, 49.1487955, 49.0608244))\"","subtitle":"Displaying 0 to 0 of 20
+        total results. Request done in 0.242 seconds.","updated":"2020-07-08T20:46:51.589Z","author":{"name":"Sentinels
+        Scientific Data Hub"},"id":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
+        TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042, 6.256451, 49.1487955, 49.0608244))\"","opensearch:totalResults":"20","opensearch:startIndex":"0","opensearch:itemsPerPage":"1","opensearch:Query":{"role":"request","searchTerms":"beginPosition:[NOW-1DAY
+        TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042, 6.256451, 49.1487955, 49.0608244))\"","startPage":"1"},"link":[{"rel":"self","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
+        TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042, 6.256451, 49.1487955, 49.0608244))\"&start=0&rows=1"},{"rel":"first","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
+        TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042, 6.256451, 49.1487955, 49.0608244))\"&start=0&rows=1"},{"rel":"next","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
+        TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042, 6.256451, 49.1487955, 49.0608244))\"&start=1&rows=1"},{"rel":"last","type":"application/atom+xml","href":"https://scihub.copernicus.eu/apihub/search?q=beginPosition:[NOW-1DAY
+        TO NOW] footprint:\"Intersects(ENVELOPE(6.1360042, 6.256451, 49.1487955, 49.0608244))\"&start=19&rows=1"},{"rel":"search","type":"application/opensearchdescription+xml","href":"opensearch_description.xml"}],"entry":{"title":"S2B_MSIL1C_20200708T102559_N0209_R108_T32ULV_20200708T124214","link":[{"href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bc5bd48d-c237-4eb2-8aa0-9d470175ff68'')/$value"},{"rel":"alternative","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bc5bd48d-c237-4eb2-8aa0-9d470175ff68'')/"},{"rel":"icon","href":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''bc5bd48d-c237-4eb2-8aa0-9d470175ff68'')/Products(''Quicklook'')/$value"}],"id":"bc5bd48d-c237-4eb2-8aa0-9d470175ff68","summary":"Date:
+        2020-07-08T10:25:59.024Z, Instrument: MSI, Mode: , Satellite: Sentinel-2,
+        Size: 683.94 MB","date":[{"name":"datatakesensingstart","content":"2020-07-08T10:25:59.024Z"},{"name":"beginposition","content":"2020-07-08T10:25:59.024Z"},{"name":"endposition","content":"2020-07-08T10:25:59.024Z"},{"name":"ingestiondate","content":"2020-07-08T18:13:01.463Z"}],"int":[{"name":"orbitnumber","content":"17437"},{"name":"relativeorbitnumber","content":"108"}],"double":{"name":"cloudcoverpercentage","content":"77.231"},"str":[{"name":"sensoroperationalmode","content":"INS-NOBS"},{"name":"gmlfootprint","content":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">\n   <gml:outerBoundaryIs>\n      <gml:LinearRing>\n         <gml:coordinates>49.53003637993339,6.235874040955493
+        49.62028986548394,6.270845206211097 49.64598096654525,7.750537404965346 48.6585189163826,7.775131037790508
+        48.63303181535822,6.285371051797206 49.53003637993339,6.235874040955493</gml:coordinates>\n      </gml:LinearRing>\n   </gml:outerBoundaryIs>\n</gml:Polygon>"},{"name":"footprint","content":"MULTIPOLYGON
+        (((6.285371051797206 48.63303181535822, 7.775131037790508 48.6585189163826,
+        7.750537404965346 49.64598096654525, 6.270845206211097 49.62028986548394,
+        6.235874040955493 49.53003637993339, 6.285371051797206 48.63303181535822)))"},{"name":"level1cpdiidentifier","content":"S2B_OPER_MSI_L1C_TL_MPS__20200708T124214_A017437_T32ULV_N02.09"},{"name":"tileid","content":"32ULV"},{"name":"hv_order_tileid","content":"UV32L"},{"name":"format","content":"SAFE"},{"name":"processingbaseline","content":"02.09"},{"name":"platformname","content":"Sentinel-2"},{"name":"filename","content":"S2B_MSIL1C_20200708T102559_N0209_R108_T32ULV_20200708T124214.SAFE"},{"name":"instrumentname","content":"Multi-Spectral
+        Instrument"},{"name":"instrumentshortname","content":"MSI"},{"name":"size","content":"683.94
+        MB"},{"name":"s2datatakeid","content":"GS2B_20200708T102559_017437_N02.09"},{"name":"producttype","content":"S2MSI1C"},{"name":"platformidentifier","content":"2017-013A"},{"name":"orbitdirection","content":"DESCENDING"},{"name":"platformserialidentifier","content":"Sentinel-2B"},{"name":"processinglevel","content":"Level-1C"},{"name":"identifier","content":"S2B_MSIL1C_20200708T102559_N0209_R108_T32ULV_20200708T124214"},{"name":"uuid","content":"bc5bd48d-c237-4eb2-8aa0-9d470175ff68"}]}}}'
+    headers:
+      content-length:
+      - '4851'
+      content-type:
+      - application/json
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+      vary:
+      - Accept-Encoding
     status:
       code: 200
       message: OK

--- a/tests/fixtures/vcr_cassettes/test_placename_to_wkt_invalid.yaml
+++ b/tests/fixtures/vcr_cassettes/test_placename_to_wkt_invalid.yaml
@@ -8,21 +8,15 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       User-Agent:
-      - python-requests/2.22.0
-    method: POST
+      - sentinelsat/0.14
+    method: GET
     uri: https://nominatim.openstreetmap.org/search?q=%21%40%23%24%25%5E&format=geojson
   response:
     body:
       string: "{\"type\":\"FeatureCollection\",\"licence\":\"Data \xA9 OpenStreetMap
         contributors, ODbL 1.0. https://osm.org/copyright\",\"features\":[]}"
     headers:
-      Access-Control-Allow-Methods:
-      - OPTIONS,GET
-      Access-Control-Allow-Origin:
-      - '*'
       Connection:
       - keep-alive
       Content-Type:

--- a/tests/fixtures/vcr_cassettes/test_placename_to_wkt_valid.yaml
+++ b/tests/fixtures/vcr_cassettes/test_placename_to_wkt_valid.yaml
@@ -8,11 +8,9 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       User-Agent:
-      - python-requests/2.22.0
-    method: POST
+      - sentinelsat/0.14
+    method: GET
     uri: https://nominatim.openstreetmap.org/search?q=florida&format=geojson
   response:
     body:
@@ -31,10 +29,6 @@ interactions:
         of America\",\"place_rank\":30,\"category\":\"place\",\"type\":\"peninsula\",\"importance\":0.4741541321378574},\"bbox\":[-81.25005,27.24995,-81.24995,27.25005],\"geometry\":{\"type\":\"Point\",\"coordinates\":[-81.25,27.25]}},{\"type\":\"Feature\",\"properties\":{\"place_id\":235596325,\"osm_type\":\"relation\",\"osm_id\":1319503,\"display_name\":\"Florida,
         Valle del Cauca, Colombia\",\"place_rank\":12,\"category\":\"boundary\",\"type\":\"administrative\",\"importance\":0.47048881922758246,\"icon\":\"https://nominatim.openstreetmap.org/images/mapicons/poi_boundary_administrative.p.20.png\"},\"bbox\":[-76.3483323,3.2112461,-76.0391011,3.3891582],\"geometry\":{\"type\":\"Point\",\"coordinates\":[-76.1905432829982,3.30080485]}}]}"
     headers:
-      Access-Control-Allow-Methods:
-      - OPTIONS,GET
-      Access-Control-Allow-Origin:
-      - '*'
       Connection:
       - keep-alive
       Content-Type:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -535,4 +535,6 @@ def test_info_cli(run_cli, tmpdir):
 def test_location_cli(run_cli):
     result = run_cli("--location", "Metz", "-l", "1")
     assert "Found" in result.output
-    assert int(re.search(r"Found (\d+) products", result.output)[1]) < 100
+    m = re.search(r"Found (\d+) products", result.output)
+    assert m, result.output
+    assert int(m.group(1)) < 100

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -533,5 +533,6 @@ def test_info_cli(run_cli, tmpdir):
 @pytest.mark.vcr
 @pytest.mark.scihub
 def test_location_cli(run_cli):
-    result = run_cli("--location", "Metz", "-l", "5")
+    result = run_cli("--location", "Metz", "-l", "1")
     assert "Found" in result.output
+    assert int(re.search(r"Found (\d+) products", result.output)[1]) < 100


### PR DESCRIPTION
Follow-up for #372.
The location info output was printing `{}` placeholders instead of values and the cassettes were not updated after the final bugfix.
I also tweaked the location info logging further by adding the bounding box extents in km and the box coordinates in a clearer format. So, for example, `sentinelsat --location Metz` prints
```
Querying location: 'Metz, Moselle, Grand Est, France métropolitaine, France' with 9.8 x 8.8 km, 49.060824, 6.136004 to 49.148795, 6.256451 bounding box
```
The box size info is useful since the Nominatim results are not always perfect, i.e. `sentinelsat --location Estonia` yields a bounding box halfway in Poland
```
Querying location: 'Eesti', 807.5 x 1556.7 km, 51.752378, 18.331908 to 65.752378, 32.331908
```