### PR TITLE
Add support for SHA3-256

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ CLI changes
 Added
 ~~~~~
 * Better handling 403 error in ``trigger_offline_retrieval()`` (`#491 <https://github.com/sentinelsat/sentinelsat/issues/491>`_ `@z4zz <https://github.com/z4zz>`_)
+* Added support for SHA3-256 checksums. (`#523 <https://github.com/sentinelsat/sentinelsat/issues/523>`_ `@valgur <https://github.com/valgur>`_)
 
 Changed
 ~~~~~~~

--- a/sentinelsat/products.py
+++ b/sentinelsat/products.py
@@ -119,7 +119,10 @@ class SentinelProductsAPI(sentinelsat.SentinelAPI):
         node_info = product_info.copy()
         node_info["url"] = self._path_to_url(product_info, path, "value")
         node_info["size"] = dataobj_info["size"]
-        node_info["md5"] = dataobj_info["md5"]
+        if "md5" in dataobj_info:
+            node_info["md5"] = dataobj_info["md5"]
+        if "sha3-256" in dataobj_info:
+            node_info["sha3-256"] = dataobj_info["sha3-256"]
         node_info["node_path"] = dataobj_info["href"]
         # node_info["parent"] = product_info
 
@@ -225,8 +228,8 @@ def _xml_to_dataobj_info(element):
     # assert data['locator_type'] == "URL"
 
     elem = element.find("byteStream/checksum")
-    assert elem.attrib["checksumName"].upper() == "MD5"
-    data["md5"] = elem.text
+    assert elem.attrib["checksumName"].upper() in ["MD5", "SHA3-256"]
+    data[elem.attrib["checksumName"].lower()] = elem.text
 
     return data
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1174,7 +1174,7 @@ class SentinelAPI:
             checksum = product_info["sha3-256"]
             algo = hashlib.sha3_256()
         else:
-            raise InvalidChecksumError("Checksum value is missing")
+            raise InvalidChecksumError("No checksum information found in product information.")
         file_path = Path(file_path)
         file_size = file_path.stat().st_size
         with self._tqdm(

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1167,12 +1167,12 @@ class SentinelAPI:
 
     def _checksum_compare(self, file_path, product_info, block_size=2 ** 13):
         """Compare a given MD5 checksum with one calculated from a file."""
-        if "md5" in product_info:
-            checksum = product_info["md5"]
-            algo = hashlib.md5()
-        elif "sha3-256" in product_info:
+        if "sha3-256" in product_info:
             checksum = product_info["sha3-256"]
             algo = hashlib.sha3_256()
+        elif "md5" in product_info:
+            checksum = product_info["md5"]
+            algo = hashlib.md5()
         else:
             raise InvalidChecksumError("No checksum information found in product information.")
         file_path = Path(file_path)

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -543,7 +543,7 @@ class SentinelAPI:
                 )
                 temp_path.unlink()
             elif size == product_info["size"]:
-                if verify_checksum and not self._md5_compare(temp_path, product_info["md5"]):
+                if verify_checksum and not self._checksum_compare(temp_path, product_info):
                     # Log a warning since this should never happen
                     self.logger.warning(
                         "Existing incomplete file %s appears to be fully downloaded but "
@@ -567,7 +567,7 @@ class SentinelAPI:
             )
         # Check integrity with MD5 checksum
         if verify_checksum is True:
-            if not self._md5_compare(temp_path, product_info["md5"]):
+            if not self._checksum_compare(temp_path, product_info):
                 temp_path.unlink()
                 raise InvalidChecksumError("File corrupt: checksums do not match")
         # Download successful, rename the temporary file to its proper name
@@ -1152,8 +1152,8 @@ class SentinelAPI:
 
             is_fine = False
             for product_info in product_infos[name]:
-                if path.stat().st_size == product_info["size"] and self._md5_compare(
-                    path, product_info["md5"]
+                if path.stat().st_size == product_info["size"] and self._checksum_compare(
+                    path, product_info
                 ):
                     is_fine = True
                     break
@@ -1165,22 +1165,29 @@ class SentinelAPI:
 
         return corrupt
 
-    def _md5_compare(self, file_path, checksum, block_size=2 ** 13):
+    def _checksum_compare(self, file_path, product_info, block_size=2 ** 13):
         """Compare a given MD5 checksum with one calculated from a file."""
+        if "md5" in product_info:
+            checksum = product_info["md5"]
+            algo = hashlib.md5()
+        elif "sha3-256" in product_info:
+            checksum = product_info["sha3-256"]
+            algo = hashlib.sha3_256()
+        else:
+            raise InvalidChecksumError("Checksum value is missing")
         file_path = Path(file_path)
         file_size = file_path.stat().st_size
         with self._tqdm(
-            desc="MD5 checksumming", total=file_size, unit="B", unit_scale=True
+            desc=f"{algo.name} checksumming", total=file_size, unit="B", unit_scale=True
         ) as progress:
-            md5 = hashlib.md5()
             with open(file_path, "rb") as f:
                 while True:
                     block_data = f.read(block_size)
                     if not block_data:
                         break
-                    md5.update(block_data)
+                    algo.update(block_data)
                     progress.update(len(block_data))
-            return md5.hexdigest().lower() == checksum.lower()
+            return algo.hexdigest().lower() == checksum.lower()
 
     def _download(self, url, path, file_size):
         headers = {}

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -354,7 +354,7 @@ def test_get_stream(api, tmpdir, smallest_online_products):
         shutil.copyfileobj(response.raw, f)
 
     assert product_info["size"] == expected_path.size()
-    assert api._md5_compare(expected_path, product_info["md5"])
+    assert api._checksum_compare(expected_path, product_info)
 
     tmpdir.remove()
 


### PR DESCRIPTION
Used by manifest.info files in newer products.
https://sentinel.esa.int/web/sentinel/-/update-of-copernicus-sentinel-2-level-1c-and-level-2a-processing-baselines-1/1.0
Fixes #517.