### PR TITLE
Recommend apihub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Python Library
   from datetime import date
 
   # connect to the API
-  api = SentinelAPI('user', 'password', 'https://scihub.copernicus.eu/dhus')
+  api = SentinelAPI('user', 'password', 'https://scihub.copernicus.eu/apihub')
 
   # download single scene by known product id
   api.download(<product_id>)
@@ -133,7 +133,7 @@ orbit, for the year 2015.
 
   sentinelsat -u <user> -p <password> -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending" \
-  --url "https://scihub.copernicus.eu/dhus"
+  --url "https://scihub.copernicus.eu/apihub"
 
 Username, password and DHuS URL can also be set via environment variables for convenience.
 
@@ -142,7 +142,7 @@ Username, password and DHuS URL can also be set via environment variables for co
   # same result as query above
   export DHUS_USER="<user>"
   export DHUS_PASSWORD="<password>"
-  export DHUS_URL="https://scihub.copernicus.eu/dhus"
+  export DHUS_URL="https://scihub.copernicus.eu/apihub"
 
   sentinelsat -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending"

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -57,7 +57,7 @@ orbit for the year 2015.
 
   sentinelsat -u <user> -p <password> -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending" \
-  --url "https://scihub.copernicus.eu/dhus"
+  --url "https://scihub.copernicus.eu/apihub"
 
 Download a single Sentinel-1 GRDH scene covering Santa Claus Village in Finland
 on Christmas Eve 2015.


### PR DESCRIPTION
As mentioned in many issues, the recommended SciHub endpoint for machine access is `/apihub`, NOT `/dhus`.

For a while `/dhus` was a convenient drop-in replacement when user credential changes (including new sign-ups) had not propagated to `/apihub` yet. But the Copernicus Open Access Hub now prevents that by heavily rate-limiting access to `/dhus`.

In short, we should not anywhere recommend that users call `/apihub` on the Copernicus Open Access Hub anymore.