### PR TITLE
Use tqdm.write for nicer logging + progress bars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 CLI changes
 ~~~~~~~~~~~
-* 
+* Progressbars no longer conflict with logging output. (`#531 <https://github.com/sentinelsat/sentinelsat/issues/531>`_ `@valgur <https://github.com/valgur>`_)
 
 Added
 ~~~~~

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,9 @@ def run_cli(credentials):
         must_raise = kwargs.pop("must_raise", None)
         must_return_nonzero = kwargs.pop("must_return_nonzero", False) or must_raise is not None
 
+        # Otherwise tqdm.write() messes up the stdout for testing
+        os.environ["DISABLE_TQDM_LOGGING"] = "y"
+
         assert_raises = pytest.raises(must_raise) if must_raise else nullcontext()
         with assert_raises:
             result = runner.invoke(


### PR DESCRIPTION
This ensures that progressbars don't overwrite logging output and vice versa.
However, had to include a `DISABLE_TQDM_LOGGING` environment variable option to not break tests.