### PR TITLE
Add main script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Added
 * Display DHuS server version with CLI flag ``--info`` (#367 @thomasyoung-audet)
 * Added seraching by placenames with the CLI flag ``--location`` (#372 @thomasyoung-audet)
 * Download quicklooks directly with the CLI flag ``--quicklook`` (#361 @mackland)
+* Added ``setinelsat/__main__.py`` (#412 @avalentino)
 
 Changed
 ~~~~~~~

--- a/sentinelsat/__main__.py
+++ b/sentinelsat/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from sentinelsat.scripts.cli import cli as main
+
+sys.exit(main())


### PR DESCRIPTION
Add a ``__main__.py`` file that simply calls ``sentinelsat.scripts.cli.cli`` to be able to run sentinelsat CLI as follows:
```
$ python3 -m sentinelsat --help
```

This could be handy when one uses multiple python environments.
