### PR TITLE
Add --timeout, set default timeout to 60 seconds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ CLI changes
 * Download quicklooks directly with the CLI flag ``--quicklook`` (#361 @mackland)
 * Got rid of the special handling of ``--uuid`` and ``--name`` CLI arguments. The product IDs are now simply passed to ``api.query()`` as a set.
   As a result they no longer ignore the date range arguments (fixes #387). (#390 @valgur)
+* Added ``--timeout`` option with a default value of 60 seconds to avoid waiting indefinitely for a response. (#475 @valgur)
 
 Added
 ~~~~~
@@ -53,6 +54,7 @@ Changed
 * Gracefully handle cancelled futures. (#448 @avalentino)
 * Use the HTTP status instead of OData metadata to determine the online status of a product when downloading. 
   This is a workaround for the rare server-side bug of the OData info for the online status being incorrect (#467). (#469 @valgur) 
+* Set the default query timeout to 60 seconds to avoid waiting indefinitely for a response. (#475 @valgur)
 
 Deprecated
 ~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,10 @@ Options
      - TEXT
      - Glob pattern to filter files (within each product) to be excluded from the downloaded.
    * -  
+     - --timeout
+     - FLOAT
+     - How long to wait for a DataHub response (in seconds, default 60 sec).
+   * -  
      - --info
      -  
      - Display DHuS server information.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -187,6 +187,10 @@ Options
     Glob pattern to filter files (within each product) to be excluded
     from the downloaded.
 
+.. option:: --timeout <seconds>
+
+    How long to wait for a DataHub response (in seconds, default 60 sec).
+
 .. option:: --info
 
     Display DHuS server information.

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -158,8 +158,7 @@ def validate_query_param(ctx, param, kwargs):
     "--timeout",
     type=float,
     default=60,
-    show_default=True,
-    help="How long to wait for DataHub response (in seconds)",
+    help="How long to wait for a DataHub response (in seconds, default 60 sec).",
 )
 @click.option(
     "--debug",

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -155,6 +155,13 @@ def validate_query_param(ctx, param, kwargs):
     """,
 )
 @click.option(
+    "--timeout",
+    type=float,
+    default=60,
+    show_default=True,
+    help="How long to wait for DataHub response (in seconds)",
+)
+@click.option(
     "--debug",
     is_flag=True,
     help="Print debug log messages.",
@@ -195,6 +202,7 @@ def cli(
     order_by,
     location,
     limit,
+    timeout,
     debug,
     include_pattern,
     exclude_pattern,
@@ -215,7 +223,7 @@ def cli(
         _set_logger_handler("INFO")
 
     if info:
-        api = SentinelProductsAPI(None, None, url)
+        api = SentinelProductsAPI(None, None, url, timeout=timeout)
         ctx = click.get_current_context()
         click.echo("DHuS version: " + api.dhus_version)
         ctx.exit()
@@ -243,7 +251,7 @@ def cli(
             "for environment variables and .netrc support."
         )
 
-    api = SentinelProductsAPI(user, password, url)
+    api = SentinelProductsAPI(user, password, url, timeout=timeout)
 
     search_kwargs = {}
     if sentinel and not (producttype or instrument):

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -48,9 +48,10 @@ class SentinelAPI:
         defaults to 'https://apihub.copernicus.eu/apihub'
     show_progressbars : bool
         Whether progressbars should be shown or not, e.g. during download. Defaults to True.
-    timeout : float or tuple, optional
+    timeout : float or tuple, default 60
         How long to wait for DataHub response (in seconds).
         Tuple (connect, read) allowed.
+        Set to None to wait indefinitely.
 
     Attributes
     ----------
@@ -73,7 +74,7 @@ class SentinelAPI:
         password,
         api_url="https://apihub.copernicus.eu/apihub/",
         show_progressbars=True,
-        timeout=None,
+        timeout=60,
     ):
         self.session = requests.Session()
         if user and password:


### PR DESCRIPTION
Fixes #411.

I also replaced the default of no timeout with a 60 second limit in both the CLI and API, which seems like a saner default to me. I doubt that most users would prefer to have the client hang indefinitely when the server fails to respond.