### PR TITLE
handle 403 error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ CLI changes
 
 Added
 ~~~~~
-* Better handling 403 error in ``trigger_offline_retrieval()`` 
+* Better handling 403 error in `trigger_offline_retrieval()` (`#491 <https://github.com/sentinelsat/sentinelsat/issues/491>`_ `@z4zz <https://github.com/z4zz>`_)
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ CLI changes
 
 Added
 ~~~~~
-* Better handling 403 error in ``trigger_offline_retrieval()``
+* Better handling 403 error in ``trigger_offline_retrieval()`` 
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ CLI changes
 
 Added
 ~~~~~
-* 
+* Better handling 403 error in ``trigger_offline_retrieval()``
 
 Changed
 ~~~~~~~

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -630,10 +630,12 @@ class SentinelAPI:
         elif r.status_code == 202:
             self.logger.debug("Accepted for retrieval")
             return True
-        elif r.status_code == 403 and "concurrent flows" in cause:
-            self.logger.debug("Product is online")
+        elif r.status_code == 403 and cause and "concurrent flows" in cause:
+            # cause: 'An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "username""'
+            self.logger.debug("Product is online but concurrent downloads limit was exceeded")
             return False
         elif r.status_code == 403:
+            # cause: 'User 'username' offline products retrieval quota exceeded (20 fetches max) trying to fetch product PRODUCT_FILENAME (BYTES_COUNT bytes compressed)'
             msg = f"User quota exceeded: {cause}"
             self.logger.error(msg)
             raise LTAError(msg, r)

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -630,6 +630,9 @@ class SentinelAPI:
         elif r.status_code == 202:
             self.logger.debug("Accepted for retrieval")
             return True
+        elif r.status_code == 403 and "concurrent flows" in cause:
+            self.logger.debug("Product is online")
+            return False
         elif r.status_code == 403:
             msg = f"User quota exceeded: {cause}"
             self.logger.error(msg)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -71,12 +71,12 @@ def test_dhus_version(dhus_url, version):
         ),
     ],
 )
-def test_trigger_lta_success(http_status_code, expected_result):
+def test_trigger_lta_success(http_status_code, expected_result, headers):
     api = SentinelAPI("mock_user", "mock_password")
     uuid = "8df46c9e-a20c-43db-a19a-4240c2ed3b8b"
 
     with requests_mock.mock() as rqst:
-        rqst.get(api._get_download_url(uuid), status_code=http_status_code)
+        rqst.get(api._get_download_url(uuid), status_code=http_status_code, headers=headers)
         assert api.trigger_offline_retrieval(uuid) is expected_result
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -78,7 +78,13 @@ def test_trigger_lta_success(http_status_code, expected_result):
     [
         # Note: the HTTP status codes have slightly more specific meanings in the LTA API.
         # Forbidden - user has exceeded their offline product retrieval quota.
-        (403, LTAError, {"cause-message": "User 'mock_user' offline products retrieval quota exceeded (20 fetches max) trying to fetch product S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC (143549851 bytes compressed)"}),
+        (
+            403, 
+            LTAError, 
+            {
+                "cause-message": "User 'mock_user' offline products retrieval quota exceeded (20 fetches max) trying to fetch product S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC (143549851 bytes compressed)"
+            }
+        ),
         # Service Unavailable - request refused since the service is busy handling other requests.
         (503, LTAError, {}),
         # Internal Server Error - attempted to download a sub-element of an offline product.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -66,9 +66,9 @@ def test_dhus_version(dhus_url, version):
             403,
             False,
             {
-                "cause-message":'An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "mock_user"'
+                "cause-message": 'An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "mock_user"'
             },
-        )
+        ),
     ],
 )
 def test_trigger_lta_success(http_status_code, expected_result):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -79,11 +79,11 @@ def test_trigger_lta_success(http_status_code, expected_result):
         # Note: the HTTP status codes have slightly more specific meanings in the LTA API.
         # Forbidden - user has exceeded their offline product retrieval quota.
         (
-            403, 
-            LTAError, 
+            403,
+            LTAError,
             {
                 "cause-message": "User 'mock_user' offline products retrieval quota exceeded (20 fetches max) trying to fetch product S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC (143549851 bytes compressed)"
-            }
+            },
         ),
         # Service Unavailable - request refused since the service is busy handling other requests.
         (503, LTAError, {}),

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -74,25 +74,25 @@ def test_trigger_lta_success(http_status_code, expected_result):
 
 @pytest.mark.mock_api
 @pytest.mark.parametrize(
-    "http_status_code, exception",
+    "http_status_code, exception, headers",
     [
         # Note: the HTTP status codes have slightly more specific meanings in the LTA API.
         # Forbidden - user has exceeded their offline product retrieval quota.
-        (403, LTAError),
+        (403, LTAError, {"cause-message": "User 'mock_user' offline products retrieval quota exceeded (20 fetches max) trying to fetch product S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC (143549851 bytes compressed)"}),
         # Service Unavailable - request refused since the service is busy handling other requests.
-        (503, LTAError),
+        (503, LTAError, {}),
         # Internal Server Error - attempted to download a sub-element of an offline product.
-        (500, ServerError),
-        (555, ServerError),
-        (333, ServerError),
+        (500, ServerError, {}),
+        (555, ServerError, {}),
+        (333, ServerError, {}),
     ],
 )
-def test_trigger_lta_failed(http_status_code, exception):
+def test_trigger_lta_failed(http_status_code, exception, headers):
     api = SentinelAPI("mock_user", "mock_password")
     uuid = "8df46c9e-a20c-43db-a19a-4240c2ed3b8b"
 
     with requests_mock.mock() as rqst:
-        rqst.get(api._get_download_url(uuid), status_code=http_status_code)
+        rqst.get(api._get_download_url(uuid), status_code=http_status_code, headers=headers)
         with pytest.raises(exception):
             api.trigger_offline_retrieval(uuid)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -53,14 +53,22 @@ def test_dhus_version(dhus_url, version):
 
 @pytest.mark.mock_api
 @pytest.mark.parametrize(
-    "http_status_code, expected_result",
+    "http_status_code, expected_result, headers",
     [
         # Note: the HTTP status codes have slightly more specific meanings in the LTA API.
         # OK - already online
-        (200, False),
-        (206, False),
+        (200, False, {}),
+        (206, False, {}),
         # Accepted for retrieval - the product offline product will be retrieved from the LTA.
-        (202, True),
+        (202, True, {}),
+        # already online but concurrent downloads limit was exceeded
+        (
+            403,
+            False,
+            {
+                "cause-message":'An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "mock_user"'}
+            },
+        )
     ],
 )
 def test_trigger_lta_success(http_status_code, expected_result):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -66,7 +66,7 @@ def test_dhus_version(dhus_url, version):
             403,
             False,
             {
-                "cause-message":'An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "mock_user"'}
+                "cause-message":'An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "mock_user"'
             },
         )
     ],


### PR DESCRIPTION
handle 403 error while Fetching archival status by `download all()`


Full error cause message for online product: 
> An exception occured while creating a stream: Maximum number of 4 concurrent flows achieved by the user "_username_"

Full error cause message for offline product: 
> User '_username_' offline products retrieval quota exceeded (20 fetches max) trying to fetch product _PRODUCT_FILENAME_ (_BYTES_COUNT_ bytes compressed)
