### PR TITLE
Use HEAD for online status checks, fix inconsistent application of timeout param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,11 +51,13 @@ Deprecated
 
 Fixed
 ~~~~~
-* fix location information for Nominatim bounding box queries (#384)
+* Fix location information for Nominatim bounding box queries (#384)
 * Get file name extension more reliably from either header or internal logic (in particular for S5 products #270) (#378 @valgur)
 * Updated the API Hub URL to `https://apihub.copernicus.eu/apihub/`.
 * Server-side error info has become much more detailed and the client code has been updated to correctly handle that.
 * ``check_existing()`` now determines the filename correctly for Sentinel-5 products. (@valgur #452)
+* Fix accidental downloading of the whole product in memory when the product is actually available despite being marked
+  as offline in its metadata. (#386, #421, #454 @lucadelu)
 
 Development Changes
 ~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ Fixed
 * ``check_existing()`` now determines the filename correctly for Sentinel-5 products. (@valgur #452)
 * Fix accidental downloading of the whole product in memory when the product is actually available despite being marked
   as offline in its metadata. (#386, #421, #454 @lucadelu)
+* Fixed timeout not being used in some queries. (#454 @valgur)
 
 Development Changes
 ~~~~~~~~~~~~~~~~~~~

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -641,23 +641,23 @@ class SentinelAPI:
         -----
         https://scihub.copernicus.eu/userguide/LongTermArchive
         """
-        with self.session.get(url, auth=self.session.auth, timeout=self.timeout) as r:
-            # check https://scihub.copernicus.eu/userguide/LongTermArchive#HTTP_Status_codes
-            if r.status_code == 202:
-                self.logger.debug("Accepted for retrieval")
-            elif r.status_code == 403:
-                self.logger.debug("Requests exceed user quota")
-            elif r.status_code == 503:
-                self.logger.error("Request not accepted")
-                raise SentinelAPILTAError("Request for retrieval from LTA not accepted", r)
-            elif r.status_code == 500:
-                # should not happen
-                self.logger.error("Trying to download an offline product")
-                raise SentinelAPILTAError("Trying to download an offline product", r)
-            else:
-                self.logger.error("Unexpected response %s from SciHub", r.status_code)
-                raise SentinelAPILTAError("Unexpected response from SciHub", r)
-            return r.status_code
+        r = self.session.head(url, auth=self.session.auth, timeout=self.timeout)
+        # check https://scihub.copernicus.eu/userguide/LongTermArchive#HTTP_Status_codes
+        if r.status_code == 202:
+            self.logger.debug("Accepted for retrieval")
+        elif r.status_code == 403:
+            self.logger.debug("Requests exceed user quota")
+        elif r.status_code == 503:
+            self.logger.error("Request not accepted")
+            raise SentinelAPILTAError("Request for retrieval from LTA not accepted", r)
+        elif r.status_code == 500:
+            # should not happen
+            self.logger.error("Trying to download an offline product")
+            raise SentinelAPILTAError("Trying to download an offline product", r)
+        else:
+            self.logger.error("Unexpected response %s from SciHub", r.status_code)
+            raise SentinelAPILTAError("Unexpected response from SciHub", r)
+        return r.status_code
 
     def download_all(
         self,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -68,7 +68,7 @@ def test_trigger_lta_success(http_status_code):
     request_url = "https://apihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/$value"
 
     with requests_mock.mock() as rqst:
-        rqst.get(request_url, status_code=http_status_code)
+        rqst.head(request_url, status_code=http_status_code)
         assert api._trigger_offline_retrieval(request_url) == http_status_code
 
 
@@ -86,7 +86,7 @@ def test_trigger_lta_failed(http_status_code):
     request_url = "https://apihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/$value"
 
     with requests_mock.mock() as rqst:
-        rqst.get(request_url, status_code=http_status_code)
+        rqst.head(request_url, status_code=http_status_code)
         with pytest.raises(SentinelAPILTAError):
             api._trigger_offline_retrieval(request_url)
 


### PR DESCRIPTION
Fixes #386 and extends the #421 PR. 

I also noticed that the `self.timeout` parameter was used somewhat inconsistently across queries and fixed that by making it a default session parameter. Setting `auth=self.session.auth` for all queries no longer seems necessary either - all tests pass without it and the CLI works as expected.