### PR TITLE
Add automatic publishing to PyPI via CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [ released ]
+    types: [ published, released ]
 jobs:
   publish:
     name: Publish to PyPI
@@ -30,6 +30,9 @@ jobs:
         run: ls dist/
 
       - name: Publish to PyPI
+        # Do the actual publishing only for releases, not pre-releases.
+        # This can be used to test that the previous steps work.
+        if: ${{ github.event.action == 'released' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,8 @@ jobs:
       - name: Install prereqs
         run: python -m pip install -U build wheel setuptools
 
-      - name: Test
-        run: |
-          python -m pip install .[dev]
-          pytest tests
-
       - name: Build packages
-        run: |
-          rm -rf dist/
-          python -m build
+        run: python -m build
 
       - name: Inspect
         run: ls dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish
+on:
+  release:
+    types: [ released ]
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install prereqs
+        run: python -m pip install -U build wheel setuptools
+
+      - name: Test
+        run: |
+          python -m pip install .[dev]
+          pytest tests
+
+      - name: Build packages
+        run: |
+          rm -rf dist/
+          python -m build
+
+      - name: Inspect
+        run: ls dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -137,16 +137,7 @@ Documentation is automatically built after each merge in the ``main`` branch usi
 
 A new Zenodo DOI is created automatically with every Github release using the Zenodo webhook.
 
-A new package is release on PyPi with the following commands.
-
-.. code-block:: console
-
-  pip install rstcheck twine
-  rstcheck README.rst CONTRIBUTE.rst AUTHORS.rst
-  python setup.py sdist bdist_wheel --universal
-  twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-  twine upload dist/*
-
+A new version is published to PyPI automatically via CI on every GitHub release.
 
 
 License


### PR DESCRIPTION
This workflow gets triggered whenever a release is created on GitHub and will automatically build and publish the sdist and wheel packages to PyPI. 

The `PYPI_API_TOKEN` secret will have to be provided in the project settings first, of course. @Fernerkundung can you add it to the project, please?