### PR TITLE
upgrade CI to Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os:  [ubuntu-latest]
         # os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/live-testing.yaml
+++ b/.github/workflows/live-testing.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ CLI changes
 
 Added
 ~~~~~
-* 
+* support for Python 3.11
 
 Changed
 ~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Utilities",
     ],


### PR DESCRIPTION
Add latest Python release 3.11 to CI testing and latest testing targets in the workflows.

https://docs.python.org/3.11/whatsnew/3.11.html