### PR TITLE
Avoid guessing of the filename for LTA products

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,7 +59,7 @@ Deprecated
 Fixed
 ~~~~~
 * Fix location information for Nominatim bounding box queries (#384)
-* Get file name extension more reliably from either header or internal logic (in particular for S5 products #270) (#378 @valgur)
+* Get file name extension more reliably from either the HTTP header or an OData attribute. (#378, #472 @valgur)
 * Updated the API Hub URL to `https://apihub.copernicus.eu/apihub/`.
 * Server-side error info has become much more detailed and the client code has been updated to correctly handle that.
 * ``check_existing()`` now determines the filename correctly for Sentinel-5 products. (@valgur #452)

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -611,7 +611,10 @@ class SentinelAPI:
             )
             _check_scihub_response(req, test_json=False)
             filename = req.text
-            return filename.replace(".SAFE", ".zip")
+            # This should cover all currently existing file types: .SAFE, .SEN3, .nc and .EOF
+            filename = filename.replace(".SAFE", ".zip")
+            filename = filename.replace(".SEN3", ".zip")
+            return filename
         req = self.session.head(product_info["url"])
         _check_scihub_response(req, test_json=False)
         cd = req.headers.get("Content-Disposition")

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -607,10 +607,10 @@ class SentinelAPI:
     def _get_filename(self, product_info):
         if not product_info["Online"]:
             req = self.session.get(
-                product_info["url"].replace("$value", "Attributes('Filename')?$format=json")
+                product_info["url"].replace("$value", "Attributes('Filename')/Value/$value")
             )
-            _check_scihub_response(req)
-            filename = req.json()["d"]["Value"]
+            _check_scihub_response(req, test_json=False)
+            filename = req.text
             return filename.replace(".SAFE", ".zip")
         req = self.session.head(product_info["url"])
         _check_scihub_response(req, test_json=False)

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -605,17 +605,17 @@ class SentinelAPI:
         shutil.move(temp_path, path)
 
     def _get_filename(self, product_info):
-        # Default guess, mostly for archived products
-        filename = product_info["title"] + (
-            ".nc" if product_info["title"].startswith("S5P") else ".zip"
-        )
         if not product_info["Online"]:
-            return filename
+            req = self.session.get(
+                product_info["url"].replace("$value", "Attributes('Filename')?$format=json")
+            )
+            _check_scihub_response(req)
+            filename = req.json()["d"]["Value"]
+            return filename.replace(".SAFE", ".zip")
         req = self.session.head(product_info["url"])
         _check_scihub_response(req, test_json=False)
         cd = req.headers.get("Content-Disposition")
-        if cd and "=" in cd:
-            filename = cd.split("=", 1)[1].strip('"')
+        filename = cd.split("=", 1)[1].strip('"')
         return filename
 
     def _trigger_offline_retrieval(self, url):

--- a/tests/fixtures/vcr_cassettes/test_download_all_lta.yaml
+++ b/tests/fixtures/vcr_cassettes/test_download_all_lta.yaml
@@ -386,4 +386,34 @@ interactions:
     status:
       code: 202
       message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - sentinelsat/0.14
+    method: GET
+    uri: https://apihub.copernicus.eu/apihub/odata/v1/Products('5f1595cf-8522-4ac2-babc-68dd892d8624')/Attributes('Filename')?$format=json
+  response:
+    body:
+      string: '{"d":{"__metadata":{"id":"https://apihub.copernicus.eu/apihub/odata/v1/Products(''5f1595cf-8522-4ac2-babc-68dd892d8624'')/Attributes(''Filename'')","uri":"https://apihub.copernicus.eu/apihub/odata/v1/Products(''5f1595cf-8522-4ac2-babc-68dd892d8624'')/Attributes(''Filename'')","type":"DHuS.Attribute"},"Id":"Filename","Name":"Filename","ContentType":"text/plain","ContentLength":"99","Value":"S3A_OL_2_LFR____20161128T001516_20161128T001516_20180320T053612_0000_011_244_4680_LR2_R_NT_002.SEN3","Category":"summary"}}'
+    headers:
+      content-length:
+      - '508'
+      content-type:
+      - application/json
+      dataserviceversion:
+      - '2.0'
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/vcr_cassettes/test_download_all_lta.yaml
+++ b/tests/fixtures/vcr_cassettes/test_download_all_lta.yaml
@@ -398,15 +398,15 @@ interactions:
       User-Agent:
       - sentinelsat/0.14
     method: GET
-    uri: https://apihub.copernicus.eu/apihub/odata/v1/Products('5f1595cf-8522-4ac2-babc-68dd892d8624')/Attributes('Filename')?$format=json
+    uri: https://apihub.copernicus.eu/apihub/odata/v1/Products('5f1595cf-8522-4ac2-babc-68dd892d8624')/Attributes('Filename')/Value/$value
   response:
     body:
-      string: '{"d":{"__metadata":{"id":"https://apihub.copernicus.eu/apihub/odata/v1/Products(''5f1595cf-8522-4ac2-babc-68dd892d8624'')/Attributes(''Filename'')","uri":"https://apihub.copernicus.eu/apihub/odata/v1/Products(''5f1595cf-8522-4ac2-babc-68dd892d8624'')/Attributes(''Filename'')","type":"DHuS.Attribute"},"Id":"Filename","Name":"Filename","ContentType":"text/plain","ContentLength":"99","Value":"S3A_OL_2_LFR____20161128T001516_20161128T001516_20180320T053612_0000_011_244_4680_LR2_R_NT_002.SEN3","Category":"summary"}}'
+      string: S3A_OL_2_LFR____20161128T001516_20161128T001516_20180320T053612_0000_011_244_4680_LR2_R_NT_002.SEN3
     headers:
       content-length:
-      - '508'
+      - '99'
       content-type:
-      - application/json
+      - text/plain;charset=utf-8
       dataserviceversion:
       - '2.0'
       pragma:


### PR DESCRIPTION
For LTA products we currently pretty much guess the filename extension. This is an issue for new or non-standard products like the newly-added GNSS products (#441). This can be made more reliable by fetching the `Filename` attribute from the extended OData metadata and replacing `.SAFE` with `.zip` for the common case.