### PR TITLE
Run the weekly live test only in the main sentinelsat/sentinelsat repository

### DIFF
--- a/.github/workflows/live-testing.yaml
+++ b/.github/workflows/live-testing.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   run-live-test:
+    if: ${{ github.repository == 'sentinelsat/sentinelsat' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
I suppose that the "live-testing.yaml" action was not intended to be run on cloned repositories.
Please consider to add the proposed guard.