### PR TITLE
Suppress unnecessary server stacktrace printing for QueryLengthError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,15 +12,15 @@ CLI changes
 
 Added
 ~~~~~
-* Better handling 403 error in `trigger_offline_retrieval()` (`#491 <https://github.com/sentinelsat/sentinelsat/issues/491>`_ `@z4zz <https://github.com/z4zz>`_)
+* Better handling 403 error in ``trigger_offline_retrieval()`` (`#491 <https://github.com/sentinelsat/sentinelsat/issues/491>`_ `@z4zz <https://github.com/z4zz>`_)
 
 Changed
 ~~~~~~~
-* 
+* Suppressed the unnecessary server stacktrace printing for ``QueryLengthError``. (`#524 <https://github.com/sentinelsat/sentinelsat/issues/524>`_ `@valgur <https://github.com/valgur>`_)
 
 Fixed
 ~~~~~
-* Changed logic for _get_filename when cd header not present (`#494 <https://github.com/sentinelsat/sentinelsat/issues/494>`_ `@rbrishabh <https://github.com/rbrishabh>`_)
+* Changed logic for ``_get_filename`` when Content-Disposition header not present (`#494 <https://github.com/sentinelsat/sentinelsat/issues/494>`_ `@rbrishabh <https://github.com/rbrishabh>`_)
 * Fixed online status checks accidentally counting towards the concurrent downloads limit on the server, causing downloads to fail. (`#508 <https://github.com/sentinelsat/sentinelsat/issues/508>`_ `@avalentino <https://github.com/avalentino>`_).
 
 [1.0.1] – 2021-05-25

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1475,7 +1475,7 @@ def _check_scihub_response(response, test_json=True, query_string=None):
                     "Consider using SentinelAPI.check_query_length() for "
                     "client-side validation of the query string length.".format(length)
                 )
-            raise QueryLengthError(msg, response)
+            raise QueryLengthError(msg, response) from None
         elif "Invalid key" in msg:
             msg = msg.split(" : ", 1)[-1]
             raise InvalidKeyError(msg, response)


### PR DESCRIPTION
As suggested in #521.