### PR TITLE
Drop Gitter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 sentinelsat
 ===========
 
+.. image:: https://readthedocs.org/projects/sentinelsat/badge/?version=stable
+    :target: http://sentinelsat.readthedocs.io/en/stable/?badge=stable
+    :alt: Documentation
+
 .. image:: https://badge.fury.io/py/sentinelsat.svg
     :target: http://badge.fury.io/py/sentinelsat
     :alt: PyPI package
@@ -12,14 +16,6 @@ sentinelsat
 .. image:: https://codecov.io/gh/sentinelsat/sentinelsat/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/sentinelsat/sentinelsat
     :alt: codecov.io code coverage
-
-.. image:: https://readthedocs.org/projects/sentinelsat/badge/?version=stable
-    :target: http://sentinelsat.readthedocs.io/en/stable/?badge=stable
-    :alt: Documentation
-
-.. image:: https://img.shields.io/badge/gitter-join_chat-1dce73.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB4PSIwIiB5PSI1IiBmaWxsPSIjZmZmIiB3aWR0aD0iMSIgaGVpZ2h0PSI1Ii8%2BPHJlY3QgeD0iMiIgeT0iNiIgZmlsbD0iI2ZmZiIgd2lkdGg9IjEiIGhlaWdodD0iNyIvPjxyZWN0IHg9IjQiIHk9IjYiIGZpbGw9IiNmZmYiIHdpZHRoPSIxIiBoZWlnaHQ9IjciLz48cmVjdCB4PSI2IiB5PSI2IiBmaWxsPSIjZmZmIiB3aWR0aD0iMSIgaGVpZ2h0PSI0Ii8%2BPC9zdmc%2B&logoWidth=8
-    :target: https://gitter.im/sentinelsat/
-    :alt: gitter.im chat
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.595961.svg
    :target: https://doi.org/10.5281/zenodo.595961


### PR DESCRIPTION
I propose we drop the Gitter link from the readme. I don't think any maintainer is really keeping an eye on it with any regularity, if at all. The issue tracker appears to be quite sufficient for assistance now and we could also consider enabling the Discussions page feature.