### PR TITLE
Drop python2 (Closes  #416)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ branches:
   only:
   - master
 before_install:
-- python -m pip install -U pip
+- pip3 install -U pip
 install:
-- pip install codecov
-- pip install -e .[dev]
-- if [[ $TRAVIS_OS_NAME == linux && $TRAVIS_PYTHON_VERSION == 3.8 ]]; then pip install black; fi
+- pip3 install codecov
+- pip3 install -e .[dev]
+- if [[ $TRAVIS_OS_NAME == linux && $TRAVIS_PYTHON_VERSION == 3.8 ]]; then pip3 install black; fi
 script:
 - coverage run --source=sentinelsat -m pytest -v
 # check black code formatting

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 jobs:
     include:
-      - python: '2.7'
       - python: '3.5'
       - python: '3.6'
       - python: '3.7'

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,4 +33,4 @@ Contributors
 * `@yepremyana <https://github.com/yepremyana>`_
 * Sarah Floris `@sdf94 <https://github.com/sdf94>`_
 * Thomas Young-Audet `@thomas-youngaudet <https://github.com/thomasyoung-audet>`_
-
+* Antonio Valentino `@avalentino <https://github.com/avalentino>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 [master] – YYYY-MM-DD
 ---------------------
+* Dropped support for Python 2.7. Now setuptools requires Python >= 3.5.
 
 Added
 ~~~~~

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -48,7 +48,7 @@ All public functions should have docstrings. We use the `numpy docstring standar
 Development Environment
 =======================
 
-We prefer developing with the most recent version of Python. ``sentinelsat`` currently supports Python 2.7 and all versions after 3.5 (inclusive).
+We prefer developing with the most recent version of Python. ``sentinelsat`` currently supports Python >= 3.5.
 
 Initial Setup
 -------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,7 +40,7 @@ There are two minor issues to keep in mind when recording unit tests VCRs.
 Supported Python versions
 -------------------------
 
-Sentinelsat has been tested with Python versions 2.7 and 3.5+. Earlier Python 3 versions are
+Sentinelsat has been tested with Python versions 3.5+. Earlier Python 3 versions are
 expected to work as well, as long as the dependencies are fulfilled.
 
 Optional dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ click
 html2text
 geojson >= 2
 tqdm
-six
 geomet

--- a/sentinelsat/exceptions.py
+++ b/sentinelsat/exceptions.py
@@ -14,7 +14,7 @@ class SentinelAPIError(Exception):
         self.response = response
 
     def __str__(self):
-        return "HTTP status {0} {1}: {2}".format(
+        return "HTTP status {} {}: {}".format(
             self.response.status_code,
             self.response.reason,
             ("\n" if "\n" in self.msg else "") + self.msg,

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -3,13 +3,6 @@ import logging
 import math
 import os
 
-try:
-    from json import JSONDecodeError
-
-    json_parse_exception = json.decoder.JSONDecodeError
-except ImportError:  # Python 2
-    json_parse_exception = ValueError
-
 import click
 import geojson as gj
 import requests.utils
@@ -18,7 +11,6 @@ from sentinelsat import __version__ as sentinelsat_version
 
 from sentinelsat.sentinel import (
     SentinelAPI,
-    SentinelAPIError,
     geojson_to_wkt,
     read_geojson,
     placename_to_wkt,
@@ -26,6 +18,9 @@ from sentinelsat.sentinel import (
 )
 
 from sentinelsat.exceptions import InvalidKeyError
+
+
+json_parse_exception = json.decoder.JSONDecodeError
 
 logger = logging.getLogger("sentinelsat")
 

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -231,7 +231,7 @@ def cli(
         search_kwargs["cloudcoverpercentage"] = (0, cloud)
 
     if query is not None:
-        search_kwargs.update((x.split("=") for x in query))
+        search_kwargs.update(x.split("=") for x in query)
 
     if location is not None:
         wkt, info = placename_to_wkt(location)
@@ -308,7 +308,7 @@ def cli(
         if len(failed_downloads) > 0:
             with open(os.path.join(path, "corrupt_scenes.txt"), "w") as outfile:
                 for failed_id in failed_downloads:
-                    outfile.write("%s : %s\n" % (failed_id, products[failed_id]["title"]))
+                    outfile.write("{} : {}\n".format(failed_id, products[failed_id]["title"]))
     else:
         for product_id, props in products.items():
             if uuid is None:

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -20,8 +20,7 @@ import geojson
 import geomet.wkt
 import html2text
 import requests
-from six import string_types, raise_from
-from six.moves.urllib.parse import urljoin, quote_plus
+from urllib.parse import urljoin, quote_plus
 from tqdm import tqdm
 
 from sentinelsat.exceptions import (
@@ -245,7 +244,7 @@ class SentinelAPI:
 
         for attr, value in sorted(keywords.items()):
             # Escape spaces, where appropriate
-            if isinstance(value, string_types):
+            if isinstance(value, str):
                 value = value.strip()
                 if not any(
                     value.startswith(s[0]) and value.endswith(s[1])
@@ -260,11 +259,11 @@ class SentinelAPI:
                 # Automatically format date-type attributes
                 if isinstance(value, set):
                     value = "({})".format(" OR ".join(sorted(map(format_query_date, value))))
-                elif isinstance(value, string_types) and " TO " in value:
+                elif isinstance(value, str) and " TO " in value:
                     # This is a string already formatted as a date interval,
                     # e.g. '[NOW-1DAY TO NOW]'
                     pass
-                elif not isinstance(value, string_types) and len(value) == 2:
+                elif not isinstance(value, str) and len(value) == 2:
                     value = (format_query_date(value[0]), format_query_date(value[1]))
                 else:
                     raise ValueError(
@@ -1324,7 +1323,7 @@ def format_query_date(in_date):
         return "*"
     if isinstance(in_date, (datetime, date)):
         return in_date.strftime("%Y-%m-%dT%H:%M:%SZ")
-    elif not isinstance(in_date, string_types):
+    elif not isinstance(in_date, str):
         raise ValueError("Expected a string or a datetime object. Received {}.".format(in_date))
 
     in_date = in_date.strip()
@@ -1410,7 +1409,7 @@ def _check_scihub_response(response, test_json=True, query_string=None):
 
         # Suppress "During handling of the above exception..." message
         # 'raise error from None' with Python 2 compatibility
-        raise_from(error, None)
+        raise error from None
 
 
 def _format_order_by(order_by):
@@ -1481,7 +1480,7 @@ def _parse_opensearch_response(products):
         for key in prod:
             if key == "id":
                 continue
-            if isinstance(prod[key], string_types):
+            if isinstance(prod[key], str):
                 product_dict[key] = prod[key]
             else:
                 properties = prod[key]

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
-
 import concurrent.futures
 import hashlib
 import itertools
@@ -227,7 +224,7 @@ class SentinelAPI:
             raise ValueError("Incorrect AOI relation provided ({})".format(area_relation))
 
         # Check for duplicate keywords
-        kw_lower = set(x.lower() for x in keywords)
+        kw_lower = {x.lower() for x in keywords}
         if (
             len(kw_lower) != len(keywords)
             or (date is not None and "beginposition" in kw_lower)
@@ -1298,7 +1295,7 @@ def geojson_to_wkt(geojson_obj, feature_number=0, decimals=4):
 
 
 def format_query_date(in_date):
-    """
+    r"""
     Format a date, datetime or a YYYYMMDD string input as YYYY-MM-DDThh:mm:ssZ
     or validate a date string as suitable for the full text search interface and return it.
 
@@ -1364,17 +1361,17 @@ def _check_scihub_response(response, test_json=True, query_string=None):
         msg = None
         try:
             msg = response.headers["cause-message"]
-        except:
+        except Exception:
             try:
                 msg = response.json()["error"]["message"]["value"]
-            except:
+            except Exception:
                 if not response.text.strip().startswith("{"):
                     try:
                         h = html2text.HTML2Text()
                         h.ignore_images = True
                         h.ignore_anchors = True
                         msg = h.handle(response.text).strip()
-                    except:
+                    except Exception:
                         pass
 
         if msg is None:
@@ -1469,8 +1466,10 @@ def _parse_opensearch_response(products):
     """
 
     converters = {"date": _parse_iso_date, "int": int, "long": int, "float": float, "double": float}
+
     # Keep the string type by default
-    default_converter = lambda x: x
+    def default_converter(x):
+        return x
 
     output = OrderedDict()
     for prod in products:

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,12 @@ setup(
     long_description=long_description,
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Utilities",
     ],
@@ -34,7 +36,6 @@ setup(
     zip_safe=False,
     install_requires=open("requirements.txt").read().splitlines(),
     extras_require={
-        ":python_version == '2.7'": ["futures"],
         "dev": [
             "pandas",
             "geopandas",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def vcr(vcr):
         return request
 
     def scrub_response(response):
-        ignore = set(
+        ignore = {
             x.lower()
             for x in [
                 "Authorization",
@@ -47,7 +47,7 @@ def vcr(vcr):
                 "Expires",
                 "Transfer-Encoding",
             ]
-        )
+        }
         for header in list(response["headers"]):
             if header.lower() in ignore or header.lower().startswith("access-control"):
                 del response["headers"][header]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 from contextlib import contextmanager
+from functools import partialmethod
 from test.support import EnvironmentVarGuard
 
 import pytest
@@ -11,19 +12,6 @@ from click.testing import CliRunner
 
 from sentinelsat import SentinelAPI, InvalidChecksumError, QuerySyntaxError
 from sentinelsat.scripts.cli import cli
-
-try:  # Python 3.5 and greater import
-    from functools import partialmethod
-except ImportError:  # Older versions of Python, including 2.7
-    # solution taken from https://gist.github.com/carymrobbins/8940382
-
-    from functools import partial
-
-    class partialmethod(partial):
-        def __get__(self, instance, owner):
-            if instance is None:
-                return self
-            return partial(self.func, instance, *(self.args or ()), **(self.keywords or {}))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 import hashlib
-import sys
 
 import pytest
 import requests

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -32,7 +32,6 @@ def test_checksumming_progressbars(capsys, fixture_path):
 
 @pytest.mark.vcr
 @pytest.mark.scihub
-@pytest.mark.skipif(sys.version_info[0] < 3, reason="ignored for Python 2.7")
 def test_unicode_support(api):
     test_str = "٩(●̮̮̃•̃)۶:"
 

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -138,7 +138,7 @@ def test_api_query_format():
     query = SentinelAPI.format_query(wkt, (last_24h, now))
     assert (
         query
-        == "beginPosition:[%s TO %s] " % (last_24h, format_query_date(now))
+        == "beginPosition:[{} TO {}] ".format(last_24h, format_query_date(now))
         + 'footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))"'
     )
 


### PR DESCRIPTION
This PR drops support to Python 2 and modernize a little bit the code (the ``pyupgrade`` tool has been used for that).
Also the ``six`` library is no longer necessary of course. It has been removed form dependencies.