### PR TITLE
Fix KeyError when querying data

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1394,10 +1394,11 @@ def _parse_opensearch_response(products):
                         except KeyError:
                             # Sentinel-3 has one element 'arr'
                             # which violates the name:content convention
-                            try:
+                            if "content" in p:
+                                product_dict[p["name"]] = f(p["content"])
+                            elif "str" in p:
                                 product_dict[p["name"]] = f(p["str"])
-                            except KeyError:
-                                # if either content and str are not present use None
+                            else:
                                 product_dict[p["name"]] = None
     return output
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1386,20 +1386,12 @@ def _parse_opensearch_response(products):
                 else:
                     f = converters.get(key, default_converter)
                     for p in properties:
-                        try:
-                            if "content" in p:
-                                product_dict[p["name"]] = f(p["content"])
-                            else:
-                                product_dict[p["name"]] = f(p["str"])
-                        except KeyError:
-                            # Sentinel-3 has one element 'arr'
-                            # which violates the name:content convention
-                            if "content" in p:
-                                product_dict[p["name"]] = f(p["content"])
-                            elif "str" in p:
-                                product_dict[p["name"]] = f(p["str"])
-                            else:
-                                product_dict[p["name"]] = None
+                        if "content" in p:
+                            product_dict[p["name"]] = f(p["content"])
+                        elif "str" in p:
+                            product_dict[p["name"]] = f(p["str"])
+                        else:
+                            product_dict[p["name"]] = None
     return output
 
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1394,7 +1394,11 @@ def _parse_opensearch_response(products):
                         except KeyError:
                             # Sentinel-3 has one element 'arr'
                             # which violates the name:content convention
-                            product_dict[p["name"]] = f(p["name"])
+                            try:
+                                product_dict[p["name"]] = f(p["str"])
+                            except KeyError:
+                                # if either content and str are not present use None
+                                product_dict[p["name"]] = None
     return output
 
 


### PR DESCRIPTION
Data query was crashing on KeyError 'str'. Some data does not have a content value for the 'format' key, eg.: {'name': 'format'}

I have fixed this. If either content and str are not present use None.