### PR TITLE
catch server errors in `_get_filename`

### DIFF
--- a/sentinelsat/download.py
+++ b/sentinelsat/download.py
@@ -424,7 +424,8 @@ class Downloader:
                 if self.fail_fast:
                     raise
                 self.logger.error(
-                    "Getting filename for %s failed: %s",
+                    "Getting filename for %s (%s) failed: %s",
+                    product_info["title"],
                     pid,
                     _format_exception(e),
                 )


### PR DESCRIPTION
If the algorithm can't figure out whether a product exists on disk because of a server error, I don't see any issue in continuing with the `download_all` method. After all this will be checked again later according to the comment in lines 275-276.

As I understand it, the idea of `download_all` is to download the other files anyways if one file makes a problem and just log the exception.

This PR was prompted by the following Internal Server Error I got:

```
│2021-10-19 18:15:56,461 ERROR: luigi-interface: _handle_run_exception: [pid 115591] Worker Worker(salt=030957043, workers=1│
, host=Makushin, username=lukas, pid=115591) failed    DownloadLuigi(                                                       │
│        place=/media/lukas/6TB_01/data/siberia/2021_sakha,                                                                 │
│    )                                                                                                                      │
│Traceback (most recent call last):                                                                                         │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/sentinelsat/sentinel.py", line 1012, in _check_scihub_res│
ponse                                                                                                                       │
│    response.raise_for_status()                                                                                            │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/requests/models.py", line 953, in raise_for_status       │
│    raise HTTPError(http_error_msg, response=self)                                                                         │
│requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://apihub.copernicus.eu/apihub/odata/v│
1/Products('9adb53e9-ce6e-4113-af74-1d8f0269d782')/Attributes('Filename')/Value/$value                                      │
│                                                                                                                           │
│During handling of the above exception, another exception occurred:                                                        │
│                                                                                                                           │
│Traceback (most recent call last):                                                                                         │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/luigi/worker.py", line 191, in run                       │
│    new_deps = self._run_get_new_deps()                                                                                    │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/luigi/worker.py", line 133, in _run_get_new_deps         │
│    task_gen = self.task.run()                                                                                             │
│  File "/home/lukas/Desktop/EDEO-Sensing/edeo_sensing/ingest/__init__.py", line 101, in run                                │
│    download.download(target_dir=self.place, source_file=self.csv_path)                                                    │
│  File "/home/lukas/Desktop/EDEO-Sensing/edeo_sensing/ingest/download.py", line 41, in download                            │
│    downloaded, lta_triggered, failed = api.download_all(                                                                  │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/sentinelsat/sentinel.py", line 710, in download_all      │
│    statuses, exceptions, product_infos = downloader.download_all(products, directory_path)                                │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/sentinelsat/download.py", line 273, in download_all      │
│    self._skip_existing_products(directory, offline_prods, product_infos, statuses)                                        │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/sentinelsat/download.py", line 416, in _skip_existing_pro│
ducts                                                                                                                       │
│    filename = self.api._get_filename(product_info)                                                                        │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/sentinelsat/sentinel.py", line 600, in _get_filename     │
│    self._check_scihub_response(req, test_json=False)                                                                      │
│  File "/home/lukas/anaconda3/envs/es/lib/python3.9/site-packages/sentinelsat/sentinel.py", line 1058, in _check_scihub_res│
ponse                                                                                                                       │
│    raise ServerError(msg, response)                                                                                       │
│sentinelsat.exceptions.ServerError: HTTP status 500 Internal Server Error: TransactionSystemException : Could not roll back│
 Hibernate transaction; nested exception is org.hibernate.TransactionException: Unable to rollback against JDBC Connection  │
```