### PR TITLE
clean_cassettes.sh: do not delete *.yml in fixtures

### DIFF
--- a/tests/fixtures/clean_cassettes.sh
+++ b/tests/fixtures/clean_cassettes.sh
@@ -3,9 +3,7 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 (
-  cd "$SCRIPT_DIR"
-  rm ./*.yml
-  cd vcr_cassettes
+  cd "$SCRIPT_DIR/vcr_cassettes"
   ls -Q ./*.yaml | grep -v test_info_cli.yaml | xargs rm
   cd data
   rm ./* 


### PR DESCRIPTION
These are meant to stay the same over time unlike cassettes and their change indicates a likely regression.