### PR TITLE
Change of API Hub URL (28 April 2021) 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Python Library
   from datetime import date
 
   # connect to the API
-  api = SentinelAPI('user', 'password', 'https://scihub.copernicus.eu/apihub')
+  api = SentinelAPI('user', 'password', 'https://apihub.copernicus.eu/apihub/')
 
   # download single scene by known product id
   api.download(<product_id>)
@@ -133,7 +133,7 @@ orbit, for the year 2015.
 
   sentinelsat -u <user> -p <password> -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending" \
-  --url "https://scihub.copernicus.eu/apihub"
+  --url "https://apihub.copernicus.eu/apihub"
 
 Username, password and DHuS URL can also be set via environment variables for convenience.
 
@@ -142,7 +142,7 @@ Username, password and DHuS URL can also be set via environment variables for co
   # same result as query above
   export DHUS_USER="<user>"
   export DHUS_PASSWORD="<password>"
-  export DHUS_URL="https://scihub.copernicus.eu/apihub"
+  export DHUS_URL="https://apihub.copernicus.eu/apihub"
 
   sentinelsat -g <search_polygon.geojson> -s 20150101 -e 20151231 -d \
   --producttype SLC -q "orbitdirection=Descending"
@@ -163,7 +163,7 @@ Options
    * - 
      - --url
      - TEXT
-     - Define another API URL. Default URL is 'https://scihub.copernicus.eu/apihub/'.
+     - Define another API URL. Default URL is 'https://apihub.copernicus.eu/apihub/'.
    * - -s
      - --start
      - TEXT

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -46,7 +46,7 @@ class SentinelAPI:
         set to None to use ~/.netrc
     api_url : string, optional
         URL of the DataHub
-        defaults to 'https://scihub.copernicus.eu/apihub'
+        defaults to 'https://apihub.copernicus.eu/apihub/'
     show_progressbars : bool
         Whether progressbars should be shown or not, e.g. during download. Defaults to True.
     timeout : float or tuple, optional
@@ -72,7 +72,7 @@ class SentinelAPI:
         self,
         user,
         password,
-        api_url="https://scihub.copernicus.eu/apihub/",
+        api_url='https://apihub.copernicus.eu/apihub/',
         show_progressbars=True,
         timeout=None,
     ):


### PR DESCRIPTION
https://scihub.copernicus.eu/news/News00868

```
Open Access Hub users are informed that the API Hub URL has changed from 
https://scihub.copernicus.eu/apihub/ to 
https://apihub.copernicus.eu/apihub/ as of 28 April 2021.
The former URL will not be dismissed. An automatic redirection to the new URL is performed transparently. 
```