### PR TITLE
Pin rstcheck to v5, fix tests on Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os:  [ubuntu-latest]
         # os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.10"
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/live-testing.yaml
+++ b/.github/workflows/live-testing.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/sentinelsat/download.py
+++ b/sentinelsat/download.py
@@ -100,7 +100,7 @@ class Downloader:
         self.dl_retry_delay = dl_retry_delay
         self.lta_retry_delay = lta_retry_delay
         self.lta_timeout = lta_timeout
-        self.chunk_size = 2 ** 20  # download in 1 MB chunks by default
+        self.chunk_size = 2**20  # download in 1 MB chunks by default
 
     def download(self, id, directory=".", *, stop_event=None):
         """Download a product.

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -944,7 +944,7 @@ class SentinelAPI:
 
         return corrupt
 
-    def _checksum_compare(self, file_path, product_info, block_size=2 ** 13):
+    def _checksum_compare(self, file_path, product_info, block_size=2**13):
         """Compare a given MD5 checksum with one calculated from a file."""
         if "sha3-256" in product_info:
             checksum = product_info["sha3-256"]

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Utilities",
     ],

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             "pytest-socket",
             "requests-mock",
             "pyyaml",
-            "rstcheck",
+            "rstcheck < 6",
             "sphinx >= 1.3",
             "sphinx_rtd_theme",
             "flaky",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from functools import partialmethod
 
 try:
     from test.support.os_helper import EnvironmentVarGuard
-except:
+except ImportError:
     from test.support import EnvironmentVarGuard
 
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,11 @@ import glob
 import shutil
 from contextlib import contextmanager
 from functools import partialmethod
-from test.support import EnvironmentVarGuard
+
+try:
+    from test.support.os_helper import EnvironmentVarGuard
+except:
+    from test.support import EnvironmentVarGuard
 
 import pytest
 import requests_mock
@@ -155,8 +159,8 @@ def test_cli_geometry_WKT_alternative_fail(run_cli):
         must_return_nonzero=True,
     )
     assert (
-        "neither a GeoJSON file with a valid path, a GeoJSON String nor a WKT string."
-        in result.output
+            "neither a GeoJSON file with a valid path, a GeoJSON String nor a WKT string."
+            in result.output
     )
 
 
@@ -553,7 +557,7 @@ def test_product_node_download_single(run_cli, api, tmpdir, smallest_online_prod
 @pytest.mark.vcr(allow_playback_repeats=True)
 @pytest.mark.scihub
 def test_product_node_download_single_with_filter(
-    run_cli, api, tmpdir, node_test_products, monkeypatch
+        run_cli, api, tmpdir, node_test_products, monkeypatch
 ):
     # Change default arguments for quicker test.
     # Also, vcrpy is not threadsafe, so only one worker is used.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,8 +159,8 @@ def test_cli_geometry_WKT_alternative_fail(run_cli):
         must_return_nonzero=True,
     )
     assert (
-            "neither a GeoJSON file with a valid path, a GeoJSON String nor a WKT string."
-            in result.output
+        "neither a GeoJSON file with a valid path, a GeoJSON String nor a WKT string."
+        in result.output
     )
 
 
@@ -557,7 +557,7 @@ def test_product_node_download_single(run_cli, api, tmpdir, smallest_online_prod
 @pytest.mark.vcr(allow_playback_repeats=True)
 @pytest.mark.scihub
 def test_product_node_download_single_with_filter(
-        run_cli, api, tmpdir, node_test_products, monkeypatch
+    run_cli, api, tmpdir, node_test_products, monkeypatch
 ):
     # Change default arguments for quicker test.
     # Also, vcrpy is not threadsafe, so only one worker is used.


### PR DESCRIPTION
The `rstcheck` API has changed significantly and the Python API has been moved to `rstcheck-core`.

However, the newer versions no longer support Python 3.6 and I don't find this change to be a good enough of a reason for us to drop Python 3.6 support, so I am pinning `rstcheck` to an older version instead. The output from the newer version was identical to the older one's.

Also added Python 3.10 to CI and fixed a minor related test incompatibility.