### PR TITLE
LTA handling improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,19 +27,21 @@ Added
 * New ``sentinelsat/products.py`` module providing a "product nodes" API that
   allows to filter and download only selected files of the requested products
   (#414 @avalentino)
+* Added ``trigger_offline_retrieval()``. (#476 @valgur)
 
 Changed
 ~~~~~~~
 * Replaced ``SentinelAPIError`` exceptions with more specific types:
 
   * ``SentinelAPIError`` -- the parent, catch-all exception. Only used when no other more specific exception can be applied.
-  * ``SentinelAPILTAError`` -- raised when retrieving a product from the Long Term Archive.
   * ``ServerError`` -- raised when the server responded in an unexpected manner, typically due to undergoing maintenance.
   * ``UnauthorizedError`` -- raised when attempting to retrieve a product with incorrect credentials.
   * ``QuerySyntaxError`` -- raised when the query string could not be parsed on the server side.
   * ``QueryLengthError`` -- raised when the query string length was excessively long.
   * ``InvalidKeyError`` -- raised when product with given key was not found on the server.
   * ``InvalidChecksumError`` -- MD5 checksum of a local file does not match the one from the server.
+  * ``LTAError`` -- raised when triggering a retrieval from the Long Term Archive failed.
+  * ``LTATriggered`` -- raised in some cases when the product is offline and retrieval was triggered successfully.
 
   The new exceptions are still subclasses of ``SentinelAPIError`` for backwards compatibility.
   (#285 @valgur, @dwlsalmeida)
@@ -52,7 +54,8 @@ Changed
 * Added stricter checks for empty keyword values in queries, which would cause server-side errors. (#390 @valgur)
 * Gracefully handle cancelled futures. (#448 @avalentino)
 * Use the HTTP status instead of OData metadata to determine the online status of a product when downloading. 
-  This is a workaround for the rare server-side bug of the OData info for the online status being incorrect (#467). (#469 @valgur) 
+  This is a workaround for the rare server-side bug of the OData info for the online status being incorrect (#467). (#469 @valgur)
+* ``download()`` now raises ``LTATriggered`` or ``LTAError`` if the requested product is offline. (#476 @valgur)
 
 Deprecated
 ~~~~~~~~~~

--- a/sentinelsat/__init__.py
+++ b/sentinelsat/__init__.py
@@ -4,7 +4,8 @@ __version__ = "0.14"
 from . import sentinel
 from .exceptions import (
     SentinelAPIError,
-    SentinelAPILTAError,
+    LTAError,
+    LTATriggered,
     ServerError,
     InvalidKeyError,
     QueryLengthError,

--- a/sentinelsat/exceptions.py
+++ b/sentinelsat/exceptions.py
@@ -14,6 +14,8 @@ class SentinelAPIError(Exception):
         self.response = response
 
     def __str__(self):
+        if self.response is None:
+            return self.msg
         if self.response.reason:
             reason = " " + self.response.reason
         else:
@@ -25,10 +27,20 @@ class SentinelAPIError(Exception):
         )
 
 
-class SentinelAPILTAError(SentinelAPIError):
+class LTAError(SentinelAPIError):
     """Error raised when retrieving a product from the Long Term Archive"""
 
     pass
+
+
+class LTATriggered(SentinelAPIError):
+    """Download failed due to product being in the Long Term Archive and retrieval from LTA was triggered"""
+
+    def __init__(self, uuid):
+        self.uuid = uuid
+        super().__init__(
+            f"Product {uuid} is not online. Triggered retrieval from the Long Term Archive."
+        )
 
 
 class ServerError(SentinelAPIError):

--- a/tests/fixtures/vcr_cassettes/test_download_product_nodes.yaml
+++ b/tests/fixtures/vcr_cassettes/test_download_product_nodes.yaml
@@ -140,4 +140,42 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - sentinelsat/0.14
+    method: HEAD
+    uri: https://apihub.copernicus.eu/apihub/odata/v1/Products('1f62a176-c980-41dc-b3a1-c735d660c910')/$value
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-disposition:
+      - inline;filename="S1A_WV_OCN__2SSH_20150603T092625_20150603T093332_006207_008194_521E.zip"
+      content-length:
+      - '213433'
+      content-range:
+      - bytes 0-213432/213433
+      content-type:
+      - application/octet-stream
+      dataserviceversion:
+      - '2.0'
+      etag:
+      - 9eb46e4e31f77f108213e16bb8fbe088
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/vcr_cassettes/test_get_stream.yaml
+++ b/tests/fixtures/vcr_cassettes/test_get_stream.yaml
@@ -70,4 +70,42 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - sentinelsat/0.14
+    method: HEAD
+    uri: https://apihub.copernicus.eu/apihub/odata/v1/Products('1f62a176-c980-41dc-b3a1-c735d660c910')/$value
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-disposition:
+      - inline;filename="S1A_WV_OCN__2SSH_20150603T092625_20150603T093332_006207_008194_521E.zip"
+      content-length:
+      - '213433'
+      content-range:
+      - bytes 0-213432/213433
+      content-type:
+      - application/octet-stream
+      dataserviceversion:
+      - '2.0'
+      etag:
+      - 9eb46e4e31f77f108213e16bb8fbe088
+      pragma:
+      - no-cache
+      server:
+      - Apache-Coyote/1.1
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -16,7 +16,7 @@ import requests_mock
 from flaky import flaky
 
 from sentinelsat import SentinelAPI, make_path_filter
-from sentinelsat.exceptions import InvalidChecksumError, InvalidKeyError, SentinelAPILTAError
+from sentinelsat.exceptions import InvalidChecksumError, InvalidKeyError, LTAError, ServerError
 
 
 @pytest.mark.fast
@@ -53,39 +53,47 @@ def test_dhus_version(dhus_url, version):
 
 @pytest.mark.mock_api
 @pytest.mark.parametrize(
-    "http_status_code",
+    "http_status_code, expected_result",
     [
         # Note: the HTTP status codes have slightly more specific meanings in the LTA API.
-        202,  # Accepted for retrieval - the product offline product will be retrieved from the LTA.
-        403,  # Forbidden - user has exceeded their offline product retrieval quota.
+        # OK - already online
+        (200, False),
+        # Accepted for retrieval - the product offline product will be retrieved from the LTA.
+        (202, True),
     ],
 )
-def test_trigger_lta_success(http_status_code):
+def test_trigger_lta_success(http_status_code, expected_result):
     api = SentinelAPI("mock_user", "mock_password")
-    request_url = "https://apihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/$value"
+    uuid = "8df46c9e-a20c-43db-a19a-4240c2ed3b8b"
 
     with requests_mock.mock() as rqst:
-        rqst.head(request_url, status_code=http_status_code)
-        assert api._trigger_offline_retrieval(request_url) == http_status_code
+        rqst.head(api._get_download_url(uuid), status_code=http_status_code)
+        assert api.trigger_offline_retrieval(uuid) is expected_result
 
 
 @pytest.mark.mock_api
 @pytest.mark.parametrize(
-    "http_status_code",
+    "http_status_code, exception",
     [
         # Note: the HTTP status codes have slightly more specific meanings in the LTA API.
-        503,  # Service Unavailable - request refused since the service is busy handling other requests.
-        500,  # Internal Server Error - attempted to download a sub-element of an offline product.
+        # Forbidden - user has exceeded their offline product retrieval quota.
+        (403, LTAError),
+        # Service Unavailable - request refused since the service is busy handling other requests.
+        (503, LTAError),
+        # Internal Server Error - attempted to download a sub-element of an offline product.
+        (500, ServerError),
+        (555, ServerError),
+        (333, ServerError),
     ],
 )
-def test_trigger_lta_failed(http_status_code):
+def test_trigger_lta_failed(http_status_code, exception):
     api = SentinelAPI("mock_user", "mock_password")
-    request_url = "https://apihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/$value"
+    uuid = "8df46c9e-a20c-43db-a19a-4240c2ed3b8b"
 
     with requests_mock.mock() as rqst:
-        rqst.head(request_url, status_code=http_status_code)
-        with pytest.raises(SentinelAPILTAError):
-            api._trigger_offline_retrieval(request_url)
+        rqst.head(api._get_download_url(uuid), status_code=http_status_code)
+        with pytest.raises(exception):
+            api.trigger_offline_retrieval(uuid)
 
 
 @pytest.mark.vcr
@@ -320,14 +328,15 @@ def test_download_quicklook_invalid_id(api):
 @pytest.mark.vcr
 @pytest.mark.scihub
 def test_get_stream(api, tmpdir, smallest_online_products):
-    uuid = smallest_online_products[0]["id"]
-    filename = smallest_online_products[0]["title"]
+    product_info = smallest_online_products[0]
+    uuid = product_info["id"]
+    filename = product_info["title"]
     expected_path = tmpdir.join(filename + ".zip")
 
-    raw, product_info = api.get_stream(uuid)
+    response = api.get_stream(uuid)
     assert product_info["title"] == filename
     with open(expected_path, "wb") as f:
-        shutil.copyfileobj(raw, f)
+        shutil.copyfileobj(response.raw, f)
 
     assert product_info["size"] == expected_path.size()
     assert api._md5_compare(expected_path, product_info["md5"])


### PR DESCRIPTION
- Converted `trigger_offline_retrieval()` into a public method.
- `trigger_offline_retrieval()` now returns True/False depending on whether the product was triggered or is already online and raises an exception in all other cases.
- renamed `SentinelAPILTAError` to `LTAError`, added `LTATriggered` exception.
- `download()` and `get_stream()` now raise `LTATriggered` exception if the product is offline.
- made `get_stream()` more flexible.