### PR TITLE
Update docstrings to match current function name

### DIFF
--- a/sentinelsat/products.py
+++ b/sentinelsat/products.py
@@ -166,7 +166,7 @@ class SentinelProductsAPI(sentinelsat.SentinelAPI):
         Returns
         -------
         product_info : dict
-            Dictionary containing the product's info from get_product_info() as well as
+            Dictionary containing the product's info from get_product_odata() as well as
             the path on disk.
 
         Raises

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -491,7 +491,7 @@ class SentinelAPI:
         Returns
         -------
         product_info : dict
-            Dictionary containing the product's info from get_product_info() as well as
+            Dictionary containing the product's info from get_product_odata() as well as
             the path on disk.
 
         Raises
@@ -857,7 +857,7 @@ class SentinelAPI:
         ----------
 
         product_info : dict
-            Contains the product's info as returned by get_product_info()
+            Contains the product's info as returned by get_product_odata()
         directory_path : string, optional
             Where the file will be downloaded
         checksum : bool, optional


### PR DESCRIPTION
The function `get_product_info()` has been renamed to `get_product_odata()` in 0.9 (2017-02-26). As a user, seeing the non-existent function in docstring can be confusing.