### PR TITLE
Drop -d as an alias for --debug in CLI

### DIFF
--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -162,7 +162,6 @@ class CommaSeparatedString(click.ParamType):
 )
 @click.option(
     "--debug",
-    "-d",
     is_flag=True,
     help="Print debug log messages.",
 )


### PR DESCRIPTION
`-d` is already used with `--download`.

Fixes #455.