### PR TITLE
updated path filter & addition to chain node filters

### DIFF
--- a/sentinelsat/products.py
+++ b/sentinelsat/products.py
@@ -40,7 +40,7 @@ def make_path_filter(pattern, exclude=False):
     Parameters
     ----------
     pattern : str, sequence[str]
-        glob patter (or sequence of patterns) for files selection
+        glob pattern (or sequence of patterns) for files selection
     exclude : bool, optional
         if set to True then files matching the specified pattern are excluded. Default False.
        The `pattern` parameter can also be a list of patterns.

--- a/sentinelsat/products.py
+++ b/sentinelsat/products.py
@@ -42,10 +42,9 @@ def make_path_filter(pattern, exclude=False):
     pattern : str, sequence[str]
         glob pattern (or sequence of patterns) for files selection
     exclude : bool, optional
-        if set to True then files matching the specified pattern are excluded. Default False.
+        If set to true, then files matching any of the specified patterns are excluded.
        The `pattern` parameter can also be a list of patterns.
     """
-
     patterns = [pattern] if isinstance(pattern, str) else pattern
 
     def node_filter(node_info):


### PR DESCRIPTION
Based on the issue #574, enhancement to support-

-  Path filters to accept a sequence of pattern
-  Chain multiple node filters

Example notebook added [here. ](https://github.com/cOsprey/sentinelsat_filter_example/blob/main/filter_example.ipynb)

Please let me know if more changes are required, as I am new to this may need some help.
