### PR TITLE
Fix: remove rep_id from sentinalsat/products.py

### DIFF
--- a/sentinelsat/products.py
+++ b/sentinelsat/products.py
@@ -215,7 +215,6 @@ def _xml_to_dataobj_info(element):
     assert element.tag == "dataObject"
     data = dict(
         id=element.attrib["ID"],
-        rep_id=element.attrib["repID"],
     )
     elem = element.find("byteStream")
     # data["mime_type"] = elem.attrib['mimeType']


### PR DESCRIPTION
within products.py
The function `_xml_to_dataobj_info` initially creates a dictionary called `data` with two elements: `id` and `rep_id`.
the attribute `repID` does not seem to exist in some products and will cause a KeyError.
Removing rep_id at line 218 fixes the issue and seems to cause no additional issues in the base code.