### PR TITLE
Register pytest marks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,12 @@ exclude = '''
   )/
 )
 '''
+
+[tool.pytest.ini_options]
+markers = [
+    "scihub: marks tests requiring Open Access Hub / SciHub access",
+    "pandas",
+    "geopandas",
+    "mock_api",
+    "fast"
+]


### PR DESCRIPTION
In CI, we get a lot of warnings about our custom pytest marks not being registered. This PR attempts at fixing that https://docs.pytest.org/en/stable/mark.html