### PR TITLE
v1.1.1 release

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,8 +35,9 @@ Contributors
 * Thomas Young-Audet `@thomas-youngaudet <https://github.com/thomasyoung-audet>`_
 * Antonio Valentino `@avalentino <https://github.com/avalentino>`_
 * Florian Fichtner `@fwfichtner <https://github.com/fwfichtner>`_
-*  `@nishadhka <https://github.com/nishadhka>`_
+* `@nishadhka <https://github.com/nishadhka>`_
 * Marcus Ackland `@mackland <https://github.com/mackland>`_
-*  `@IpsumCapra <https://github.com/IpsumCapra>`_
+* `@IpsumCapra <https://github.com/IpsumCapra>`_
 * Rishabh Budhiraja `@rbrishabh <https://github.com/rbrishabh>`_
-* @z4zz <https://github.com/z4zz>`_
+* `@z4zz <https://github.com/z4zz>`_
+* `@joooeey <https://github.com/joooeey>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to ``sentinelsat`` will be listed here.
 
 CLI changes
 ~~~~~~~~~~~
-* 
+* Show help when no CLI arguments are provided.
 
 Added
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 
 Changed
 ~~~~~~~
-* 
+* Tests are no longer included in the Python source package to significantly reduce its size.
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,16 +3,12 @@ Change Log
 
 All notable changes to ``sentinelsat`` will be listed here.
 
-[Unreleased] – YYYY-MM-DD
--------------------------
+[1.1.1] – 2021-11-23
+--------------------
 
 CLI changes
 ~~~~~~~~~~~
 * Show help when no CLI arguments are provided.
-
-Added
-~~~~~
-* 
 
 Changed
 ~~~~~~~

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -139,6 +139,16 @@ A new Zenodo DOI is created automatically with every Github release using the Ze
 
 A new version is published to PyPI automatically via CI on every GitHub release.
 
+Release checklist
+-----------------
+
+* Update the package version at https://github.com/sentinelsat/sentinelsat/blob/main/sentinelsat/__init__.py#L1
+* Update the link to latest changes on the main branch under https://github.com/sentinelsat/sentinelsat#changelog
+* Make sure docs are up to date and are rendered correctly at https://sentinelsat.readthedocs.io/en/main/
+* Make sure all notable changes are covered in CHANGELOG.rst and update the version number there
+* Update AUTHORS.rst
+* Copy the relevant part of changelog into the release description and create a new release
+* Start a new "Unreleased" version section in changelog
 
 License
 =======

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
 include README.rst
 include requirements.txt
-recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/README.rst
+++ b/README.rst
@@ -311,7 +311,7 @@ The full documentation is also published at http://sentinelsat.readthedocs.io/.
 Changelog
 =========
 
-See `CHANGELOG <CHANGELOG.rst>`_. You can also use GitHub's compare view to see the `changes in the main branch since last release <https://github.com/sentinelsat/sentinelsat/compare/v1.1.0...main>`_.
+See `CHANGELOG <CHANGELOG.rst>`_. You can also use GitHub's compare view to see the `changes in the main branch since last release <https://github.com/sentinelsat/sentinelsat/compare/v1.1.1...main>`_.
 
 Contributors
 ============

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-click
+click >= 7.1
 html2text
 geojson >= 2
 tqdm >= 4.58

--- a/sentinelsat/__init__.py
+++ b/sentinelsat/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # Import for backwards-compatibility
 from . import sentinel

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -49,7 +49,7 @@ def validate_query_param(ctx, param, kwargs):
     return kwargs
 
 
-@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]), no_args_is_help=True)
 @click.option(
     "--user",
     "-u",
@@ -201,10 +201,12 @@ def validate_query_param(ctx, param, kwargs):
     show_default=True,
     help="""Specify a custom format to print results. The format string shall
     be compatible with the Python "Format Specification Mini-Language".
+
     Some common keywords for substitution are:
     'uuid', 'identifier', 'summary', 'link', 'size', 'platformname', 'producttype',
     'beginposition', 'instrumentshortname', 'cloudcoverpercentage',
     'orbitdirection', 'relativeorbitnumber', 'footprint'.
+
     For a complete set of available keywords see the "properties" output from a
     relevant query with ``--footprints -`` (and possibly ``--limit 1``) appended.
     """,

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -208,7 +208,7 @@ def validate_query_param(ctx, param, kwargs):
     'orbitdirection', 'relativeorbitnumber', 'footprint'.
 
     For a complete set of available keywords see the "properties" output from a
-    relevant query with ``--footprints -`` (and possibly ``--limit 1``) appended.
+    relevant query with ``--footprints -`` appended.
     """,
 )
 @click.option("--info", is_flag=True, is_eager=True, help="Displays the DHuS version used")
@@ -244,10 +244,9 @@ def cli(
     info,
 ):
     """Search for Sentinel products and, optionally, download all the results
-    and/or create a geojson file with the search result footprints.
-    Beyond your Copernicus Open Access Hub user and password, you must pass a geojson file
-    containing the geometry of the area you want to search for or the UUIDs of the products. If you
-    don't specify the start and end dates, it will search in the last 24 hours.
+    and/or create a GeoJSON file with the search result footprints.
+    Beyond your Copernicus Open Access Hub user and password, you will typically want to pass a GeoJSON file
+    containing the geometry of the area you want to search for and the relevant time range.
     """
 
     if footprints and footprints.name == "-":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file=README.rst
+description_file=README.rst
 
 [flake8]
 ignore = E731

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     url="https://github.com/sentinelsat/sentinelsat",
     license="GPLv3+",
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
-    include_package_data=True,
-    zip_safe=False,
+    include_package_data=False,
+    zip_safe=True,
     install_requires=open("requirements.txt").read().splitlines(),
     extras_require={
         "dev": [


### PR DESCRIPTION
Preparations for the v1.1.1 release.

Some unrelated small changes:
* Added a release checklist to [CONTRIBUTE.rst](https://github.com/valgur/sentinelsat/blob/b2389e358e4338ff50fbe5f35fbae173ccdcdee1/CONTRIBUTE.rst#release-checklist)
* Excluded all tests and fixtures from the sdist package. The cassettes were taking up 5 MB uncompressed / 1 MB compressed. This is pretty much a dead weight since I don't expect anyone to be actually running tests from the installed package.
* Tidied the CLI help info a bit.

Also, I noticed https://sentinelsat.readthedocs.io/en/main/ does not exist and https://sentinelsat.readthedocs.io/en/latest/ is outdated as well. @Fernerkundung, please update the default branch in ReadTheDocs to `main`. Adding me and @j08lue as admins there would probably not hurt either.