### PR TITLE
Add streaming option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,4 +33,4 @@ Contributors
 * `@yepremyana <https://github.com/yepremyana>`_
 * Sarah Floris `@sdf94 <https://github.com/sdf94>`_
 * Thomas Young-Audet `@thomas-youngaudet <https://github.com/thomasyoung-audet>`_
-
+* Florian Fichtner `@fwfichtner <https://github.com/fwfichtner>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 * Added CLI support for ``--geometry`` input as a string (#381 @thomasyoung-audet)
 * Download quicklooks directly with the CLI flag ``--quicklook`` (#361 @mackland)
 * Added ``setinelsat/__main__.py`` (#412 @avalentino)
+* Added ``get_stream()`` (#430 @fwfichtner)
 
 
 Changed

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1253,7 +1253,7 @@ class SentinelAPI:
         product_info = self.get_product_odata(id)
         if not product_info["Online"]:
             raise NotImplementedError("Product is offline, no retrieval implemented.")
-        r = requests.get(
+        r = self.session.get(
             product_info["url"],
             stream=True,
             auth=self.session.auth,

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1237,6 +1237,29 @@ class SentinelAPI:
         )
         product["quicklook_url"] = url
 
+    def get_stream(self, id):
+        """Exposes requests response ready to stream product to e.g. S3.
+
+        Parameters
+        ----------
+        id : string
+            UUID of the product, e.g. 'a8dd0cfd-613e-45ce-868c-d79177b916ed'
+
+        Returns
+        -------
+        tuple:
+            raw socket response from server, contains product's info as returned by get_product_info()
+        """
+        product_info = self.get_product_odata(id)
+        if not product_info["Online"]:
+            raise NotImplementedError("Product is offline, no retrieval implemented.")
+        r = requests.get(
+            product_info["url"],
+            stream=True,
+            auth=self.session.auth,
+        )
+        return r.raw, product_info
+
 
 def read_geojson(geojson_file):
     """Read a GeoJSON file into a GeoJSON object."""

--- a/tests/fixtures/vcr_cassettes/test_get_stream.yaml
+++ b/tests/fixtures/vcr_cassettes/test_get_stream.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - sentinelsat/0.14
+    method: GET
+    uri: https://scihub.copernicus.eu/apihub/odata/v1/Products('1f62a176-c980-41dc-b3a1-c735d660c910')?$format=json
+  response:
+    body:
+      string: '{"d":{"__metadata":{"id":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')","uri":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')","type":"DHuS.Product","content_type":"application/octet-stream","media_src":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')/$value","edit_media":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')/$value"},"Id":"1f62a176-c980-41dc-b3a1-c735d660c910","Name":"S1A_WV_OCN__2SSH_20150603T092625_20150603T093332_006207_008194_521E","ContentType":"application/octet-stream","ContentLength":"130006","ChildrenNumber":"0","Value":null,"CreationDate":"\/Date(1560925272977)\/","IngestionDate":"\/Date(1447779361826)\/","ModificationDate":"\/Date(1617722052681)\/","EvictionDate":null,"Online":true,"OnDemand":false,"ContentDate":{"__metadata":{"type":"DHuS.TimeRange"},"Start":"\/Date(1433323584921)\/","End":"\/Date(1433324013345)\/"},"Checksum":{"__metadata":{"type":"DHuS.Checksum"},"Algorithm":"MD5","Value":"eae42f27c917e1b6c9154a5be44a4eb6"},"ContentGeometry":"<gml:Polygon
+        srsName=\"http://www.opengis.net/gml/srs/epsg.xml#4326\" xmlns:gml=\"http://www.opengis.net/gml\">   <gml:outerBoundaryIs>      <gml:LinearRing>         <gml:coordinates>42.260288,-47.310867
+        42.298096,-47.558411 42.476940,-47.508129 42.439095,-47.259823 42.260288,-47.310867</gml:coordinates>      </gml:LinearRing>   </gml:outerBoundaryIs></gml:Polygon>","Products":{"__deferred":{"uri":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')/Products"}},"Nodes":{"__deferred":{"uri":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')/Nodes"}},"Attributes":{"__deferred":{"uri":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')/Attributes"}},"Class":{"__deferred":{"uri":"https://scihub.copernicus.eu/apihub/odata/v1/Products(''1f62a176-c980-41dc-b3a1-c735d660c910'')/Class"}}}}'
+    headers:
+      content-length:
+      - '2089'
+      content-type:
+      - application/json
+      dataserviceversion:
+      - '2.0'
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://scihub.copernicus.eu/apihub/odata/v1/Products('1f62a176-c980-41dc-b3a1-c735d660c910')/$value
+  response:
+    body: {}
+    headers:
+      accept-ranges:
+      - bytes
+      content-disposition:
+      - inline;filename="S1A_WV_OCN__2SSH_20150603T092625_20150603T093332_006207_008194_521E.zip"
+      content-length:
+      - '130006'
+      content-range:
+      - bytes 0-130005/130006
+      content-type:
+      - application/octet-stream
+      dataserviceversion:
+      - '2.0'
+      etag:
+      - 03f5e428062ed6554b1c8936c02f5334
+      last-modified:
+      - Wed, 19 Jun 2019 06:21:12 UTC
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/vcr_cassettes/test_get_stream.yaml
+++ b/tests/fixtures/vcr_cassettes/test_get_stream.yaml
@@ -49,7 +49,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - sentinelsat/0.14
     method: GET
     uri: https://scihub.copernicus.eu/apihub/odata/v1/Products('1f62a176-c980-41dc-b3a1-c735d660c910')/$value
   response:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -7,6 +7,8 @@ There are two minor issues to keep in mind when recording unit tests VCRs.
 2. dhus and apihub have different md5 hashes for products with the same UUID.
 
 """
+import shutil
+
 import py.path
 import pytest
 import requests_mock
@@ -318,8 +320,9 @@ def test_get_stream(api, tmpdir, smallest_online_products):
     raw, product_info = api.get_stream(uuid)
     assert product_info["title"] == filename
     with open(expected_path, "wb") as f:
-        f.write(raw.data)
+        shutil.copyfileobj(raw, f)
+
     assert product_info["size"] == expected_path.size()
-    assert product_info["md5"].lower() == expected_path.computehash("md5")
+    assert api._md5_compare(expected_path, product_info["md5"])
 
     tmpdir.remove()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -306,3 +306,20 @@ def test_download_quicklook_invalid_id(api):
     with pytest.raises(SentinelAPIError) as excinfo:
         api.download_quicklook(uuid)
     assert "Invalid key" in excinfo.value.msg
+
+
+@pytest.mark.vcr
+@pytest.mark.scihub
+def test_get_stream(api, tmpdir, smallest_online_products):
+    uuid = smallest_online_products[0]["id"]
+    filename = smallest_online_products[0]["title"]
+    expected_path = tmpdir.join(filename + ".zip")
+
+    raw, product_info = api.get_stream(uuid)
+    assert product_info["title"] == filename
+    with open(expected_path, "wb") as f:
+        f.write(raw.data)
+    assert product_info["size"] == expected_path.size()
+    assert product_info["md5"].lower() == expected_path.computehash("md5")
+
+    tmpdir.remove()


### PR DESCRIPTION
As discussed in https://github.com/sentinelsat/sentinelsat/issues/396 and https://github.com/dlr-eoc/ukis-pysat/pull/132 it could be a useful addition to allow the user to get a `requests` response object ready for streaming with a new method.

I opted not to handle any LTA triggers for now. For the test I had to adapt the checksum manually, because the file I got had another one. That's weird, but I did not want to adapt other tests or recordings as well.